### PR TITLE
Integrating Github actions for CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,29 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Testing
+
+on:
+  push:
+    branches: [ '**' ]
+  pull_request:
+    branches: [ '**' ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: npm run build --if-present
+    - run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: node_js
-node_js:
-  - node
-env:
-  - NODE_ENV=test
-before_script:
-  - npm install
-script:
-  - npm run test


### PR DESCRIPTION
Integrating Github actions for CI as per #5 

- The Github actions are triggered on push and pull request events.
- There is no trigger event for commit. 
- Triggered on all branches.
- The tests are being run on node v10.x, 12.x, 14.x (please comment if all these are needed).
- I have kept the **build** script (optional) as well if we plan to add any, can be removed if not needed.

## When the tests fail (tested by expecting HTTP reponse 400 instead of 200):

![image](https://user-images.githubusercontent.com/56217868/90341909-60280700-e021-11ea-800f-2a6f3da45dc5.png)
![image](https://user-images.githubusercontent.com/56217868/90341913-6a4a0580-e021-11ea-86a9-6a41a1a2447b.png)



## When the tests pass:
![image](https://user-images.githubusercontent.com/56217868/90341883-366ee000-e021-11ea-8625-b3dd98466361.png)
![image](https://user-images.githubusercontent.com/56217868/90341941-9cf3fe00-e021-11ea-8ba6-1d458194b104.png)


