### PR TITLE
Enabled conditional logger transports for all environments

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -2,7 +2,8 @@ const setBooleanConfig = require('../utils/config').setBooleanConfig
 
 module.exports = {
   port: process.env.PORT || 3000,
-  enableLogTrasports: setBooleanConfig(process.env.ENABLE_LOGS, true),
+  enableFileLogs: setBooleanConfig(process.env.ENABLE_FILE_LOGS, true),
+  enableConsoleLogs: setBooleanConfig(process.env.ENABLE_CONSOLE_LOGS, false),
 
   githubOauth: {
     clientId: process.env.GITHUB_CLIENT_ID,

--- a/config/development.js
+++ b/config/development.js
@@ -3,7 +3,8 @@ const port = process.env.PORT || 3000
 
 module.exports = {
   port: port,
-  enableLogTrasports: setBooleanConfig(process.env.ENABLE_LOGS, true),
+  enableFileLogs: setBooleanConfig(process.env.ENABLE_FILE_LOGS, false),
+  enableConsoleLogs: setBooleanConfig(process.env.ENABLE_CONSOLE_LOGS, true),
 
   githubOauth: {
     clientId: process.env.GITHUB_CLIENT_ID,

--- a/config/production.js
+++ b/config/production.js
@@ -2,7 +2,8 @@ const setBooleanConfig = require('../utils/config').setBooleanConfig
 
 module.exports = {
   port: process.env.PORT || 3000,
-  enableLogTrasports: setBooleanConfig(process.env.ENABLE_LOGS, true),
+  enableFileLogs: setBooleanConfig(process.env.ENABLE_FILE_LOGS, true),
+  enableConsoleLogs: setBooleanConfig(process.env.ENABLE_CONSOLE_LOGS, false),
 
   githubOauth: {
     clientId: process.env.GITHUB_CLIENT_ID,

--- a/config/staging.js
+++ b/config/staging.js
@@ -2,7 +2,8 @@ const setBooleanConfig = require('../utils/config').setBooleanConfig
 
 module.exports = {
   port: process.env.PORT || 3000,
-  enableLogTrasports: setBooleanConfig(process.env.ENABLE_LOGS, true),
+  enableFileLogs: setBooleanConfig(process.env.ENABLE_FILE_LOGS, true),
+  enableConsoleLogs: setBooleanConfig(process.env.ENABLE_CONSOLE_LOGS, false),
 
   githubOauth: {
     clientId: process.env.GITHUB_CLIENT_ID,

--- a/config/test.js
+++ b/config/test.js
@@ -3,7 +3,8 @@ const port = process.env.PORT || 3000
 
 module.exports = {
   port: port,
-  enableLogTrasports: setBooleanConfig(process.env.ENABLE_LOGS, true),
+  enableFileLogs: setBooleanConfig(process.env.ENABLE_FILE_LOGS, false),
+  enableConsoleLogs: setBooleanConfig(process.env.ENABLE_CONSOLE_LOGS, false),
 
   githubOauth: {
     clientId: 'clientId',

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -24,14 +24,16 @@ const options = {
 // instantiate a new Winston Logger with the settings defined above
 const logger = new winston.createLogger({ // eslint-disable-line new-cap
   /**
-   *   Env:
-   *   - production, staging: log to file
-   *   - development: log on console
-   *   - test: nothing
+   * Application defaults:
+   * - File logs enabled in: [production, staging]
+   * - Console logs enabled in: [development]
+   *
+   * Modifications to be made through environment variables defined in config files
    */
-  transports: (['production', 'staging'].includes(process.env.NODE_ENV) && config.get('enableLogTrasports'))
-    ? [new winston.transports.File(options.file)]
-    : [new winston.transports.Console(options.console)],
+  transports: [
+    ...(config.get('enableFileLogs') ? [new winston.transports.File(options.file)] : []),
+    ...(config.get('enableConsoleLogs') ? [new winston.transports.Console(options.console)] : [])
+  ],
 
   exitOnError: false // do not exit on handled exceptions
 })


### PR DESCRIPTION
- Added conditional log transports in all environments
- Added defaults in respective environments
- This change has been done as there was no way for looking at application logs logged in .log files on Heroku (as far as I searched for it)