### PR TITLE
Credentials set to true for Access-Control-Allow-Credentials #56

### DIFF
--- a/middlewares/index.js
+++ b/middlewares/index.js
@@ -30,6 +30,7 @@ const middleware = (app) => {
   app.use(helmet())
   app.use(cors({
     origin: config.get('cors.allowedOrigins'),
+    credentials: true,
     optionsSuccessStatus: 200
   }))
 


### PR DESCRIPTION
So solve #56 fully, we need to take care of this setting from [docs](https://www.npmjs.com/package/cors#enabling-cors-pre-flight):
>credentials: Configures the Access-Control-Allow-Credentials CORS header. Set to true to pass the header, otherwise it is omitted.

Problem mentioned [here](https://discordapp.com/channels/673083527624916993/735598747949465640/764489829332811796)

Read more here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials