### PR TITLE
Throw err from model functions instead of returning them

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,7 +27,7 @@ module.exports = {
     'no-console': 'error',
 
     // Custom mocha rules
-    'mocha/no-skipped-tests': 'error',
+    // 'mocha/no-skipped-tests': 'error',
     'mocha/no-exclusive-tests': 'error'
   },
   ignorePatterns: ['public/*']

--- a/models/users.js
+++ b/models/users.js
@@ -45,7 +45,7 @@ const addOrUpdate = async (userData, userId = null) => {
     return { isNewUser: true, userId: userInfo.id }
   } catch (err) {
     logger.error('Error in adding or updating user', err)
-    return err
+    throw err
   }
 }
 
@@ -74,7 +74,7 @@ const fetchUsers = async (query) => {
     return allUsers
   } catch (err) {
     logger.error('Error retrieving user data', err)
-    return err
+    throw err
   }
 }
 
@@ -98,7 +98,7 @@ const fetchUser = async (userId) => {
     }
   } catch (err) {
     logger.error('Error retrieving user data', err)
-    return err
+    throw err
   }
 }
 

--- a/test/integration/healthController.test.js
+++ b/test/integration/healthController.test.js
@@ -48,6 +48,7 @@ describe('healthController', function () {
       .get('/healthcheck/v2')
       .set('cookie', `rds-session=${jwt}`)
       .end((err, res) => {
+        this.skip()
         if (err) { return done() }
 
         expect(res).to.have.status(200)

--- a/test/integration/healthController.test.js
+++ b/test/integration/healthController.test.js
@@ -6,7 +6,7 @@ chai.use(chaiHttp)
 const app = require('../../server')
 const authService = require('../../services/authService')
 
-describe('healthController', function () {
+describe.skip('healthController', function () {
   it('should return uptime from the healthcheck API', function (done) {
     chai
       .request(app)
@@ -48,7 +48,6 @@ describe('healthController', function () {
       .get('/healthcheck/v2')
       .set('cookie', `rds-session=${jwt}`)
       .end((err, res) => {
-        this.skip()
         if (err) { return done() }
 
         expect(res).to.have.status(200)

--- a/test/integration/usersController.test.js
+++ b/test/integration/usersController.test.js
@@ -20,7 +20,7 @@ describe('Users', function () {
     sinon.restore()
   })
 
-  describe('POST /users - create one user', function () {
+  describe.skip('POST /users - create one user', function () {
     it('Should return success response after adding the user', function (done) {
       sinon.stub(userQuery, 'addOrUpdate').callsFake((userData) => {
         return { isNewUser: true, userId: 'userId' }
@@ -40,9 +40,7 @@ describe('Users', function () {
           twitter_id: 'whatifi'
         })
         .end((err, res) => {
-          this.skip()
           if (err) { return done() }
-
           expect(res).to.have.status(200)
           expect(res.body).to.be.a('object')
           expect(res.body.message).to.equal('User added successfully!')
@@ -71,9 +69,7 @@ describe('Users', function () {
           twitter_id: 'whatifi'
         })
         .end((err, res) => {
-          this.skip()
           if (err) { return done() }
-
           expect(res).to.have.status(409)
           expect(res.body).to.be.a('object')
           expect(res.body.message).to.equal('User already exists')
@@ -83,7 +79,7 @@ describe('Users', function () {
     })
   })
 
-  describe('PATCH /users', function () {
+  describe.skip('PATCH /users', function () {
     it('Should update the user with given id', function (done) {
       sinon.stub(userQuery, 'addOrUpdate').callsFake((userData, userId) => {
         return { isNewUser: false, userId: 'userId' }
@@ -97,9 +93,7 @@ describe('Users', function () {
           first_name: 'Test first_name'
         })
         .end((err, res) => {
-          this.skip()
           if (err) { return done() }
-
           expect(res).to.have.status(200)
           expect(res.body).to.be.a('object')
           expect(res.body.message).to.equal('User updated successfully!')
@@ -121,9 +115,7 @@ describe('Users', function () {
           first_name: 'Test first_name'
         })
         .end((err, res) => {
-          this.skip()
           if (err) { return done() }
-
           expect(res).to.have.status(404)
           expect(res.body).to.be.a('object')
           expect(res.body.message).to.equal('User not found')
@@ -133,7 +125,7 @@ describe('Users', function () {
     })
   })
 
-  describe('GET /users', function () {
+  describe.skip('GET /users', function () {
     it('Should get all the users in system', function (done) {
       sinon.stub(userQuery, 'fetchUsers').callsFake((query) => {
         return [
@@ -155,9 +147,7 @@ describe('Users', function () {
         .get('/users')
         .set('cookie', `rds-session=${jwt}`)
         .end((err, res) => {
-          this.skip()
           if (err) { return done() }
-
           expect(res).to.have.status(200)
           expect(res.body).to.be.a('object')
           expect(res.body.message).to.equal('Users returned successfully!')
@@ -168,7 +158,7 @@ describe('Users', function () {
     })
   })
 
-  describe('GET /users/id', function () {
+  describe.skip('GET /users/id', function () {
     it('Should return one user with given id', function (done) {
       sinon.stub(userQuery, 'fetchUser').callsFake((userId) => {
         return {
@@ -191,9 +181,7 @@ describe('Users', function () {
         .get('/users/userId')
         .set('cookie', `rds-session=${jwt}`)
         .end((err, res) => {
-          this.skip()
           if (err) { return done() }
-
           expect(res).to.have.status(200)
           expect(res.body).to.be.a('object')
           expect(res.body.message).to.equal('User returned successfully!')
@@ -213,9 +201,7 @@ describe('Users', function () {
         .get('/users/userId')
         .set('cookie', `rds-session=${jwt}`)
         .end((err, res) => {
-          this.skip()
           if (err) { return done() }
-
           expect(res).to.have.status(404)
           expect(res.body).to.be.a('object')
           expect(res.body.message).to.equal('User doesn\'t exist')

--- a/test/integration/usersController.test.js
+++ b/test/integration/usersController.test.js
@@ -40,6 +40,7 @@ describe('Users', function () {
           twitter_id: 'whatifi'
         })
         .end((err, res) => {
+          this.skip()
           if (err) { return done() }
 
           expect(res).to.have.status(200)
@@ -70,6 +71,7 @@ describe('Users', function () {
           twitter_id: 'whatifi'
         })
         .end((err, res) => {
+          this.skip()
           if (err) { return done() }
 
           expect(res).to.have.status(409)
@@ -95,6 +97,7 @@ describe('Users', function () {
           first_name: 'Test first_name'
         })
         .end((err, res) => {
+          this.skip()
           if (err) { return done() }
 
           expect(res).to.have.status(200)
@@ -118,6 +121,7 @@ describe('Users', function () {
           first_name: 'Test first_name'
         })
         .end((err, res) => {
+          this.skip()
           if (err) { return done() }
 
           expect(res).to.have.status(404)
@@ -151,6 +155,7 @@ describe('Users', function () {
         .get('/users')
         .set('cookie', `rds-session=${jwt}`)
         .end((err, res) => {
+          this.skip()
           if (err) { return done() }
 
           expect(res).to.have.status(200)
@@ -186,6 +191,7 @@ describe('Users', function () {
         .get('/users/userId')
         .set('cookie', `rds-session=${jwt}`)
         .end((err, res) => {
+          this.skip()
           if (err) { return done() }
 
           expect(res).to.have.status(200)
@@ -207,6 +213,7 @@ describe('Users', function () {
         .get('/users/userId')
         .set('cookie', `rds-session=${jwt}`)
         .end((err, res) => {
+          this.skip()
           if (err) { return done() }
 
           expect(res).to.have.status(404)

--- a/test/unit/middlewares/contentTypeCheck.test.js
+++ b/test/unit/middlewares/contentTypeCheck.test.js
@@ -42,7 +42,7 @@ describe('contentTypeCheck', function () {
       })
   })
 
-  it('should process the request when content-type application/json is passed', function (done) {
+  it.skip('should process the request when content-type application/json is passed', function (done) {
     const jwt = authService.generateAuthToken({ userId: 1 })
 
     sinon.stub(userQuery, 'addOrUpdate').callsFake((userData, userId) => {
@@ -57,7 +57,6 @@ describe('contentTypeCheck', function () {
         first_name: 'Test first_name'
       })
       .end((err, res) => {
-        this.skip()
         if (err) { return done() }
 
         expect(res).to.have.status(200)

--- a/test/unit/middlewares/contentTypeCheck.test.js
+++ b/test/unit/middlewares/contentTypeCheck.test.js
@@ -57,6 +57,7 @@ describe('contentTypeCheck', function () {
         first_name: 'Test first_name'
       })
       .end((err, res) => {
+        this.skip()
         if (err) { return done() }
 
         expect(res).to.have.status(200)


### PR DESCRIPTION
Solves #63 
- Throw error from model functions
- Added `this.skip()` to the tests which were failing because of lack of test suite as suggested by @ankurnarkhede 

![image](https://user-images.githubusercontent.com/56217868/95988390-7813df80-0e46-11eb-9362-bc8a40f54095.png)

![image](https://user-images.githubusercontent.com/56217868/95988308-59ade400-0e46-11eb-82ce-4fb753835b8d.png)


Feel free to suggest changes. Thank you! 😄 