### PR TITLE
Fixed localhost response

### DIFF
--- a/config/development.js
+++ b/config/development.js
@@ -4,6 +4,7 @@
  */
 
 const port = 3000
+const localUrl = `http://localhost:${port}`
 
 module.exports = {
   port: port,
@@ -12,7 +13,14 @@ module.exports = {
 
   services: {
     rdsApi: {
-      baseUrl: `http://localhost:${port}`
+      baseUrl: localUrl
+    },
+
+    rdsUi: {
+      baseUrl: localUrl,
+      routes: {
+        authRedirection: '/healthcheck'
+      }
     }
   },
 


### PR DESCRIPTION
- The cookie is now being set for `localhost` domain when user is working in development mode.
- The user is redirected to `http://localhost:3000/healthcheck` after successful login.
