### PR TITLE
Fix firestore emulator issue

### DIFF
--- a/scripts/tests/testIntegration.sh
+++ b/scripts/tests/testIntegration.sh
@@ -3,18 +3,5 @@
 # set 'test' environment
 export NODE_ENV='test'
 
-# Set environment variable for firestore emulator host
-# @todo: Get port value from '../../firebase.json'
-export FIRESTORE_EMULATOR_HOST='localhost:8080'
-
-echo 'Start Firestore Emulator:'
-firebase emulators:start &
-
-echo 'Running integration tests:'
-nyc mocha test/integration/**
-
-# Erase the database
-# @todo: Get port value from '../../firebase.json' and projectId from config
-# Route; DELETE http://localhost:<PORT>/emulator/v1/projects/<PROJECT_ID>/databases/(default)/documents
-echo 'Erasing Firestore data:'
-curl -v -X DELETE 'http://localhost:8080/emulator/v1/projects/rds-dev/databases/(default)/documents'
+echo 'Start firestore emulator and run integration tests:'
+firebase emulators:exec 'nyc mocha test/integration/**'

--- a/scripts/tests/testUnit.sh
+++ b/scripts/tests/testUnit.sh
@@ -3,18 +3,5 @@
 # set 'test' environment
 export NODE_ENV='test'
 
-# set environment variable for firestore emulator host
-# @todo: Get port value from '../../firebase.json'
-export FIRESTORE_EMULATOR_HOST='localhost:8080'
-
-echo 'Start Firestore Emulator:'
-firebase emulators:start &
-
-echo 'Running unit tests:'
-nyc mocha test/unit/**
-
-# Erase the database
-# @todo: Get port value from '../../firebase.json' and projectId from config
-# Route; DELETE http://localhost:<PORT>/emulator/v1/projects/<PROJECT_ID>/databases/(default)/documents
-echo 'Erasing Firestore data:'
-curl -v -X DELETE 'http://localhost:8080/emulator/v1/projects/rds-dev/databases/(default)/documents'
+echo 'Start firestore emulator and run unit tests:'
+firebase emulators:exec 'nyc mocha test/unit/**'


### PR DESCRIPTION
As per this issue https://github.com/Real-Dev-Squad/website-backend/issues/32, the firestore emulator would keep running even after the tests are done running.

This change fixes --
- Firestore emulator is stopped after the tests are done.
- Remove unnecessary teardown step of erasing data.

We don't need to erase data because firestore emulator does not persist it by default.

If we want to persist data, we have to use `emulators:import` and `emulators:export`. 

Ref:
- [Install, configure and integrate Local Emulator Suite](https://firebase.google.com/docs/emulator-suite/install_and_configure)
- [Test your Cloud Firestore Security Rules](https://firebase.google.com/docs/firestore/security/test-rules-emulator)
