### PR TITLE
Scripts updated to run tests on windows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,6 +120,13 @@ The following project structure should be followed:
 - The emulator will be running on the port: 8080
 - You can view the emulator UI at: `http://localhost:4000`
 
+## Running test scripts on Windows
+- Git Bash is recommended for running test scripts on Windows.
+- Run `npm run test-integration` for running integration tests.
+- Run `npm run test-unit` for running unit tests.
+- Make sure to close the emulator window after running the tests in order to avoid the blocking of the port for the next tests to run. 
+- For e.g - After running the integration tests, close the emulator window and then run the command for unit tests.
+
 ## Pull request guidelines
 - Ensure that the tests pass locally before raising a PR.
 - All pull requests should have base as the develop branch.

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "lint": "eslint .",
     "lint-fix": "eslint . --fix",
     "test-config": "node scripts/local-test.js",
-    "test-integration": "./scripts/tests/testIntegration.sh",
-    "test-unit": "./scripts/tests/testUnit.sh",
+    "test-integration": "sh scripts/tests/testIntegration.sh",
+    "test-unit": "sh scripts/tests/testUnit.sh",
     "test": "npm run lint && npm run test-integration && npm run test-unit",
     "generate-api-schema": "node utils/generateAPISchema.js"
   },


### PR DESCRIPTION
- Changed the scripts for testing on windows. ( Works for linux and macOS also)
- `npm run test-integration` and `npm run test-unit` will run the Integration tests and Unit tests correspondingly.
- Fixes #158 