### PR TITLE
Sets sameSite attribute of cookie as lax

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -38,7 +38,8 @@ const githubAuth = (req, res, next) => {
         domain: rdsUiUrl.hostname,
         expires: new Date(Date.now() + config.get('userToken.ttl') * 1000),
         httpOnly: true,
-        secure: true
+        secure: true,
+        sameSite: 'lax'
       })
 
       return res.redirect(authRedirectionUrl)

--- a/middlewares/authenticate.js
+++ b/middlewares/authenticate.js
@@ -52,7 +52,8 @@ module.exports = async (req, res, next) => {
           domain: rdsUiUrl.hostname,
           expires: new Date(Date.now() + config.get('userToken.ttl') * 1000),
           httpOnly: true,
-          secure: true
+          secure: true,
+          sameSite: 'lax'
         })
 
         // add user data to `req.userData` for further use

--- a/scripts/tests/testIntegration.sh
+++ b/scripts/tests/testIntegration.sh
@@ -4,4 +4,4 @@
 export NODE_ENV='test'
 
 echo 'Start firestore emulator and run integration tests:'
-firebase emulators:exec './node_modules/.bin/nyc ./node_modules/.bin/mocha test/integration/**'
+firebase emulators:exec 'nyc mocha test/integration/**'

--- a/test/integration/authController.test.js
+++ b/test/integration/authController.test.js
@@ -66,6 +66,7 @@ describe('authController', function () {
         expect(res.headers['set-cookie'][0]).to.include('HttpOnly')
         expect(res.headers['set-cookie'][0]).to.include('Secure')
         expect(res.headers['set-cookie'][0]).to.include(`Domain=${rdsUiUrl.hostname}`)
+        expect(res.headers['set-cookie'][0]).to.include('sameSite', 'lax')
 
         return done()
       })

--- a/test/integration/authController.test.js
+++ b/test/integration/authController.test.js
@@ -66,7 +66,7 @@ describe('authController', function () {
         expect(res.headers['set-cookie'][0]).to.include('HttpOnly')
         expect(res.headers['set-cookie'][0]).to.include('Secure')
         expect(res.headers['set-cookie'][0]).to.include(`Domain=${rdsUiUrl.hostname}`)
-        expect(res.headers['set-cookie'][0]).to.include('sameSite', 'lax')
+        expect(res.headers['set-cookie'][0]).to.include('SameSite=Lax')
 
         return done()
       })


### PR DESCRIPTION
The `sameSite` attribute of cookie is set to `lax`. Fixes #196 