### PR TITLE
feature(TDD): Add TDD setup and soft-enable 50% coverage markers 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,29 +16,50 @@
 ## About the Project
 This Project serves the backend APIs required for [Real Dev Squad](https://realdevsquad.com/) web projects. This project is built in [Express.js](https://expressjs.com/).
 
-## Running the Project
-We are moving to yarn, to ensure that we use yarn , we are moving ahead with [Volta](https://docs.volta.sh/guide/#why-volta)
-To install Volta, please follow the [process](https://docs.volta.sh/guide/getting-started)
-```shell
-$ yarn
-$ yarn start
-```
-#### Running in dev mode
-```shell
-$ yarn run dev
-```
-
-#### Test local setup
-```shell
-$ yarn run validate-setup
-```
-
 ## Prerequisites
 - The application uses [node-config](https://github.com/lorenwest/node-config)([documentation](https://github.com/lorenwest/node-config/wiki/Configuration-Files)) for managing config.
 - Create a new file: `config/local.js`. Override the required config values from `config/development.js` and `config/default.js` into `config/local.js`.
 - Register the application for [GitHub OAuth](https://docs.github.com/en/developers/apps/creating-an-oauth-app) to get the `clientId` and `clientSecret`. Add the callback URL as `http://<HOSTNAME>:<PORT>/auth/github/callback`
 - Create an application on [FireStore](https://firebase.google.com/docs/firestore) and [generate a service file](https://cloud.google.com/iam/docs/creating-managing-service-account-keys). Add the service file credentials in the local config (or your env variables) as a string (don't forget to escape the newline in private_key)
 - For running the project locally, [Firebase Local Emulator Suite](https://firebase.google.com/docs/emulator-suite) can also be used instead of using the remote DB. Steps for setting it up: [CONTRIBUTING.md - Using Firebase Emulator Locally](https://github.com/Real-Dev-Squad/website-backend/blob/develop/CONTRIBUTING.md#using-firebase-emulator-locally)
+
+## Starting Local Development
+Please install `yarn` and `volta`
+
+[Why Volta?](https://docs.volta.sh/guide/#why-volta)
+
+To install Volta, please follow the [process](https://docs.volta.sh/guide/getting-started)
+
+### Local Development Setup
+
+Install all the packages using the following command:
+```shell
+yarn
+```
+
+#### Confirm correct configuration setup
+
+This command should be successful, before moving to development.
+```shell
+yarn validate-setup
+```
+
+#### TDD Local Development
+
+Head over to [TDD Tests Files List](scripts/tests/tdd-files-list.txt), and add the list of your new (or old) test files.
+
+> You can use wildcard '*' in the filepaths
+
+Run TDD in watch mode. Exiting this command will print the coverage report. Try to achieve 100% coverage.
+
+```shell
+yarn tdd:watch
+```
+#### Running a server in Dev mode
+```shell
+yarn dev
+```
+> In production, a separate process will take place, that will be mentioned here - TK
 
 ## API Documentation:
 - View the RDS API documentation: [Real Dev Squad API](https://documenter.getpostman.com/view/2021368/TW6wH8Ns)

--- a/nyc.config.js
+++ b/nyc.config.js
@@ -4,10 +4,21 @@
  */
 module.exports = {
   all: true,
+  'check-coverage': false, // Will be enabled after reaching 50% coverage: https://github.com/Real-Dev-Squad/website-backend/issues/493
   exclude: [
-    '**/test.js'
+    'test/**'
   ],
   reporter: ['text', 'lcov', 'text-summary'],
   reportDir: '.coverage',
-  tempDir: '.coverage'
+  tempDir: '.coverage',
+  branches: 50,
+  lines: 50,
+  functions: 50,
+  statements: 50,
+  watermarks: {
+    lines: [75, 90],
+    functions: [75, 90],
+    branches: [75, 90],
+    statements: [75, 90]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "validate-setup": "node scripts/validateSetup.js",
     "test-integration": "sh scripts/tests/testIntegration.sh",
     "test-unit": "sh scripts/tests/testUnit.sh",
-    "test": "yarn run lint && yarn run test-integration && yarn run test-unit",
+    "test": "yarn lint && yarn test-unit && yarn test-integration",
+    "tdd:watch": "sh scripts/tests/tdd.sh",
     "generate-api-schema": "node utils/generateAPISchema.js"
   },
   "dependencies": {

--- a/scripts/tests/tdd-files-list.txt
+++ b/scripts/tests/tdd-files-list.txt
@@ -1,0 +1,5 @@
+test/integration/<replace>.test.js
+test/integration/<replace>>.test.js
+test/unit/<replace>/<replace>.test.js
+test/unit/<replace>/<replace>.test.js
+test/unit/<replace>/<replace>.test.js

--- a/scripts/tests/tdd.sh
+++ b/scripts/tests/tdd.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# "tdd-files-list.txt only contain those files that are to be tested locally during development.
+# Wildcards are allowed in the filepaths. You can add any number of paths.
+# Note - Don't forget the newline in the end.
+
+BASEDIR=$(dirname "$0")
+tddFilename="$BASEDIR/tdd-files-list.txt"
+
+allPaths=""
+while read -r line; do
+    name="$line"
+    echo "Will run tests from file :- $name"
+    allPaths+="$name "
+done < "$tddFilename"
+
+export NODE_ENV='test'
+echo '\nStart firestore emulator and run tests during TDD only:\n'
+
+# Read config meanings here: https://github.com/istanbuljs/nyc#common-configuration-options
+firebase emulators:exec "nyc --check-coverage=true --all=false --skip-full=true --per-file=true mocha --watch $allPaths"
+
+# Aim to achieve these results when you exit:
+# =============================== Coverage summary ===============================
+# Statements   : 100% (  )
+# Branches     : 100% (  )
+# Functions    : 100% (  )
+# Lines        : 100% (  )
+# ================================================================================
+
+# Upon exiting, the script is expected to say "Script exited unsuccessfully (code 130)"
+
+# NOTE - Before commiting the code, run `yarn test` to run all the tests.


### PR DESCRIPTION
Closes #492 

A developer can now set the files (with wildcards) and run `yarn tdd:watch` and make all the tests pass.

Also, we should make sure that our coverage from `yarn test` reaches a minimum of 50%, before enabling the flag