### PR TITLE
fix logs fetch authorization

### DIFF
--- a/routes/logs.js
+++ b/routes/logs.js
@@ -3,7 +3,7 @@ const router = express.Router();
 const logs = require("../controllers/logs");
 const authenticate = require("../middlewares/authenticate");
 const { authorizeUser } = require("../middlewares/authorization");
-const { ROLES } = require("../constants/users");
+const ROLES = require("../constants/roles");
 
 router.get("/:type", authenticate, authorizeUser(ROLES.SUPER_USER), logs.fetchLogs);
 


### PR DESCRIPTION
Default users were able to use the `/logs/:type` endpoint which were supposed to be available only to super users