### PR TITLE
Modifies /members to return only unarchived users (by default)

### DIFF
--- a/constants/roles.js
+++ b/constants/roles.js
@@ -5,6 +5,6 @@ const LEGACY_ROLES = {
 };
 
 // Use Roles with authorizeRoles middleware
-const ROLES = { SUPERUSER: "super_user", APPOWNER: "app_owner", MEMBER: "member" };
+const ROLES = { SUPERUSER: "super_user", APPOWNER: "app_owner", MEMBER: "member", ARCHIVED: "archived" };
 
 module.exports = { LEGACY_ROLES, ROLES };

--- a/controllers/members.js
+++ b/controllers/members.js
@@ -14,7 +14,7 @@ const ERROR_MESSAGE = "Something went wrong. Please try again or contact admin";
 
 const getMembers = async (req, res) => {
   try {
-    const allUsers = await members.fetchUsers();
+    const allUsers = await members.fetchUsers(req.query);
 
     return res.json({
       message: allUsers.length ? "Members returned successfully!" : "No member found",

--- a/middlewares/validators/members.js
+++ b/middlewares/validators/members.js
@@ -1,0 +1,19 @@
+const joi = require("joi");
+
+const validateGetMembers = async (req, res, next) => {
+  const querySchema = joi.object().keys({
+    showArchived: joi.boolean().optional(),
+  });
+
+  try {
+    await querySchema.validateAsync(req.query);
+    next();
+  } catch (error) {
+    logger.error(`Error validating getMembers query params : ${error}`);
+    res.boom.badRequest(error.details[0].message);
+  }
+};
+
+module.exports = {
+  validateGetMembers,
+};

--- a/models/members.js
+++ b/models/members.js
@@ -16,14 +16,13 @@ const fetchUsers = async (queryParams = {}) => {
     const snapshot = await userModel.get();
     const allMembers = [];
 
-    let { includeArchived } = queryParams;
-    if (includeArchived === "true") includeArchived = true;
-    else includeArchived = false;
+    let { showArchived } = queryParams;
+    showArchived = showArchived === "true";
 
     if (!snapshot.empty) {
       snapshot.forEach((doc) => {
         const memberData = doc.data();
-        if (!includeArchived && memberData?.roles && memberData.roles[ROLES.ARCHIVED] === true) return;
+        if (!showArchived && memberData?.roles && memberData.roles[ROLES.ARCHIVED] === true) return;
         const curatedMemberData = {
           id: doc.id,
           ...memberData,

--- a/models/members.js
+++ b/models/members.js
@@ -5,21 +5,25 @@
 
 const firestore = require("../utils/firestore");
 const userModel = firestore.collection("users");
-
+const { ROLES } = require("../constants/roles");
 /**
  * Fetches the data about our users
  * @return {Promise<userModel|Array>}
  */
 
-const fetchUsers = async () => {
+const fetchUsers = async (queryParams = {}) => {
   try {
     const snapshot = await userModel.get();
-
     const allMembers = [];
+
+    let { includeArchived } = queryParams;
+    if (includeArchived === "true") includeArchived = true;
+    else includeArchived = false;
 
     if (!snapshot.empty) {
       snapshot.forEach((doc) => {
         const memberData = doc.data();
+        if (!includeArchived && memberData?.roles && memberData.roles[ROLES.ARCHIVED] === true) return;
         const curatedMemberData = {
           id: doc.id,
           ...memberData,
@@ -158,8 +162,8 @@ const addArchiveRoleToMembers = async (userId) => {
   try {
     const userDoc = await userModel.doc(userId).get();
     const user = userDoc.data();
-    if (user?.roles?.archivedMember) return { isArchived: true };
-    const roles = { ...user.roles, archivedMember: true };
+    if (user?.roles && user.roles[ROLES.ARCHIVED]) return { isArchived: true };
+    const roles = { ...user.roles, [ROLES.ARCHIVED]: true };
     await userModel.doc(userId).update({
       roles,
     });

--- a/models/members.js
+++ b/models/members.js
@@ -17,7 +17,7 @@ const fetchUsers = async (queryParams = {}) => {
     const allMembers = [];
 
     const { showArchived } = queryParams;
-    let isArchived = showArchived === "true";
+    const isArchived = showArchived === "true";
 
     if (!snapshot.empty) {
       snapshot.forEach((doc) => {

--- a/models/members.js
+++ b/models/members.js
@@ -16,13 +16,13 @@ const fetchUsers = async (queryParams = {}) => {
     const snapshot = await userModel.get();
     const allMembers = [];
 
-    let { showArchived } = queryParams;
-    showArchived = showArchived === "true";
+    const { showArchived } = queryParams;
+    let isArchived = showArchived === "true";
 
     if (!snapshot.empty) {
       snapshot.forEach((doc) => {
         const memberData = doc.data();
-        if (!showArchived && memberData?.roles && memberData.roles[ROLES.ARCHIVED] === true) return;
+        if (!isArchived && memberData?.roles && memberData.roles[ROLES.ARCHIVED] === true) return;
         const curatedMemberData = {
           id: doc.id,
           ...memberData,

--- a/routes/members.js
+++ b/routes/members.js
@@ -5,6 +5,7 @@ const { authorizeUser } = require("../middlewares/authorization");
 const authenticate = require("../middlewares/authenticate");
 const { addRecruiter, fetchRecruitersInfo } = require("../controllers/recruiters");
 const { validateRecruiter } = require("../middlewares/validators/recruiter");
+const { validateGetMembers } = require("../middlewares/validators/members");
 const {
   LEGACY_ROLES: { SUPER_USER },
 } = require("../constants/roles");
@@ -37,7 +38,7 @@ const {
  *               $ref: '#/components/schemas/errors/badImplementation'
  */
 
-router.get("/", members.getMembers);
+router.get("/", validateGetMembers, members.getMembers);
 
 /**
  * @swagger

--- a/routes/members.js
+++ b/routes/members.js
@@ -18,7 +18,7 @@ const {
  *       - Members
  *     parameters:
  *        - in: query
- *          name: includeArchived
+ *          name: showArchived
  *          schema:
  *             type: boolean
  *          description: If true, the endpoint returns all users (including archived)

--- a/routes/members.js
+++ b/routes/members.js
@@ -13,12 +13,18 @@ const {
  * @swagger
  * /members:
  *   get:
- *     summary: Gets details of all the Real Dev Squad members
+ *     summary: Gets details of all the unarchived users
  *     tags:
  *       - Members
+ *     parameters:
+ *        - in: query
+ *          name: includeArchived
+ *          schema:
+ *             type: boolean
+ *          description: If true, the endpoint returns all users (including archived)
  *     responses:
  *       200:
- *         description: Details of all the RDS members
+ *         description: Details of all the unarchived users
  *         content:
  *           application/json:
  *             schema:

--- a/test/fixtures/user/user.js
+++ b/test/fixtures/user/user.js
@@ -112,7 +112,7 @@ module.exports = () => {
       status: "active",
       roles: {
         app_owner: true,
-        archivedMember: true,
+        archived: true,
       },
     },
     {
@@ -132,7 +132,7 @@ module.exports = () => {
       status: "active",
       roles: {
         member: true,
-        archivedMember: true,
+        archived: false,
       },
     },
   ];

--- a/test/integration/members.test.js
+++ b/test/integration/members.test.js
@@ -27,6 +27,13 @@ const userWithoutRolesObject = userData[1];
 const userWithRolesObjectWithArchivedTrue = userData[5];
 const userWithRolesObjectWithArchivedFalse = userData[6];
 
+const archivedUsersGithubIds = [userWithRolesObjectWithArchivedTrue.github_id];
+const unarchivedUsersGithubIds = [
+  userWithoutRolesObject.github_id,
+  userWithRolesObjectWithoutArchivedProperty.github_id,
+  userWithRolesObjectWithArchivedFalse.github_id,
+];
+
 describe("Members", function () {
   let jwt;
 
@@ -98,13 +105,10 @@ describe("Members", function () {
           expect(res.body).to.be.a("object");
           expect(res.body.message).to.equal("Members returned successfully!");
           expect(res.body.members).to.be.a("array");
+          expect(res.body.members.length).to.be.equal(unarchivedUsersGithubIds.length);
           const memberGithubIds = res.body.members.map((member) => member.github_id);
-          expect(memberGithubIds.indexOf(userWithoutRolesObject.github_id)).to.greaterThanOrEqual(0);
-          expect(memberGithubIds.indexOf(userWithRolesObjectWithoutArchivedProperty.github_id)).to.greaterThanOrEqual(
-            0
-          );
-          expect(memberGithubIds.indexOf(userWithRolesObjectWithArchivedFalse.github_id)).to.greaterThanOrEqual(0);
-          expect(memberGithubIds.indexOf(userWithRolesObjectWithArchivedTrue.github_id)).to.equal(-1);
+          expect(memberGithubIds).to.include.all.members(unarchivedUsersGithubIds);
+          expect(memberGithubIds).to.not.include.any.members(archivedUsersGithubIds);
           return done();
         });
     });
@@ -117,18 +121,14 @@ describe("Members", function () {
           if (err) {
             return done(err);
           }
-
+          const totalUsersCount = unarchivedUsersGithubIds.length + archivedUsersGithubIds.length;
           expect(res).to.have.status(200);
           expect(res.body).to.be.a("object");
           expect(res.body.message).to.equal("Members returned successfully!");
           expect(res.body.members).to.be.a("array");
+          expect(res.body.members.length).to.be.equal(totalUsersCount);
           const memberGithubIds = res.body.members.map((member) => member.github_id);
-          expect(memberGithubIds.indexOf(userWithoutRolesObject.github_id)).to.greaterThanOrEqual(0);
-          expect(memberGithubIds.indexOf(userWithRolesObjectWithoutArchivedProperty.github_id)).to.greaterThanOrEqual(
-            0
-          );
-          expect(memberGithubIds.indexOf(userWithRolesObjectWithArchivedTrue.github_id)).to.greaterThanOrEqual(0);
-          expect(memberGithubIds.indexOf(userWithRolesObjectWithArchivedFalse.github_id)).to.greaterThanOrEqual(0);
+          expect(memberGithubIds).to.include.all.members([...unarchivedUsersGithubIds, ...archivedUsersGithubIds]);
           return done();
         });
     });

--- a/test/integration/members.test.js
+++ b/test/integration/members.test.js
@@ -81,16 +81,13 @@ describe("Members", function () {
           expect(res.body).to.be.a("object");
           expect(res.body.message).to.equal("Members returned successfully!");
           expect(res.body.members).to.be.a("array");
-          // console.log(res.body.members)
           const memberGithubIds = res.body.members.map((member) => member.github_id);
-          // console.log(`memberGithubIds : ${memberGithubIds}`)
           expect(memberGithubIds.indexOf(userWithoutRolesObject.github_id)).to.greaterThanOrEqual(0);
           expect(memberGithubIds.indexOf(userWithRolesObjectWithoutArchivedProperty.github_id)).to.greaterThanOrEqual(
             0
           );
           expect(memberGithubIds.indexOf(userWithRolesObjectWithArchivedFalse.github_id)).to.greaterThanOrEqual(0);
           expect(memberGithubIds.indexOf(userWithRolesObjectWithArchivedTrue.github_id)).to.equal(-1);
-          // expect(res.body.members[0].roles.member).to.eql(true);
           return done();
         });
     });
@@ -108,16 +105,13 @@ describe("Members", function () {
           expect(res.body).to.be.a("object");
           expect(res.body.message).to.equal("Members returned successfully!");
           expect(res.body.members).to.be.a("array");
-          // console.log(res.body.members)
           const memberGithubIds = res.body.members.map((member) => member.github_id);
-          // console.log(`memberGithubIds : ${memberGithubIds}`)
           expect(memberGithubIds.indexOf(userWithoutRolesObject.github_id)).to.greaterThanOrEqual(0);
           expect(memberGithubIds.indexOf(userWithRolesObjectWithoutArchivedProperty.github_id)).to.greaterThanOrEqual(
             0
           );
           expect(memberGithubIds.indexOf(userWithRolesObjectWithArchivedTrue.github_id)).to.greaterThanOrEqual(0);
           expect(memberGithubIds.indexOf(userWithRolesObjectWithArchivedFalse.github_id)).to.greaterThanOrEqual(0);
-          // expect(res.body.members[0].roles.member).to.eql(true);
           return done();
         });
     });

--- a/test/integration/members.test.js
+++ b/test/integration/members.test.js
@@ -22,6 +22,10 @@ const nonSuperUser = userData[0];
 const userDoesNotExists = userData[1];
 const userToBeArchived = userData[3];
 const userAlreadyArchived = userData[5];
+const userWithRolesObjectWithoutArchivedProperty = userData[0];
+const userWithoutRolesObject = userData[1];
+const userWithRolesObjectWithArchivedTrue = userData[5];
+const userWithRolesObjectWithArchivedFalse = userData[6];
 
 describe("Members", function () {
   let jwt;
@@ -38,7 +42,15 @@ describe("Members", function () {
     before(async function () {
       await cleanDb();
     });
-    it("Should return empty array if no member is found", function (done) {
+
+    afterEach(async function () {
+      await addUser(userWithoutRolesObject);
+      await addUser(userWithRolesObjectWithoutArchivedProperty);
+      await addUser(userWithRolesObjectWithArchivedTrue);
+      await addUser(userWithRolesObjectWithArchivedFalse);
+    });
+
+    it("Should return empty array if no user is found", function (done) {
       chai
         .request(app)
         .get("/members")
@@ -56,7 +68,7 @@ describe("Members", function () {
         });
     });
 
-    it("Get all the members in the database", function (done) {
+    it("Get all the unarchived users in the database", function (done) {
       chai
         .request(app)
         .get("/members")
@@ -69,8 +81,43 @@ describe("Members", function () {
           expect(res.body).to.be.a("object");
           expect(res.body.message).to.equal("Members returned successfully!");
           expect(res.body.members).to.be.a("array");
-          expect(res.body.members[0].roles.member).to.eql(true);
+          // console.log(res.body.members)
+          const memberGithubIds = res.body.members.map((member) => member.github_id);
+          // console.log(`memberGithubIds : ${memberGithubIds}`)
+          expect(memberGithubIds.indexOf(userWithoutRolesObject.github_id)).to.greaterThanOrEqual(0);
+          expect(memberGithubIds.indexOf(userWithRolesObjectWithoutArchivedProperty.github_id)).to.greaterThanOrEqual(
+            0
+          );
+          expect(memberGithubIds.indexOf(userWithRolesObjectWithArchivedFalse.github_id)).to.greaterThanOrEqual(0);
+          expect(memberGithubIds.indexOf(userWithRolesObjectWithArchivedTrue.github_id)).to.equal(-1);
+          // expect(res.body.members[0].roles.member).to.eql(true);
+          return done();
+        });
+    });
 
+    it("Get all the users in the database (including archived)", function (done) {
+      chai
+        .request(app)
+        .get("/members?includeArchived=true")
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          expect(res).to.have.status(200);
+          expect(res.body).to.be.a("object");
+          expect(res.body.message).to.equal("Members returned successfully!");
+          expect(res.body.members).to.be.a("array");
+          // console.log(res.body.members)
+          const memberGithubIds = res.body.members.map((member) => member.github_id);
+          // console.log(`memberGithubIds : ${memberGithubIds}`)
+          expect(memberGithubIds.indexOf(userWithoutRolesObject.github_id)).to.greaterThanOrEqual(0);
+          expect(memberGithubIds.indexOf(userWithRolesObjectWithoutArchivedProperty.github_id)).to.greaterThanOrEqual(
+            0
+          );
+          expect(memberGithubIds.indexOf(userWithRolesObjectWithArchivedTrue.github_id)).to.greaterThanOrEqual(0);
+          expect(memberGithubIds.indexOf(userWithRolesObjectWithArchivedFalse.github_id)).to.greaterThanOrEqual(0);
+          // expect(res.body.members[0].roles.member).to.eql(true);
           return done();
         });
     });

--- a/test/integration/members.test.js
+++ b/test/integration/members.test.js
@@ -68,6 +68,23 @@ describe("Members", function () {
         });
     });
 
+    it("Should return 400 for showArchived query param value other than true/false", function (done) {
+      chai
+        .request(app)
+        .get("/members?showArchived=xyz")
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          expect(res).to.have.status(400);
+          expect(res.body).to.be.a("object");
+          expect(res.body.message).to.equal('"showArchived" must be a boolean');
+
+          return done();
+        });
+    });
+
     it("Get all the unarchived users in the database", function (done) {
       chai
         .request(app)

--- a/test/integration/members.test.js
+++ b/test/integration/members.test.js
@@ -95,7 +95,7 @@ describe("Members", function () {
     it("Get all the users in the database (including archived)", function (done) {
       chai
         .request(app)
-        .get("/members?includeArchived=true")
+        .get("/members?showArchived=true")
         .end((err, res) => {
           if (err) {
             return done(err);


### PR DESCRIPTION
* Added a new role archived in ROLES constant

* Added a query param includeArchived(default value false)

* By default only unarchived users are returned. We can use includeArchived = true flag to get all users

* Updated and added integration test for /members endpoint

* Updated swagger doc for /members endpoint

* Rename all occurrences of archivedMember to archived

Closes #601 

Please follow the merge order specified here : https://github.com/Real-Dev-Squad/website-backend/issues/672