### PR TITLE
Adds an endpoint to add default archived role only where it does not exists

### DIFF
--- a/controllers/users.js
+++ b/controllers/users.js
@@ -292,6 +292,26 @@ const rejectProfileDiff = async (req, res) => {
   }
 };
 
+/**
+ * Returns the lists of usernames where default archived role was added
+ *
+ * @param req {Object} - Express request object
+ * @param res {Object} - Express response object
+ */
+
+const addDefaultArchivedRole = async (req, res) => {
+  try {
+    const addedDefaultArchivedRoleData = await userQuery.addDefaultArchivedRole();
+    return res.json({
+      message: "Users default archived role added successfully!",
+      ...addedDefaultArchivedRoleData,
+    });
+  } catch (error) {
+    logger.error(`Error adding default archived role: ${error}`);
+    return res.boom.badImplementation("Something went wrong. Please contact admin");
+  }
+};
+
 module.exports = {
   verifyUser,
   generateChaincode,
@@ -305,4 +325,5 @@ module.exports = {
   rejectProfileDiff,
   getUserById,
   profileURL,
+  addDefaultArchivedRole,
 };

--- a/models/users.js
+++ b/models/users.js
@@ -6,7 +6,7 @@ const walletConstants = require("../constants/wallets");
 
 const firestore = require("../utils/firestore");
 const { fetchWallet, createWallet } = require("../models/wallets");
-
+const { ROLES } = require("../constants/roles");
 const userModel = firestore.collection("users");
 
 /**
@@ -181,6 +181,39 @@ const fetchUserImage = async (users) => {
   return images;
 };
 
+/**
+ * Adds default archived role
+ * @return {Promise<usersMigrated|Object>}
+ */
+const addDefaultArchivedRole = async () => {
+  try {
+    const userSnapShot = await userModel.get();
+    const migratedUsers = [];
+    const updateUserPromises = [];
+    const usersArr = [];
+
+    userSnapShot.forEach((doc) => usersArr.push({ id: doc.id, ...doc.data() }));
+    for (const user of usersArr) {
+      const roles = user.roles ? user.roles : {};
+      if (roles[ROLES.ARCHIVED] === undefined) {
+        roles[ROLES.ARCHIVED] = false;
+        updateUserPromises.push(
+          userModel.doc(user.id).set({
+            ...user,
+            roles,
+          })
+        );
+        migratedUsers.push(user.username);
+      }
+    }
+    await Promise.all(updateUserPromises);
+    return { count: migratedUsers.length, users: migratedUsers };
+  } catch (err) {
+    logger.error("Error adding default archived roles", err);
+    throw err;
+  }
+};
+
 module.exports = {
   addOrUpdate,
   fetchUsers,
@@ -189,4 +222,5 @@ module.exports = {
   initializeUser,
   updateUserPicture,
   fetchUserImage,
+  addDefaultArchivedRole,
 };

--- a/routes/users.js
+++ b/routes/users.js
@@ -279,6 +279,41 @@ router.patch("/profileURL", authenticate, userValidator.updateProfileURL, users.
 
 router.patch("/rejectDiff", authenticate, authorizeUser(SUPER_USER), users.rejectProfileDiff);
 
+/**
+ * @swagger
+ * /members/add-default-archived-role:
+ *  patch:
+ *   summary: One time call to add default archived role for the users only where it does not exists
+ *   tags:
+ *     - Users
+ *   responses:
+ *     200:
+ *       description: Details of the users migrated
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/migratedUsers'
+ *     401:
+ *       description: unAuthorized
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/errors/unAuthorized'
+ *     403:
+ *       description: forbidden
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/errors/forbidden'
+ *     500:
+ *       description: badImplementation
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/errors/badImplementation'
+ */
+router.patch("/add-default-archived-role", authenticate, authorizeUser(SUPER_USER), users.addDefaultArchivedRole);
+
 router.patch("/:userId", authenticate, authorizeUser(SUPER_USER), users.updateUser);
 
 module.exports = router;

--- a/test/fixtures/user/user.js
+++ b/test/fixtures/user/user.js
@@ -92,6 +92,7 @@ module.exports = () => {
       },
       roles: {
         super_user: true,
+        archived: false,
       },
     },
     {


### PR DESCRIPTION
## This PR can only be merged after #661
- #661 

* Endpoint : `PATCH /users/add-default-archived-role`
* Added model,route,controller methods. Default archived = `false` role will be added to all users where either roles DNE or role.archived DNE
* Added integration test for this endpoint
* Load tested this endpoint with `5000` users (all without archived property in roles map). 
Time taken ≈ `15-20 sec` . 
Breakdown : 5000 reads(≈4s) + 5000 updates(≈12s) 

Closes #651 

Please follow the merge order specified here : https://github.com/Real-Dev-Squad/website-backend/issues/672