### PR TITLE
added level and categories key in validators-middleware for task object

### DIFF
--- a/middlewares/validators/tasks.js
+++ b/middlewares/validators/tasks.js
@@ -25,6 +25,13 @@ const createTask = async (req, res, next) => {
           [NEELAM]: joi.number().optional(),
         })
         .optional(),
+      taskLevel: joi
+        .object()
+        .keys({
+          category: joi.string().optional(),
+          level: joi.number().optional(),
+        })
+        .optional(),
       lossRate: joi
         .object()
         .keys({
@@ -66,6 +73,13 @@ const updateTask = async (req, res, next) => {
         .keys({
           [DINERO]: joi.number().optional(),
           [NEELAM]: joi.number().optional(),
+        })
+        .optional(),
+      taskLevel: joi
+        .object()
+        .keys({
+          category: joi.string().optional(),
+          level: joi.number().optional(),
         })
         .optional(),
       lossRate: joi


### PR DESCRIPTION
closes #743 
## Change
level and category key is added into validators of task object as part of adding new feature to display tags on each task on status website
### Subtask:
Update website-api-contract/tasks/
### Related PR 
https://github.com/Real-Dev-Squad/website-status/pull/322