### PR TITLE
Status changed by User on the task will be logged

### DIFF
--- a/controllers/tasks.js
+++ b/controllers/tasks.js
@@ -173,23 +173,27 @@ const updateTaskStatus = async (req, res, next) => {
       body: {
         subType: "update",
         new: {},
-        messages: [],
+        message: "",
       },
     };
 
-    if (req.body.status) {
+    if (req.body.status && !req.body.percentCompleted) {
       taskLog.body.new.status = req.body.status;
-      taskLog.body.messages.push(`changed status to ${req.body.status}`);
+      taskLog.body.message = `@${username} changed status to ${req.body.status}`;
     }
-    if (req.body.percentCompleted) {
+    if (req.body.percentCompleted && !req.body.status) {
       taskLog.body.new.percentCompleted = req.body.percentCompleted;
-      taskLog.body.messages.push(`changed percentCompleted to ${req.body.percentCompleted}`);
+      taskLog.body.message = `@${username} changed percentCompleted to ${req.body.percentCompleted}`;
+    }
+
+    if (req.body.percentCompleted && req.body.status) {
+      taskLog.body.new.percentCompleted = req.body.percentCompleted;
+      taskLog.body.new.status = req.body.status;
+      taskLog.body.message = `@${username} changed percentCompleted to ${req.body.percentCompleted} and status was changed to ${req.body.status}`;
     }
 
     if (req.body.percentCompleted === 100 && req.body.status === TASK_STATUS.COMPLETED) {
-      taskLog.body.messages = [
-        `changed percentCompleted to ${req.body.percentCompleted} and status was changed to COMPLETED`,
-      ];
+      taskLog.body.message = `@${username} changed percentCompleted to ${req.body.percentCompleted} and status was changed to COMPLETED`;
     }
 
     const [, taskLogResult] = await Promise.all([

--- a/controllers/tasks.js
+++ b/controllers/tasks.js
@@ -173,14 +173,17 @@ const updateTaskStatus = async (req, res, next) => {
       body: {
         subType: "update",
         new: {},
+        messages: [],
       },
     };
 
     if (req.body.status) {
       taskLog.body.new.status = req.body.status;
+      taskLog.body.messages.push(`${username} changed status to ${req.body.status}`);
     }
     if (req.body.percentCompleted) {
       taskLog.body.new.percentCompleted = req.body.percentCompleted;
+      taskLog.body.messages.push(`${username} changed percentCompleted to ${req.body.percentCompleted}`);
     }
 
     const [, taskLogResult] = await Promise.all([

--- a/controllers/tasks.js
+++ b/controllers/tasks.js
@@ -151,8 +151,6 @@ const updateTaskStatus = async (req, res, next) => {
     if (task.taskData.status === "VERIFIED")
       return res.boom.forbidden("Status cannot be updated. Please contact admin.");
 
-    await tasks.updateTask(req.body, taskId);
-
     const taskLog = {
       type: "task",
       meta: {
@@ -168,8 +166,11 @@ const updateTaskStatus = async (req, res, next) => {
       taskLog.body = `${username} changed task percent Completed to ${req.body.percentCompleted}`;
     }
 
-    const { id: taskLogId } = await addLog(taskLog.type, taskLog.meta, taskLog.body);
-    taskLog.id = taskLogId;
+    const [taskResult] = await Promise.all([
+      tasks.updateTask(req.body, taskId),
+      addLog(taskLog.type, taskLog.meta, taskLog.body),
+    ]);
+    taskLog.id = taskResult.taskId;
 
     if (dev) {
       if (req.body.percentCompleted === 100) {

--- a/controllers/tasks.js
+++ b/controllers/tasks.js
@@ -143,7 +143,7 @@ const updateTaskStatus = async (req, res, next) => {
   try {
     const taskId = req.params.id;
     const { dev } = req.query;
-    const { id: userId, username } = req.userData;
+    const { id: userId } = req.userData;
     const task = await tasks.fetchSelfTask(taskId, userId);
 
     if (task.taskNotFound) return res.boom.notFound("Task doesn't exist");
@@ -168,7 +168,6 @@ const updateTaskStatus = async (req, res, next) => {
       meta: {
         userId,
         taskId,
-        username,
       },
       body: {
         subType: "update",

--- a/controllers/tasks.js
+++ b/controllers/tasks.js
@@ -158,12 +158,14 @@ const updateTaskStatus = async (req, res, next) => {
         taskId,
         username,
       },
+      body: [],
     };
 
     if (req.body.status) {
-      taskLog.body = `${username} changed task status to ${req.body.status}`;
-    } else if (req.body.percentCompleted) {
-      taskLog.body = `${username} changed task percent Completed to ${req.body.percentCompleted}`;
+      taskLog.body.push(`${username} changed task status to ${req.body.status}`);
+    }
+    if (req.body.percentCompleted) {
+      taskLog.body.push(`${username} changed task percent Completed to ${req.body.percentCompleted}`);
     }
 
     const [taskResult] = await Promise.all([

--- a/controllers/tasks.js
+++ b/controllers/tasks.js
@@ -173,27 +173,19 @@ const updateTaskStatus = async (req, res, next) => {
       body: {
         subType: "update",
         new: {},
-        message: "",
       },
     };
 
     if (req.body.status && !req.body.percentCompleted) {
       taskLog.body.new.status = req.body.status;
-      taskLog.body.message = `@${username} changed status to ${req.body.status}`;
     }
     if (req.body.percentCompleted && !req.body.status) {
       taskLog.body.new.percentCompleted = req.body.percentCompleted;
-      taskLog.body.message = `@${username} changed percentCompleted to ${req.body.percentCompleted}`;
     }
 
     if (req.body.percentCompleted && req.body.status) {
       taskLog.body.new.percentCompleted = req.body.percentCompleted;
       taskLog.body.new.status = req.body.status;
-      taskLog.body.message = `@${username} changed percentCompleted to ${req.body.percentCompleted} and status was changed to ${req.body.status}`;
-    }
-
-    if (req.body.percentCompleted === 100 && req.body.status === TASK_STATUS.COMPLETED) {
-      taskLog.body.message = `@${username} changed percentCompleted to ${req.body.percentCompleted} and status was changed to COMPLETED`;
     }
 
     const [, taskLogResult] = await Promise.all([

--- a/controllers/tasks.js
+++ b/controllers/tasks.js
@@ -158,21 +158,25 @@ const updateTaskStatus = async (req, res, next) => {
         taskId,
         username,
       },
-      body: [],
+      body: {
+        messages: [],
+      },
     };
 
     if (req.body.status) {
-      taskLog.body.push(`${username} changed task status to ${req.body.status}`);
+      taskLog.body.messages.push(`${username} changed task status to ${req.body.status}`);
+      taskLog.body.newStatus = req.body.status;
     }
     if (req.body.percentCompleted) {
-      taskLog.body.push(`${username} changed task percent Completed to ${req.body.percentCompleted}`);
+      taskLog.body.messages.push(`${username} changed task percent Completed to ${req.body.percentCompleted}`);
+      taskLog.body.newPercentCompleted = req.body.percentCompleted;
     }
 
-    const [taskResult] = await Promise.all([
+    const [, taskLogResult] = await Promise.all([
       tasks.updateTask(req.body, taskId),
       addLog(taskLog.type, taskLog.meta, taskLog.body),
     ]);
-    taskLog.id = taskResult.taskId;
+    taskLog.id = taskLogResult.id;
 
     if (dev) {
       if (req.body.percentCompleted === 100) {

--- a/controllers/tasks.js
+++ b/controllers/tasks.js
@@ -158,7 +158,7 @@ const updateTaskStatus = async (req, res, next) => {
   try {
     const taskId = req.params.id;
     const { dev } = req.query;
-    const { id: userId } = req.userData;
+    const { id: userId, username } = req.userData;
     const task = await tasks.fetchSelfTask(taskId, userId);
 
     if (task.taskNotFound) return res.boom.notFound("Task doesn't exist");
@@ -183,6 +183,7 @@ const updateTaskStatus = async (req, res, next) => {
       meta: {
         userId,
         taskId,
+        username,
       },
       body: {
         subType: "update",

--- a/controllers/tasks.js
+++ b/controllers/tasks.js
@@ -148,18 +148,18 @@ const updateTaskStatus = async (req, res, next) => {
 
     if (task.taskNotFound) return res.boom.notFound("Task doesn't exist");
     if (task.notAssignedToYou) return res.boom.forbidden("This task is not assigned to you");
-    if (task.taskData.status === "VERIFIED" || req.body.status === "MERGED")
+    if (task.taskData.status === TASK_STATUS.VERIFIED || req.body.status === TASK_STATUS.MERGED)
       return res.boom.forbidden("Status cannot be updated. Please contact admin.");
 
-    if (task.taskData.status === "COMPLETED" && req.body.percentCompleted < 100) {
-      if (req.body.status === "COMPLETED" || !req.body.status) {
-        return res.boom.forbidden("Task percentCompleted can't updated as status is COMPLETED");
+    if (task.taskData.status === TASK_STATUS.COMPLETED && req.body.percentCompleted < 100) {
+      if (req.body.status === TASK_STATUS.COMPLETED || !req.body.status) {
+        return res.boom.badRequest("Task percentCompleted can't updated as status is COMPLETED");
       }
     }
 
-    if (req.body.status === "COMPLETED" && task.taskData.percentCompleted !== 100) {
+    if (req.body.status === TASK_STATUS.COMPLETED && task.taskData.percentCompleted !== 100) {
       if (req.body.percentCompleted !== 100) {
-        return res.boom.forbidden("Status cannot be updated. Task is not completed yet");
+        return res.boom.badRequest("Status cannot be updated. Task is not completed yet");
       }
     }
 

--- a/controllers/tasks.js
+++ b/controllers/tasks.js
@@ -168,7 +168,8 @@ const updateTaskStatus = async (req, res, next) => {
       taskLog.body = `${username} changed task percent Completed to ${req.body.percentCompleted}`;
     }
 
-    await addLog(taskLog.type, taskLog.meta, taskLog.body);
+    const { id: taskLogId } = await addLog(taskLog.type, taskLog.meta, taskLog.body);
+    taskLog.id = taskLogId;
 
     if (dev) {
       if (req.body.percentCompleted === 100) {

--- a/controllers/tasks.js
+++ b/controllers/tasks.js
@@ -148,8 +148,20 @@ const updateTaskStatus = async (req, res, next) => {
 
     if (task.taskNotFound) return res.boom.notFound("Task doesn't exist");
     if (task.notAssignedToYou) return res.boom.forbidden("This task is not assigned to you");
-    if (task.taskData.status === "VERIFIED")
+    if (task.taskData.status === "VERIFIED" || req.body.status === "MERGED")
       return res.boom.forbidden("Status cannot be updated. Please contact admin.");
+
+    if (task.taskData.status === "COMPLETED" && req.body.percentCompleted < 100) {
+      if (req.body.status === "COMPLETED" || !req.body.status) {
+        return res.boom.forbidden("Task percentCompleted can't updated as status is COMPLETED");
+      }
+    }
+
+    if (req.body.status === "COMPLETED" && task.taskData.percentCompleted !== 100) {
+      if (req.body.percentCompleted !== 100) {
+        return res.boom.forbidden("Status cannot be updated. Task is not completed yet");
+      }
+    }
 
     const taskLog = {
       type: "task",
@@ -159,7 +171,7 @@ const updateTaskStatus = async (req, res, next) => {
         username,
       },
       body: {
-        subTask: "update",
+        subType: "update",
         new: {},
       },
     };

--- a/controllers/tasks.js
+++ b/controllers/tasks.js
@@ -179,11 +179,17 @@ const updateTaskStatus = async (req, res, next) => {
 
     if (req.body.status) {
       taskLog.body.new.status = req.body.status;
-      taskLog.body.messages.push(`${username} changed status to ${req.body.status}`);
+      taskLog.body.messages.push(`changed status to ${req.body.status}`);
     }
     if (req.body.percentCompleted) {
       taskLog.body.new.percentCompleted = req.body.percentCompleted;
-      taskLog.body.messages.push(`${username} changed percentCompleted to ${req.body.percentCompleted}`);
+      taskLog.body.messages.push(`changed percentCompleted to ${req.body.percentCompleted}`);
+    }
+
+    if (req.body.percentCompleted === 100 && req.body.status === TASK_STATUS.COMPLETED) {
+      taskLog.body.messages = [
+        `changed percentCompleted to ${req.body.percentCompleted} and status was changed to COMPLETED`,
+      ];
     }
 
     const [, taskLogResult] = await Promise.all([

--- a/controllers/tasks.js
+++ b/controllers/tasks.js
@@ -159,17 +159,16 @@ const updateTaskStatus = async (req, res, next) => {
         username,
       },
       body: {
-        messages: [],
+        subTask: "update",
+        new: {},
       },
     };
 
     if (req.body.status) {
-      taskLog.body.messages.push(`${username} changed task status to ${req.body.status}`);
-      taskLog.body.newStatus = req.body.status;
+      taskLog.body.new.status = req.body.status;
     }
     if (req.body.percentCompleted) {
-      taskLog.body.messages.push(`${username} changed task percent Completed to ${req.body.percentCompleted}`);
-      taskLog.body.newPercentCompleted = req.body.percentCompleted;
+      taskLog.body.new.percentCompleted = req.body.percentCompleted;
     }
 
     const [, taskLogResult] = await Promise.all([

--- a/models/logs.js
+++ b/models/logs.js
@@ -17,7 +17,7 @@ const addLog = async (type, meta, body) => {
       meta,
       body,
     };
-    await logsModel.add(log);
+    return await logsModel.add(log);
   } catch (err) {
     logger.error("Error in adding log", err);
     throw err;

--- a/test/integration/tasks.test.js
+++ b/test/integration/tasks.test.js
@@ -325,6 +325,7 @@ describe("Tasks", function () {
           }
           expect(res).to.have.status(200);
           expect(res.body.taskLog).to.have.property("type");
+          expect(res.body.taskLog).to.have.property("id");
           expect(res.body.taskLog.meta).to.be.a("object");
           expect(res.body.message).to.equal("Task updated successfully!");
           return done();

--- a/test/integration/tasks.test.js
+++ b/test/integration/tasks.test.js
@@ -326,9 +326,13 @@ describe("Tasks", function () {
           expect(res).to.have.status(200);
           expect(res.body.taskLog).to.have.property("type");
           expect(res.body.taskLog).to.have.property("id");
-          expect(res.body.taskLog.body).to.be.a("array");
+          expect(res.body.taskLog.body).to.be.a("object");
           expect(res.body.taskLog.meta).to.be.a("object");
           expect(res.body.message).to.equal("Task updated successfully!");
+
+          expect(res.body.taskLog.body.newStatus).to.equal(taskStatusData.status);
+          expect(res.body.taskLog.body.newPercentCompleted).to.equal(taskStatusData.percentCompleted);
+
           return done();
         });
     });

--- a/test/integration/tasks.test.js
+++ b/test/integration/tasks.test.js
@@ -345,9 +345,6 @@ describe("Tasks", function () {
 
           expect(res.body.taskLog.body.new.status).to.equal(taskStatusData.status);
           expect(res.body.taskLog.body.new.percentCompleted).to.equal(taskStatusData.percentCompleted);
-          expect(res.body.taskLog.body.message).that.contains(taskStatusData.percentCompleted);
-          expect(res.body.taskLog.body.message).that.contains(taskStatusData.status);
-          expect(res.body.taskLog.body.message).that.contains(`@${appOwner.username}`);
           return done();
         });
     });

--- a/test/integration/tasks.test.js
+++ b/test/integration/tasks.test.js
@@ -345,6 +345,7 @@ describe("Tasks", function () {
 
           expect(res.body.taskLog.body.new.status).to.equal(taskStatusData.status);
           expect(res.body.taskLog.body.new.percentCompleted).to.equal(taskStatusData.percentCompleted);
+          expect(res.body.taskLog.body.messages.length).to.equal(Object.keys(taskStatusData).length);
 
           return done();
         });

--- a/test/integration/tasks.test.js
+++ b/test/integration/tasks.test.js
@@ -313,6 +313,19 @@ describe("Tasks", function () {
       percentCompleted: 50,
     };
 
+    const taskData = {
+      title: "Test task",
+      type: "feature",
+      endsOn: 1234,
+      startedOn: 4567,
+      status: "VERIFIED",
+      percentCompleted: 10,
+      participants: [],
+      completionAward: { [DINERO]: 3, [NEELAM]: 300 },
+      lossRate: { [DINERO]: 1 },
+      isNoteworthy: true,
+    };
+
     it("Should update the task status for given self taskid", function (done) {
       chai
         .request(app)
@@ -379,20 +392,7 @@ describe("Tasks", function () {
     });
 
     it("Should give 403 if status is already 'VERIFIED' ", async function () {
-      const taskData = {
-        title: "Test task",
-        type: "feature",
-        endsOn: 1234,
-        startedOn: 4567,
-        status: "VERIFIED",
-        percentCompleted: 10,
-        participants: [],
-        assignee: appOwner.username,
-        completionAward: { [DINERO]: 3, [NEELAM]: 300 },
-        lossRate: { [DINERO]: 1 },
-        isNoteworthy: true,
-      };
-      taskId = (await tasks.updateTask(taskData)).taskId;
+      taskId = (await tasks.updateTask({ ...taskData, assignee: appOwner.username })).taskId;
       const res = await chai
         .request(app)
         .patch(`/tasks/self/${taskId}`)
@@ -403,20 +403,7 @@ describe("Tasks", function () {
       expect(res.body.message).to.be.equal("Status cannot be updated. Please contact admin.");
     });
     it("Should give 403 if new status is 'MERGED' ", async function () {
-      const taskData = {
-        title: "Test task",
-        type: "feature",
-        endsOn: 1234,
-        startedOn: 4567,
-        status: "COMPLETED",
-        percentCompleted: 10,
-        participants: [],
-        assignee: appOwner.username,
-        completionAward: { [DINERO]: 3, [NEELAM]: 300 },
-        lossRate: { [DINERO]: 1 },
-        isNoteworthy: true,
-      };
-      taskId = (await tasks.updateTask(taskData)).taskId;
+      taskId = (await tasks.updateTask({ ...taskData, assignee: appOwner.username })).taskId;
       const res = await chai
         .request(app)
         .patch(`/tasks/self/${taskId}`)
@@ -427,20 +414,7 @@ describe("Tasks", function () {
     });
 
     it("Should give 403 if percentCompleted is not 100 and new status is COMPLETED ", async function () {
-      const taskData = {
-        title: "Test task",
-        type: "feature",
-        endsOn: 1234,
-        startedOn: 4567,
-        status: "REVIEW",
-        percentCompleted: 10,
-        participants: [],
-        assignee: appOwner.username,
-        completionAward: { [DINERO]: 3, [NEELAM]: 300 },
-        lossRate: { [DINERO]: 1 },
-        isNoteworthy: true,
-      };
-      taskId = (await tasks.updateTask(taskData)).taskId;
+      taskId = (await tasks.updateTask({ ...taskData, status: "REVIEW", assignee: appOwner.username })).taskId;
       const res = await chai
         .request(app)
         .patch(`/tasks/self/${taskId}`)

--- a/test/integration/tasks.test.js
+++ b/test/integration/tasks.test.js
@@ -345,8 +345,9 @@ describe("Tasks", function () {
 
           expect(res.body.taskLog.body.new.status).to.equal(taskStatusData.status);
           expect(res.body.taskLog.body.new.percentCompleted).to.equal(taskStatusData.percentCompleted);
-          expect(res.body.taskLog.body.messages.length).to.equal(Object.keys(taskStatusData).length);
-
+          expect(res.body.taskLog.body.message).that.contains(taskStatusData.percentCompleted);
+          expect(res.body.taskLog.body.message).that.contains(taskStatusData.status);
+          expect(res.body.taskLog.body.message).that.contains(`@${appOwner.username}`);
           return done();
         });
     });

--- a/test/integration/tasks.test.js
+++ b/test/integration/tasks.test.js
@@ -324,6 +324,8 @@ describe("Tasks", function () {
             return done(err);
           }
           expect(res).to.have.status(200);
+          expect(res.body.taskLog).to.have.property("type");
+          expect(res.body.taskLog.meta).to.be.a("object");
           expect(res.body.message).to.equal("Task updated successfully!");
           return done();
         });

--- a/test/integration/tasks.test.js
+++ b/test/integration/tasks.test.js
@@ -413,7 +413,7 @@ describe("Tasks", function () {
       expect(res.body.message).to.be.equal("Status cannot be updated. Please contact admin.");
     });
 
-    it("Should give 403 if percentCompleted is not 100 and new status is COMPLETED ", async function () {
+    it("Should give 400 if percentCompleted is not 100 and new status is COMPLETED ", async function () {
       taskId = (await tasks.updateTask({ ...taskData, status: "REVIEW", assignee: appOwner.username })).taskId;
       const res = await chai
         .request(app)
@@ -421,11 +421,11 @@ describe("Tasks", function () {
         .set("cookie", `${cookieName}=${jwt}`)
         .send({ ...taskStatusData, status: "COMPLETED" });
 
-      expect(res).to.have.status(403);
+      expect(res).to.have.status(400);
       expect(res.body.message).to.be.equal("Status cannot be updated. Task is not completed yet");
     });
 
-    it("Should give 403 if status is COMPLETED and newpercent is less than 100", async function () {
+    it("Should give 400 if status is COMPLETED and newpercent is less than 100", async function () {
       const taskData = {
         title: "Test task",
         type: "feature",
@@ -446,7 +446,7 @@ describe("Tasks", function () {
         .set("cookie", `${cookieName}=${jwt}`)
         .send({ percentCompleted: 80 });
 
-      expect(res).to.have.status(403);
+      expect(res).to.have.status(400);
       expect(res.body.message).to.be.equal("Task percentCompleted can't updated as status is COMPLETED");
     });
 

--- a/test/integration/tasks.test.js
+++ b/test/integration/tasks.test.js
@@ -326,6 +326,7 @@ describe("Tasks", function () {
           expect(res).to.have.status(200);
           expect(res.body.taskLog).to.have.property("type");
           expect(res.body.taskLog).to.have.property("id");
+          expect(res.body.taskLog.body).to.be.a("array");
           expect(res.body.taskLog.meta).to.be.a("object");
           expect(res.body.message).to.equal("Task updated successfully!");
           return done();

--- a/test/integration/tasks.test.js
+++ b/test/integration/tasks.test.js
@@ -330,8 +330,8 @@ describe("Tasks", function () {
           expect(res.body.taskLog.meta).to.be.a("object");
           expect(res.body.message).to.equal("Task updated successfully!");
 
-          expect(res.body.taskLog.body.newStatus).to.equal(taskStatusData.status);
-          expect(res.body.taskLog.body.newPercentCompleted).to.equal(taskStatusData.percentCompleted);
+          expect(res.body.taskLog.body.new.status).to.equal(taskStatusData.status);
+          expect(res.body.taskLog.body.new.percentCompleted).to.equal(taskStatusData.percentCompleted);
 
           return done();
         });

--- a/test/integration/tasks.test.js
+++ b/test/integration/tasks.test.js
@@ -402,6 +402,79 @@ describe("Tasks", function () {
       expect(res).to.have.status(403);
       expect(res.body.message).to.be.equal("Status cannot be updated. Please contact admin.");
     });
+    it("Should give 403 if new status is 'MERGED' ", async function () {
+      const taskData = {
+        title: "Test task",
+        type: "feature",
+        endsOn: 1234,
+        startedOn: 4567,
+        status: "COMPLETED",
+        percentCompleted: 10,
+        participants: [],
+        assignee: appOwner.username,
+        completionAward: { [DINERO]: 3, [NEELAM]: 300 },
+        lossRate: { [DINERO]: 1 },
+        isNoteworthy: true,
+      };
+      taskId = (await tasks.updateTask(taskData)).taskId;
+      const res = await chai
+        .request(app)
+        .patch(`/tasks/self/${taskId}`)
+        .set("cookie", `${cookieName}=${jwt}`)
+        .send({ ...taskStatusData, status: "MERGED" });
+
+      expect(res.body.message).to.be.equal("Status cannot be updated. Please contact admin.");
+    });
+
+    it("Should give 403 if percentCompleted is not 100 and new status is COMPLETED ", async function () {
+      const taskData = {
+        title: "Test task",
+        type: "feature",
+        endsOn: 1234,
+        startedOn: 4567,
+        status: "REVIEW",
+        percentCompleted: 10,
+        participants: [],
+        assignee: appOwner.username,
+        completionAward: { [DINERO]: 3, [NEELAM]: 300 },
+        lossRate: { [DINERO]: 1 },
+        isNoteworthy: true,
+      };
+      taskId = (await tasks.updateTask(taskData)).taskId;
+      const res = await chai
+        .request(app)
+        .patch(`/tasks/self/${taskId}`)
+        .set("cookie", `${cookieName}=${jwt}`)
+        .send({ ...taskStatusData, status: "COMPLETED" });
+
+      expect(res).to.have.status(403);
+      expect(res.body.message).to.be.equal("Status cannot be updated. Task is not completed yet");
+    });
+
+    it("Should give 403 if status is COMPLETED and newpercent is less than 100", async function () {
+      const taskData = {
+        title: "Test task",
+        type: "feature",
+        endsOn: 1234,
+        startedOn: 4567,
+        status: "COMPLETED",
+        percentCompleted: 100,
+        participants: [],
+        assignee: appOwner.username,
+        completionAward: { [DINERO]: 3, [NEELAM]: 300 },
+        lossRate: { [DINERO]: 1 },
+        isNoteworthy: true,
+      };
+      taskId = (await tasks.updateTask(taskData)).taskId;
+      const res = await chai
+        .request(app)
+        .patch(`/tasks/self/${taskId}`)
+        .set("cookie", `${cookieName}=${jwt}`)
+        .send({ percentCompleted: 80 });
+
+      expect(res).to.have.status(403);
+      expect(res.body.message).to.be.equal("Task percentCompleted can't updated as status is COMPLETED");
+    });
 
     it("should give a response message as 'Task updated but another task not found' if we have completed 100% task and a task is not available", async function () {
       const taskData = tasksData[3];


### PR DESCRIPTION
# Parent RFC - #460 

## How will this work?
- Will create a new log and save to the database about the event

## What has been done?
- called the `addlog` API to create a log for the event
- Response after a successful call
![image](https://user-images.githubusercontent.com/73058928/204578461-a6251cef-0e78-41ba-babf-e61e233caf18.png)


### task log structure RFC - #733 

## Edge Cases Covered
- If the user is trying to change the status to `MERGED`, it will be forbidden.
- If `status` is already `COMPLETED` and the user is trying to change only the `percentCompleted` to less than 100, it will give a bad request.
- If `status` is not `COMPLETED` and the user is trying to change the `percentCompleted` to 100, it will give a bad request.
