### PR TITLE
added priority to task schema

### DIFF
--- a/middlewares/validators/tasks.js
+++ b/middlewares/validators/tasks.js
@@ -21,6 +21,7 @@ const createTask = async (req, res, next) => {
         .valid(...TASK_STATUS_ENUM)
         .required(),
       assignee: joi.string().optional(),
+      priority: joi.string().required(),
       percentCompleted: joi.number().required(),
       dependsOn: joi.array().items(joi.string()).optional(),
       participants: joi.array().items(joi.string()).optional(),

--- a/test/integration/tasks.test.js
+++ b/test/integration/tasks.test.js
@@ -92,6 +92,7 @@ describe("Tasks", function () {
           startedOn: 456,
           status: "AVAILABLE",
           percentCompleted: 10,
+          priority: "HIGH",
           completionAward: { [DINERO]: 3, [NEELAM]: 300 },
           lossRate: { [DINERO]: 1 },
           assignee: appOwner.username,


### PR DESCRIPTION
Closes #739 
Priority was added to the task schema and made a required parameter, allowing the priority data to be supplied when a post request is made when submitting the data from the dashboard site.