### PR TITLE
Accepting redirectURL and mobile=true as query params

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -17,7 +17,7 @@ const githubAuth = (req, res, next) => {
   const state = req.query.state; // state is being set from passport
 
   let redirectURL = req.query.redirectURL;
-  let isMobile = req.query.mobile === "true";
+  let isMobile = req.query.mobile?.toLowerCase() === "true";
 
   if (state) {
     try {

--- a/test/integration/auth.test.js
+++ b/test/integration/auth.test.js
@@ -19,6 +19,8 @@ describe("auth", function () {
     sinon.restore();
   });
 
+  // TODO: write tests for mobile response
+
   it("should redirect the request to the goto page on successful login", function (done) {
     const rdsUiUrl = config.get("services.rdsUi.baseUrl");
 
@@ -30,7 +32,7 @@ describe("auth", function () {
     chai
       .request(app)
       .get("/auth/github/callback")
-      .query({ code: "codeReturnedByGithub", state: rdsUiUrl })
+      .query({ code: "codeReturnedByGithub", redirectURL: rdsUiUrl })
       .redirects(0)
       .end((err, res) => {
         if (err) {


### PR DESCRIPTION
`/auth/github/callback` route can now accept `redirectURL=url_to_redirect_to` and `mobile=true`

For redirecting to a particular page, `redirectURL=https://realdevsquad.com` query param can be passed
ex: `/auth/github/callback?redirectURL=https://realdevsquad.com`

And to let backend know weather the request is being made from mobile, `mobile=true` query param cab be passed
ex: `/auth/github/callback?mobile=true`