### PR TITLE
added an endpoint for task assignment

### DIFF
--- a/controllers/tasks.js
+++ b/controllers/tasks.js
@@ -205,7 +205,7 @@ const overdueTasks = async (req, res) => {
 
 const assignTask = async (req, res) => {
   // we will fetch the skilltag leveltag of that particular user here once we have the skill with his userId
-  // we can check here the all the level and which ever is smallest we can make the request with taht particular category for now value is hardcoded
+  // we can check here the all the level, and whichever is the smallest we can make the request with that particular category, for now value is hardcoded
   // I am putting the names of the skills but we are going to get id
   try {
     const { status, username } = req.userData;

--- a/controllers/tasks.js
+++ b/controllers/tasks.js
@@ -1,5 +1,6 @@
 const tasks = require("../models/tasks");
 const { TASK_STATUS, TASK_STATUS_OLD } = require("../constants/tasks");
+const { userStatusEnum } = require("../constants/users");
 const { OLD_ACTIVE, OLD_BLOCKED, OLD_PENDING } = TASK_STATUS_OLD;
 const { IN_PROGRESS, BLOCKED, SMOKE_TESTING, ASSIGNED } = TASK_STATUS;
 /**
@@ -210,7 +211,7 @@ const assignTask = async (req, res) => {
   try {
     const { status, username } = req.userData;
 
-    if (status !== "idle") {
+    if (status !== userStatusEnum[1]) {
       return res.json({ message: "Task cannot be assigned to users with active or OOO status" });
     }
 

--- a/controllers/tasks.js
+++ b/controllers/tasks.js
@@ -203,6 +203,27 @@ const overdueTasks = async (req, res) => {
   }
 };
 
+const assignTask = async (req, res) => {
+  // we will fetch the skilltag leveltag of that particular user here once we have the skill with his userId
+  // we can check here the all the level and which ever is smallest we can make the request with taht particular category for now value is hardcoded
+  // I am putting the names of the skills but we are going to get id
+  try {
+    const { status, username } = req.userData;
+
+    if (status !== "idle") {
+      return res.json({ message: "Task cannot be assigned to users with active or OOO status" });
+    }
+
+    const { task } = await tasks.fetchSkillLevelTask("FRONTEND", 1);
+    if (!task) return res.json({ message: "Task not found" });
+
+    await tasks.updateTask({ assignee: username, status: TASK_STATUS.ASSIGNED }, task.id);
+    return res.json({ message: "Task assigned" });
+  } catch {
+    return res.boom.badImplementation("Something went wrong!");
+  }
+};
+
 module.exports = {
   addNewTask,
   fetchTasks,
@@ -212,4 +233,5 @@ module.exports = {
   getTask,
   updateTaskStatus,
   overdueTasks,
+  assignTask,
 };

--- a/routes/tasks.js
+++ b/routes/tasks.js
@@ -16,5 +16,6 @@ router.patch("/:id", authenticate, authorizeRoles([APPOWNER, SUPERUSER]), update
 router.get("/:id/details", tasks.getTask);
 router.get("/:username", tasks.getUserTasks);
 router.patch("/self/:id", authenticate, updateSelfTask, tasks.updateTaskStatus, assignTask);
+router.patch("/assign/self", authenticate, tasks.assignTask);
 
 module.exports = router;

--- a/test/fixtures/user/user.js
+++ b/test/fixtures/user/user.js
@@ -68,6 +68,7 @@ module.exports = () => {
       github_display_name: "Sagar Bajpai",
       phone: "1234567890",
       email: "abc@gmail.com",
+      status: "active",
       tokens: {
         githubAccessToken: "githubAccessToken",
       },
@@ -87,6 +88,7 @@ module.exports = () => {
       github_display_name: "Ankush Dharkar",
       phone: "1234567890",
       email: "ad@amazon.com",
+      status: "idle",
       tokens: {
         githubAccessToken: "githubAccessToken",
       },

--- a/test/integration/tasks.test.js
+++ b/test/integration/tasks.test.js
@@ -30,7 +30,6 @@ describe("Tasks", function () {
     const superUserId = await addUser(superUser);
     jwt = authService.generateAuthToken({ userId });
     superUserJwt = authService.generateAuthToken({ userId: superUserId });
-
     const taskData = [
       {
         title: "Test task",
@@ -534,6 +533,32 @@ describe("Tasks", function () {
       expect(res).to.have.status(200);
       expect(res.body.newAvailableTasks).to.have.lengthOf(0);
       expect(res.body.message).to.be.equal("No overdue tasks found");
+    });
+  });
+
+  describe("PATCH /tasks/assign/self", function () {
+    it("should not assign a task to the user if they do not have status idle", async function () {
+      const taskData = tasksData[4];
+      await tasks.updateTask(taskData);
+
+      const res = await chai.request(app).patch(`/tasks/assign/self`).set("cookie", `${cookieName}=${jwt}`).send();
+
+      expect(res).to.have.status(200);
+      expect(res.body.message).to.be.equal("Task cannot be assigned to users with active or OOO status");
+    });
+
+    it("should assign task to the user if their status is idle and task is available", async function () {
+      const taskData = tasksData[4];
+      await tasks.updateTask(taskData);
+
+      const res = await chai
+        .request(app)
+        .patch(`/tasks/assign/self`)
+        .set("cookie", `${cookieName}=${superUserJwt}`)
+        .send();
+
+      expect(res).to.have.status(200);
+      expect(res.body.message).to.be.equal("Task assigned");
     });
   });
 });

--- a/test/integration/tasks.test.js
+++ b/test/integration/tasks.test.js
@@ -30,6 +30,7 @@ describe("Tasks", function () {
     const superUserId = await addUser(superUser);
     jwt = authService.generateAuthToken({ userId });
     superUserJwt = authService.generateAuthToken({ userId: superUserId });
+    
     const taskData = [
       {
         title: "Test task",

--- a/test/integration/tasks.test.js
+++ b/test/integration/tasks.test.js
@@ -30,7 +30,7 @@ describe("Tasks", function () {
     const superUserId = await addUser(superUser);
     jwt = authService.generateAuthToken({ userId });
     superUserJwt = authService.generateAuthToken({ userId: superUserId });
-    
+
     const taskData = [
       {
         title: "Test task",


### PR DESCRIPTION
closes #764

- added an endpoint that can be used to assign tasks to the user, the user can hit this endpoint and a task will get assigned to them if it is available
- We can remove the assignTask middleware when this PR gets merged