### PR TITLE
feat/paginating-logs-endpoint

### DIFF
--- a/models/logs.js
+++ b/models/logs.js
@@ -41,14 +41,14 @@ const fetchLogs = async (query, param) => {
     });
 
     const { limit, lastDocId } = query;
-    let lastDoc;
+    let lastDoc = "";
     const limitDocuments = Number(limit);
 
     if (lastDocId) {
       lastDoc = await logsModel.doc(lastDocId).get();
     }
 
-    const logsSnapshotQuery = call.orderBy("timestamp", "desc").startAfter(lastDoc ? lastDoc : "");
+    const logsSnapshotQuery = call.orderBy("timestamp", "desc").startAfter(lastDoc);
     const snapshot = limit ? await logsSnapshotQuery.limit(limitDocuments).get() : await logsSnapshotQuery.get();
 
     const logs = [];

--- a/models/logs.js
+++ b/models/logs.js
@@ -49,7 +49,9 @@ const fetchLogs = async (query, param) => {
     }
 
     const logsSnapshotQuery = call.orderBy("timestamp", "desc").startAfter(lastDoc ?? "");
-    const snapshot = limit ? await logsSnapshotQuery.limit(limitDocuments).get() : await logsSnapshotQuery.get();
+    const snapshot = limit
+      ? await logsSnapshotQuery.limit(limitDocuments).get()
+      : await logsSnapshotQuery.limit(10).get();
 
     const logs = [];
     snapshot.forEach((doc) => {

--- a/models/logs.js
+++ b/models/logs.js
@@ -35,10 +35,22 @@ const fetchLogs = async (query, param) => {
     let call = logsModel.where("type", "==", param);
     Object.keys(query).forEach((key) => {
       // eslint-disable-next-line security/detect-object-injection
-      call = call.where(key, "==", query[key]);
+      if (key !== "limit" && key !== "lastDocId") {
+        call = call.where(key, "==", query[key]);
+      }
     });
 
-    const snapshot = await call.get();
+    const { limit, lastDocId } = query;
+    let lastDoc;
+    const limitDocuments = Number(limit);
+
+    if (lastDocId) {
+      lastDoc = await logsModel.doc(lastDocId).get();
+    }
+
+    const logsSnapshotQuery = call.orderBy("timestamp", "desc").startAfter(lastDoc ? lastDoc : "");
+    const snapshot = limit ? await logsSnapshotQuery.limit(limitDocuments).get() : await logsSnapshotQuery.get();
+
     const logs = [];
     snapshot.forEach((doc) => {
       logs.push({

--- a/models/logs.js
+++ b/models/logs.js
@@ -41,14 +41,14 @@ const fetchLogs = async (query, param) => {
     });
 
     const { limit, lastDocId } = query;
-    let lastDoc = "";
+    let lastDoc;
     const limitDocuments = Number(limit);
 
     if (lastDocId) {
       lastDoc = await logsModel.doc(lastDocId).get();
     }
 
-    const logsSnapshotQuery = call.orderBy("timestamp", "desc").startAfter(lastDoc);
+    const logsSnapshotQuery = call.orderBy("timestamp", "desc").startAfter(lastDoc ?? "");
     const snapshot = limit ? await logsSnapshotQuery.limit(limitDocuments).get() : await logsSnapshotQuery.get();
 
     const logs = [];


### PR DESCRIPTION
Closes #826 
Paginating the logs endpoint to reduce the number of requests made to firestore. Practically, we don't need to see all the logs in one go, instead, we prefer to see the most recent and limited logs.
### **Features**
1. If we send `limit` as a query param, it will return the top 'n' documents.
2. If we send `lastDocId` as a query param, it will return all the documents after the document whose id will be equal to the `lastDocId`.
3. If we send both the `limit` and `lastDocId`, it will return 'n' limited documents after the specific document whose id will be equal to the `lastDocId`.
4. If we do not send any query params like `limit` or `lastDocId`, only top 10 logs will be returned.

Note: The data is sorted in descending order of **timestamp** so that we can get the most recent logs.