### PR TITLE
Add new route for login with github

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,6 +1,9 @@
 const express = require("express");
+const passport = require("passport");
 const router = express.Router();
 const auth = require("../controllers/auth");
+
+router.get("/github/login", passport.authenticate("github", { scope: ["user:email"] }));
 
 router.get("/github/callback", auth.githubAuth);
 


### PR DESCRIPTION
Resolves #839 

Added a new route `/auth/github/login` which will handle the login with GitHub

Now we don't need to set CLIENT_ID in hardcode the login URL `https://github.com/login/oauth/authorize?client_id=<CLIENT_ID>` we can just hit `/auth/github/login` and it will handle the login based on the clientId and secrets set in the config file of the user
