### PR TITLE
feat: users ep GET request, query-param size validation

### DIFF
--- a/middlewares/validators/user.js
+++ b/middlewares/validators/user.js
@@ -77,8 +77,51 @@ const validateJoinData = async (req, res, next) => {
     res.boom.badRequest(error.details[0].message);
   }
 };
+
+/**
+ * Validates getting users query
+ *
+ * @param req {Object} - Express request object
+ * @param res {Object} - Express response object
+ * @param next {Object} - Express middelware function
+ */
+async function getUsers(req, res, next) {
+  const schema = joi
+    .object()
+    .strict()
+    .keys({
+      size: joi
+        .string()
+        .required()
+        .pattern(/^[1-9]\d?$|^100$/)
+        .messages({
+          "string.base": "size should be a type of string",
+          "string.empty": "size must contain value in range 1-100",
+          "string.pattern.base": "size must be in range 1-100",
+          "any.required": "size is required",
+        }),
+      page: joi
+        .string()
+        .optional()
+        .pattern(/^\d$|^[1-9]\d?/)
+        .messages({
+          "string.base": "page should be a type of string",
+          "string.empty": "page must contain value in range 0-99",
+          "string.pattern.base": "page must be in range 0-99",
+        }),
+    });
+  try {
+    await schema.validateAsync(req.query);
+    next();
+  } catch (error) {
+    logger.error(`Error in getting users: ${error}`);
+    res.boom.badRequest(error.details[0].message);
+  }
+}
+
 module.exports = {
   updateUser,
   updateProfileURL,
   validateJoinData,
+  getUsers,
 };

--- a/middlewares/validators/user.js
+++ b/middlewares/validators/user.js
@@ -95,19 +95,16 @@ async function getUsers(req, res, next) {
         .optional()
         .pattern(/^[1-9]\d?$|^100$/)
         .messages({
-          "string.base": "size should be a type of string",
           "string.empty": "size must contain value in range 1-100",
           "string.pattern.base": "size must be in range 1-100",
-          "any.required": "size is required",
         }),
       page: joi
         .string()
         .optional()
-        .pattern(/^\d$|^[1-9]\d?/)
+        .pattern(/^0$|^[1-9]\d*$/)
         .messages({
-          "string.base": "page should be a type of string",
-          "string.empty": "page must contain value in range 0-99",
-          "string.pattern.base": "page must be in range 0-99",
+          "string.empty": "page must contain a positive number or zero",
+          "string.pattern.base": "page value either be a positive number or zero",
         }),
     });
   try {

--- a/middlewares/validators/user.js
+++ b/middlewares/validators/user.js
@@ -92,7 +92,7 @@ async function getUsers(req, res, next) {
     .keys({
       size: joi
         .string()
-        .required()
+        .optional()
         .pattern(/^[1-9]\d?$|^100$/)
         .messages({
           "string.base": "size should be a type of string",

--- a/models/users.js
+++ b/models/users.js
@@ -130,8 +130,8 @@ const fetchUsers = async (query) => {
       .endAt(query.search.toLowerCase().trim() + "\uf8ff");
   };
   try {
-    // INFO: default user size cannot be max-size i.e. 100
-    // INFO: https://github.com/Real-Dev-Squad/website-backend/pull/873#discussion_r1049782404
+    // INFO: default user size set to 100
+    // INFO: https://github.com/Real-Dev-Squad/website-backend/pull/873#discussion_r1064229932
     const size = parseInt(query.size) || 100;
     const page = size * (parseInt(query.page) || 0);
 

--- a/models/users.js
+++ b/models/users.js
@@ -132,7 +132,7 @@ const fetchUsers = async (query) => {
   try {
     // INFO: default user size cannot be max-size i.e. 100
     // INFO: https://github.com/Real-Dev-Squad/website-backend/pull/873#discussion_r1049782404
-    const size = parseInt(query.size) || 10;
+    const size = parseInt(query.size) || 100;
     const page = size * (parseInt(query.page) || 0);
 
     let dbQuery = userModel.limit(size).offset(page);

--- a/models/users.js
+++ b/models/users.js
@@ -124,10 +124,11 @@ const getSuggestedUsers = async (skill) => {
  */
 const fetchUsers = async (query) => {
   try {
-    const snapshot = await userModel
-      .limit(parseInt(query.size) || 100)
-      .offset((parseInt(query.size) || 100) * (parseInt(query.page) || 0))
-      .get();
+    // INFO: default user size cannot be max-size i.e. 100
+    // INFO: https://github.com/Real-Dev-Squad/website-backend/pull/873#discussion_r1049782404
+    const size = parseInt(query.size) || 10;
+    const page = size * (parseInt(query.page) || 0);
+    const snapshot = await userModel.limit(size).offset(page).get();
 
     const allUsers = [];
 

--- a/routes/users.js
+++ b/routes/users.js
@@ -10,7 +10,7 @@ const { upload } = require("../utils/multer");
 router.post("/verify", authenticate, users.verifyUser);
 router.get("/userId/:userId", users.getUserById);
 router.patch("/self", authenticate, userValidator.updateUser, users.updateSelf);
-router.get("/", authenticate, users.getUsers);
+router.get("/", authenticate, userValidator.getUsers, users.getUsers);
 router.get("/self", authenticate, users.getSelfDetails);
 router.get("/isUsernameAvailable/:username", authenticate, users.getUsernameAvailabilty);
 router.get("/chaincode", authenticate, users.generateChaincode);

--- a/test/integration/users.test.js
+++ b/test/integration/users.test.js
@@ -123,6 +123,76 @@ describe("Users", function () {
           return done();
         });
     });
+
+    it("Should get all the users in system when query params are valid", function (done) {
+      chai
+        .request(app)
+        .get("/users")
+        .set("cookie", `${cookieName}=${jwt}`)
+        .query({
+          size: 1,
+          page: 0,
+        })
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          expect(res).to.have.status(200);
+          expect(res.body).to.be.a("object");
+          expect(res.body.message).to.equal("Users returned successfully!");
+          expect(res.body.users).to.be.a("array");
+          expect(res.body.users[0]).to.not.have.property("phone");
+          expect(res.body.users[0]).to.not.have.property("email");
+
+          return done();
+        });
+    });
+
+    it("Should return 400 bad request when query params are invalid", function (done) {
+      chai
+        .request(app)
+        .get("/users")
+        .set("cookie", `${cookieName}=${jwt}`)
+        .query({
+          size: -1,
+          page: -1,
+        })
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          expect(res).to.have.status(400);
+          expect(res.body).to.be.a("object");
+          expect(res.body.message).to.equal("size must be in range 1-100");
+          expect(res.body.error).to.equal("Bad Request");
+
+          return done();
+        });
+    });
+
+    it("Should return 400 bad request when query param size is invalid", function (done) {
+      chai
+        .request(app)
+        .get("/users")
+        .set("cookie", `${cookieName}=${jwt}`)
+        .query({
+          size: 101,
+        })
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          expect(res).to.have.status(400);
+          expect(res.body).to.be.a("object");
+          expect(res.body.message).to.equal("size must be in range 1-100");
+          expect(res.body.error).to.equal("Bad Request");
+
+          return done();
+        });
+    });
   });
 
   describe("GET /users/self", function () {

--- a/test/integration/users.test.js
+++ b/test/integration/users.test.js
@@ -142,6 +142,7 @@ describe("Users", function () {
           expect(res.body).to.be.a("object");
           expect(res.body.message).to.equal("Users returned successfully!");
           expect(res.body.users).to.be.a("array");
+          expect(res.body.users.length).to.equal(1);
           expect(res.body.users[0]).to.not.have.property("phone");
           expect(res.body.users[0]).to.not.have.property("email");
 


### PR DESCRIPTION
## What is the change

- Min(1) and Max(100) limit on number of users requested using query-param size 
- Validation on query params _size_ and _page_ using middelware **joi**

```javascript
size: /^[1-9]\d?$|^100$/
page: /^\d$|^[1-9]\d?/
``` 

## Before the change

- No limit on number of users requested using query-param size 
- No validation on query params _size_ and _page_

### Issue
[Issue: 842](https://github.com/Real-Dev-Squad/website-backend/issues/842)

### Endpoint

```javascript
GET /users?size=<value>&page=<value>
```
<small>params: \*size, page\? </small>

#### Dev Tested

- [ ] Yes
- [x] No

#### Platforms

- [X] Postman

#### Info
- Failing Tests have nothing to do with this PR.
- [API Contract](https://github.com/Real-Dev-Squad/website-api-contracts/pull/102)