### PR TITLE
Future Status Update

### DIFF
--- a/controllers/userStatus.js
+++ b/controllers/userStatus.js
@@ -120,4 +120,22 @@ const updateUserStatus = async (req, res) => {
   }
 };
 
-module.exports = { deleteUserStatus, getUserStatus, getAllUserStatus, updateUserStatus };
+/**
+ * Update All Users Status
+ *
+ * @param req {Object} - Express request object
+ * @param res {Object} - Express response object
+ */
+const updateAllUserStatus = async (req, res) => {
+  try {
+    await userStatusModel.updateAllUserStatus();
+    return res.status(200).json({
+      message: "All User Status updated successfully.",
+    });
+  } catch (err) {
+    logger.error(`Error while updating the User Data: ${err}`);
+    return res.boom.badImplementation("An internal server error occurred");
+  }
+};
+
+module.exports = { deleteUserStatus, getUserStatus, getAllUserStatus, updateUserStatus, updateAllUserStatus };

--- a/middlewares/validators/userStatus.js
+++ b/middlewares/validators/userStatus.js
@@ -1,18 +1,16 @@
 const Joi = require("joi");
 const { userState } = require("../../constants/userStatus");
-const { getTodayTimeStamp } = require("../../utils/userStatus");
 const threeDaysInMilliseconds = 172800000;
 
 const validateUpdatedUserStatus = async (req, res, next) => {
-  const todayTimeStamp = getTodayTimeStamp();
   const schema = Joi.object({
     currentStatus: Joi.object().keys({
       state: Joi.string().trim().valid(userState.IDLE, userState.ACTIVE, userState.OOO),
       updatedAt: Joi.number().required(),
-      from: Joi.number().min(todayTimeStamp).required(),
+      from: Joi.number().required(),
       until: Joi.any().when("state", {
         is: userState.OOO,
-        then: Joi.number().min(todayTimeStamp).required(),
+        then: Joi.number().required(),
         otherwise: Joi.optional(),
       }),
       message: Joi.when("state", {

--- a/middlewares/validators/userStatus.js
+++ b/middlewares/validators/userStatus.js
@@ -1,16 +1,18 @@
 const Joi = require("joi");
 const { userState } = require("../../constants/userStatus");
+const { getTodayTimeStamp } = require("../../utils/userStatus");
 const threeDaysInMilliseconds = 172800000;
 
 const validateUpdatedUserStatus = async (req, res, next) => {
+  const todayTimeStamp = getTodayTimeStamp();
   const schema = Joi.object({
     currentStatus: Joi.object().keys({
       state: Joi.string().trim().valid(userState.IDLE, userState.ACTIVE, userState.OOO),
-      updatedAt: Joi.number().required().strict(),
-      from: Joi.number().required().strict(),
+      updatedAt: Joi.number().required(),
+      from: Joi.number().min(todayTimeStamp).required(),
       until: Joi.any().when("state", {
         is: userState.OOO,
-        then: Joi.number().required().strict(),
+        then: Joi.number().min(todayTimeStamp).required(),
         otherwise: Joi.optional(),
       }),
       message: Joi.when("state", {
@@ -32,8 +34,8 @@ const validateUpdatedUserStatus = async (req, res, next) => {
       }),
     }),
     monthlyHours: Joi.object().keys({
-      committed: Joi.number().required().strict(),
-      updatedAt: Joi.number().required().strict(),
+      committed: Joi.number().required(),
+      updatedAt: Joi.number().required(),
     }),
   }).or("currentStatus", "monthlyHours");
 

--- a/models/userStatus.js
+++ b/models/userStatus.js
@@ -1,5 +1,6 @@
 const { userState } = require("../constants/userStatus");
 const firestore = require("../utils/firestore");
+const { getTommorowTimeStamp } = require("../utils/userStatus");
 const userStatusModel = firestore.collection("usersStatus");
 
 /**
@@ -88,10 +89,21 @@ const updateUserStatus = async (userId, updatedData) => {
     const [userStatusDoc] = userStatusDocs.docs;
     if (userStatusDoc) {
       const docId = userStatusDoc.id;
+      const userData = userStatusDoc.data();
       if (Object.keys(updatedData).includes("currentStatus")) {
         const updatedUserState = updatedData.currentStatus.state;
         const isUserOOO = updatedUserState === userState.OOO;
         const isUserActive = updatedUserState === userState.ACTIVE;
+        const isUserIdle = updatedUserState === userState.IDLE;
+        const isUserCurrentlyOOO = userData.currentStatus?.state === userState.OOO;
+
+        const doesUserHasFutureActiveOrIdleStatus =
+          userData.futureStatus?.state === userState.ACTIVE || userData.futureStatus?.state === userState.IDLE;
+        if (isUserCurrentlyOOO && doesUserHasFutureActiveOrIdleStatus) {
+          if (isUserActive || isUserIdle) {
+            updatedData.futureStatus = {};
+          }
+        }
 
         if (!isUserOOO) {
           updatedData.currentStatus.until = "";
@@ -99,11 +111,40 @@ const updateUserStatus = async (userId, updatedData) => {
         if (isUserActive) {
           updatedData.currentStatus.message = "";
         }
+        if (isUserOOO) {
+          const tommorow = getTommorowTimeStamp();
+          if (updatedData.currentStatus.from >= tommorow) {
+            const futureStatus = { ...updatedData.currentStatus };
+            delete updatedData.currentStatus;
+            updatedData.futureStatus = futureStatus;
+          } else {
+            updatedData.futureStatus = {};
+          }
+        }
       }
       await userStatusModel.doc(docId).update(updatedData);
       return { id: docId, userStatusExists: true, data: updatedData };
     } else {
       // the user doc doesnt exist meaning we need to create one
+      if (Object.keys(updatedData).includes("currentStatus")) {
+        const updatedUserState = updatedData.currentStatus.state;
+        const isUserOOO = updatedUserState === userState.OOO;
+        const isUserActive = updatedUserState === userState.ACTIVE;
+        if (!isUserOOO) {
+          updatedData.currentStatus.until = "";
+        }
+        if (isUserActive) {
+          updatedData.currentStatus.message = "";
+        }
+        if (isUserOOO) {
+          const tommorow = getTommorowTimeStamp();
+          if (updatedData.currentStatus.from >= tommorow) {
+            const futureStatus = { ...updatedData.currentStatus };
+            delete updatedData.currentStatus;
+            updatedData.futureStatus = futureStatus;
+          }
+        }
+      }
       const { id } = await userStatusModel.add({ userId, ...updatedData });
       return { id, userStatusExists: false, data: updatedData };
     }
@@ -113,4 +154,56 @@ const updateUserStatus = async (userId, updatedData) => {
   }
 };
 
-module.exports = { deleteUserStatus, getUserStatus, getAllUserStatus, updateUserStatus };
+/**
+ * @param userId { String }: Id of the User
+ * @param updatedData { Object }: Data to be Updated
+ * @returns Promise<userStatusModel|Object>
+ */
+
+const updateAllUserStatus = async () => {
+  try {
+    const userStatusDocs = await userStatusModel.where("futureStatus.state", "in", ["ACTIVE", "IDLE", "OOO"]).get();
+    const batch = firestore.batch();
+    const today = new Date().getTime();
+    userStatusDocs.forEach(async (document) => {
+      const doc = document.data();
+      const docRef = document.ref;
+      const updatedData = { ...doc };
+      let toUpdate = false;
+      const { futureStatus, currentStatus } = doc;
+      const { state: futureState } = futureStatus;
+      if (futureState === "ACTIVE" || futureState === "IDLE") {
+        if (today >= futureStatus.from) {
+          updatedData.currentStatus = { ...futureStatus, until: "", updatedAt: today };
+          updatedData.futureStatus = {};
+          toUpdate = !toUpdate;
+        }
+      } else {
+        if (today > futureStatus.until) {
+          updatedData.futureStatus = {};
+          toUpdate = !toUpdate;
+        } else if (today <= doc.futureStatus.until && today >= doc.futureStatus.from) {
+          let newCurrentStatus = {};
+          let newFutureStatus = {};
+          newCurrentStatus = { ...futureStatus, updatedAt: today };
+          if (currentStatus?.state) {
+            newFutureStatus = { ...currentStatus, from: futureStatus.until, updatedAt: today };
+          }
+          updatedData.currentStatus = newCurrentStatus;
+          updatedData.futureStatus = newFutureStatus;
+          toUpdate = !toUpdate;
+        }
+      }
+      if (toUpdate) {
+        batch.set(docRef, updatedData);
+      }
+    });
+    await batch.commit();
+    return { status: "All User Documents updated Successfully." };
+  } catch (error) {
+    logger.error(`error in updating User Status Documents ${error}`);
+    throw error;
+  }
+};
+
+module.exports = { deleteUserStatus, getUserStatus, getAllUserStatus, updateUserStatus, updateAllUserStatus };

--- a/routes/userStatus.js
+++ b/routes/userStatus.js
@@ -1,5 +1,11 @@
 const express = require("express");
-const { deleteUserStatus, getUserStatus, getAllUserStatus, updateUserStatus } = require("../controllers/userStatus");
+const {
+  deleteUserStatus,
+  getUserStatus,
+  getAllUserStatus,
+  updateUserStatus,
+  updateAllUserStatus,
+} = require("../controllers/userStatus");
 const router = express.Router();
 const authenticate = require("../middlewares/authenticate");
 const authorizeRoles = require("../middlewares/authorizeRoles");
@@ -10,6 +16,7 @@ router.get("/", getAllUserStatus);
 router.get("/self", authenticate, getUserStatus);
 router.get("/:userId", getUserStatus);
 router.patch("/self", authenticate, validateUpdatedUserStatus, updateUserStatus);
+router.patch("/update", authenticate, authorizeRoles([SUPERUSER]), updateAllUserStatus);
 router.patch("/:userId", authenticate, authorizeRoles([SUPERUSER]), validateUpdatedUserStatus, updateUserStatus);
 router.delete("/:userId", authenticate, authorizeRoles([SUPERUSER]), deleteUserStatus);
 

--- a/test/fixtures/userStatus/userStatus.js
+++ b/test/fixtures/userStatus/userStatus.js
@@ -1,4 +1,4 @@
-const userStsDataForNewUser = {
+const userStatusDataForNewUser = {
   currentStatus: {
     until: 1669256009000,
     message: "Bad Health",
@@ -12,7 +12,7 @@ const userStsDataForNewUser = {
   },
 };
 
-const oooStsDataForShortDuration = {
+const oooStatusDataForShortDuration = {
   currentStatus: {
     message: "",
     state: "OOO",
@@ -25,7 +25,7 @@ const oooStsDataForShortDuration = {
     committed: 40,
   },
 };
-const userStsDataForOooState = {
+const userStatusDataForOooState = {
   currentStatus: {
     until: 1669256009000,
     message: "Bad Health",
@@ -52,8 +52,8 @@ const generateUserStatusData = (state, updatedAt, from, until = "", message = ""
 };
 
 module.exports = {
-  userStsDataForNewUser,
-  userStsDataForOooState,
-  oooStsDataForShortDuration,
+  userStatusDataForNewUser,
+  userStatusDataForOooState,
+  oooStatusDataForShortDuration,
   generateUserStatusData,
 };

--- a/test/fixtures/userStatus/userStatus.js
+++ b/test/fixtures/userStatus/userStatus.js
@@ -59,10 +59,63 @@ const invalidUserStsDataforUpdate = {
   },
 };
 
+const initialDataForFutureStatus = {
+  currentStatus: {
+    state: "ACTIVE",
+    message: "",
+    updatedAt: 1668215609000,
+    from: 1668215609000,
+    until: "",
+  },
+};
+const finalDataForFutureStatus = {
+  currentStatus: {
+    state: "OOO",
+    message: "Vacation Trip",
+    updatedAt: 1668215609000,
+    from: 1669228200000,
+    until: 1669573800000,
+  },
+};
+const updatedOooDataForFutureStatus = {
+  currentStatus: {
+    state: "OOO",
+    message: "New plan for vacation Trip",
+    updatedAt: 1668215609000,
+    from: 1669833000000,
+    until: 1670178600000,
+  },
+};
+
+const oooStatusDataFromToday = {
+  currentStatus: {
+    state: "OOO",
+    message: "New plan for vacation Trip",
+    updatedAt: 1668191400000,
+    from: 1668191400000,
+    until: 1668623400000,
+  },
+};
+
+const activeStatusDataFromToday = {
+  currentStatus: {
+    state: "ACTIVE",
+    message: "",
+    updatedAt: 1669401000000,
+    from: 1669401000000,
+    until: "",
+  },
+};
+
 module.exports = {
   userStsDataForNewUser,
   userStsDataForOooState,
   oooUserStsDataForShortDuration,
   validUserStsDataforUpdate,
   invalidUserStsDataforUpdate,
+  initialDataForFutureStatus,
+  finalDataForFutureStatus,
+  updatedOooDataForFutureStatus,
+  oooStatusDataFromToday,
+  activeStatusDataFromToday,
 };

--- a/test/fixtures/userStatus/userStatus.js
+++ b/test/fixtures/userStatus/userStatus.js
@@ -12,7 +12,7 @@ const userStsDataForNewUser = {
   },
 };
 
-const oooUserStsDataForShortDuration = {
+const oooStsDataForShortDuration = {
   currentStatus: {
     message: "",
     state: "OOO",
@@ -54,6 +54,6 @@ const generateUserStatusData = (state, updatedAt, from, until = "", message = ""
 module.exports = {
   userStsDataForNewUser,
   userStsDataForOooState,
-  userStsDataForOooStateForShortDuration,
+  oooStsDataForShortDuration,
   generateUserStatusData,
 };

--- a/test/fixtures/userStatus/userStatus.js
+++ b/test/fixtures/userStatus/userStatus.js
@@ -39,83 +39,21 @@ const userStsDataForOooState = {
   },
 };
 
-const validUserStsDataforUpdate = {
-  currentStatus: {
-    until: "",
-    message: "",
-    state: "ACTIVE",
-    updatedAt: 1668215609000,
-    from: 1668215609000,
-  },
-};
-
-const invalidUserStsDataforUpdate = {
-  currentStatus: {
-    until: "",
-    message: "",
-    state: "IN_OFFICE",
-    updatedAt: 1668215609000,
-    from: 1668215609000,
-  },
-};
-
-const initialDataForFutureStatus = {
-  currentStatus: {
-    state: "ACTIVE",
-    message: "",
-    updatedAt: 1668215609000,
-    from: 1668215609000,
-    until: "",
-  },
-};
-const finalDataForFutureStatus = {
-  currentStatus: {
-    state: "OOO",
-    message: "Vacation Trip",
-    updatedAt: 1668215609000,
-    from: 1669228200000,
-    until: 1669573800000,
-  },
-};
-const updatedOooDataForFutureStatus = {
-  currentStatus: {
-    state: "OOO",
-    message: "New plan for vacation Trip",
-    updatedAt: 1668215609000,
-    from: 1669833000000,
-    until: 1670178600000,
-  },
-};
-
-const oooStatusDataFromToday = {
-  currentStatus: {
-    state: "OOO",
-    message: "New plan for vacation Trip",
-    updatedAt: 1668191400000,
-    from: 1668191400000,
-    until: 1668623400000,
-  },
-};
-
-const activeStatusDataFromToday = {
-  currentStatus: {
-    state: "ACTIVE",
-    message: "",
-    updatedAt: 1669401000000,
-    from: 1669401000000,
-    until: "",
-  },
+const generateUserStatusData = (state, updatedAt, from, until = "", message = "") => {
+  return {
+    currentStatus: {
+      state,
+      message,
+      from,
+      until,
+      updatedAt,
+    },
+  };
 };
 
 module.exports = {
   userStsDataForNewUser,
   userStsDataForOooState,
-  oooUserStsDataForShortDuration,
-  validUserStsDataforUpdate,
-  invalidUserStsDataforUpdate,
-  initialDataForFutureStatus,
-  finalDataForFutureStatus,
-  updatedOooDataForFutureStatus,
-  oooStatusDataFromToday,
-  activeStatusDataFromToday,
+  userStsDataForOooStateForShortDuration,
+  generateUserStatusData,
 };

--- a/test/integration/userStatus.test.js
+++ b/test/integration/userStatus.test.js
@@ -1,6 +1,7 @@
 const chai = require("chai");
 const { expect } = chai;
 const chaiHttp = require("chai-http");
+const sinon = require("sinon");
 
 const app = require("../../server");
 const authService = require("../../services/authService");
@@ -65,7 +66,7 @@ describe("UserStatus", function () {
     });
   });
 
-  describe("GET /user-status/:userid", function () {
+  describe("GET /users/status/:userid", function () {
     it("Should return the User Status Document with the given id", function (done) {
       chai
         .request(app)
@@ -103,13 +104,157 @@ describe("UserStatus", function () {
     });
   });
 
+  describe("PATCH /users/status/update", function () {
+    let testUserId;
+    let testUserJwt;
+    let clock;
+    beforeEach(async function () {
+      clock = sinon.useFakeTimers({
+        now: new Date(2022, 10, 12).getTime(),
+        toFake: ["Date"],
+      });
+      testUserId = await addUser(userData[1]);
+      testUserJwt = authService.generateAuthToken({ userId: testUserId });
+    });
+
+    afterEach(function () {
+      clock.restore();
+    });
+
+    it("Should update the User Status based on the future dates", async function () {
+      // creating Active Status from 12th Nov 2022
+      const response1 = await chai
+        .request(app)
+        .patch(`/users/status/self`)
+        .set("Cookie", `${cookieName}=${testUserJwt}`)
+        .send(initialDataForFutureStatus);
+      expect(response1).to.have.status(201);
+      expect(response1.body.data.currentStatus.state).to.equal("ACTIVE");
+
+      // Marking OOO Status from 24th Nov 2022 to 28th Nov 2022
+      const response2 = await chai
+        .request(app)
+        .patch(`/users/status/self`)
+        .set("Cookie", `${cookieName}=${testUserJwt}`)
+        .send(finalDataForFutureStatus);
+      expect(response2).to.have.status(200);
+      expect(response2.body.message).to.equal("User Status updated successfully.");
+      expect(response2.body.data).to.have.own.property("futureStatus");
+      expect(response2.body.data.futureStatus.state).to.equal("OOO");
+
+      // Mocking date to be 26th Nov 2022
+      clock.setSystemTime(new Date(2022, 10, 26).getTime());
+
+      // Calling the users/status/update API to update the status
+      const response3 = await chai
+        .request(app)
+        .patch(`/users/status/update`)
+        .set("Cookie", `${cookieName}=${superUserAuthToken}`)
+        .send();
+      expect(response3).to.have.status(200);
+      expect(response3.body.message).to.equal("All User Status updated successfully.");
+
+      // Checking the current status
+      const response4 = await chai.request(app).get(`/users/status/self`).set("Cookie", `${cookieName}=${testUserJwt}`);
+      expect(response4).to.have.status(200);
+      expect(response4.body).to.be.a("object");
+      expect(response4.body.message).to.equal("User Status found successfully.");
+      expect(response4.body.data).to.have.property("currentStatus");
+      expect(response4.body.data.currentStatus.state).to.equal("OOO");
+      expect(response4.body.data).to.have.property("futureStatus");
+      expect(response4.body.data.futureStatus.state).to.equal("ACTIVE");
+
+      clock.setSystemTime(new Date(2022, 10, 30).getTime());
+
+      const response5 = await chai
+        .request(app)
+        .patch(`/users/status/update`)
+        .set("Cookie", `${cookieName}=${superUserAuthToken}`)
+        .send();
+      expect(response5).to.have.status(200);
+      expect(response5.body.message).to.equal("All User Status updated successfully.");
+
+      const response6 = await chai.request(app).get(`/users/status/self`).set("Cookie", `${cookieName}=${testUserJwt}`);
+      expect(response6).to.have.status(200);
+      expect(response6.body).to.be.a("object");
+      expect(response6.body.message).to.equal("User Status found successfully.");
+      expect(response6.body.data).to.have.property("currentStatus");
+      expect(response6.body.data.currentStatus.state).to.equal("ACTIVE");
+    });
+
+    it("Should clear the future active/idle Status if during ooo period user mark themselves idle/active", async function () {
+      // creating Active Status from 12th Nov 2022
+      const response1 = await chai
+        .request(app)
+        .patch(`/users/status/self`)
+        .set("Cookie", `${cookieName}=${testUserJwt}`)
+        .send(initialDataForFutureStatus);
+      expect(response1).to.have.status(201);
+      expect(response1.body.data.currentStatus.state).to.equal("ACTIVE");
+
+      // Marking OOO Status from 24th Nov 2022 to 28th Nov 2022
+      const response2 = await chai
+        .request(app)
+        .patch(`/users/status/self`)
+        .set("Cookie", `${cookieName}=${testUserJwt}`)
+        .send(finalDataForFutureStatus);
+      expect(response2).to.have.status(200);
+      expect(response2.body.message).to.equal("User Status updated successfully.");
+      expect(response2.body.data).to.have.own.property("futureStatus");
+      expect(response2.body.data.futureStatus.state).to.equal("OOO");
+
+      // Mocking date to be 26th Nov 2022
+      clock.setSystemTime(new Date(2022, 10, 26).getTime());
+
+      // Calling the users/status/update API to update the status
+      const response3 = await chai
+        .request(app)
+        .patch(`/users/status/update`)
+        .set("Cookie", `${cookieName}=${superUserAuthToken}`)
+        .send();
+      expect(response3).to.have.status(200);
+      expect(response3.body.message).to.equal("All User Status updated successfully.");
+
+      // Checking the current status
+      const response4 = await chai.request(app).get(`/users/status/self`).set("Cookie", `${cookieName}=${testUserJwt}`);
+      expect(response4).to.have.status(200);
+      expect(response4.body).to.be.a("object");
+      expect(response4.body.message).to.equal("User Status found successfully.");
+      expect(response4.body.data).to.have.property("currentStatus");
+      expect(response4.body.data.currentStatus.state).to.equal("OOO");
+      expect(response4.body.data).to.have.property("futureStatus");
+      expect(response4.body.data.futureStatus.state).to.equal("ACTIVE");
+
+      // Marking Active From today
+      const response5 = await chai
+        .request(app)
+        .patch(`/users/status/self`)
+        .set("Cookie", `${cookieName}=${testUserJwt}`)
+        .send(activeStatusDataFromToday);
+      expect(response5).to.have.status(200);
+      expect(response5.body.message).to.equal("User Status updated successfully.");
+      expect(response5.body.data).to.have.own.property("currentStatus");
+      expect(response5.body.data.currentStatus.state).to.equal("ACTIVE");
+      expect(response5.body.data.futureStatus.state).to.equal(undefined);
+    });
+  });
+
   describe("PATCH /users/status/:userid", function () {
     let testUserId;
     let testUserJwt;
+    let clock;
 
     beforeEach(async function () {
+      clock = sinon.useFakeTimers({
+        now: new Date(2022, 10, 12).getTime(),
+        toFake: ["Date"],
+      });
       testUserId = await addUser(userData[1]);
       testUserJwt = authService.generateAuthToken({ userId: testUserId });
+    });
+
+    afterEach(function () {
+      clock.restore();
     });
 
     it("Should store the User Status in the collection", function (done) {
@@ -232,6 +377,84 @@ describe("UserStatus", function () {
           });
           return done();
         });
+    });
+
+    it("should replace old future OOO Status with new future OOO Status", async function () {
+      // creating Active Status from 12th Nov 2022
+      const response1 = await chai
+        .request(app)
+        .patch(`/users/status/self`)
+        .set("Cookie", `${cookieName}=${testUserJwt}`)
+        .send(initialDataForFutureStatus);
+      expect(response1).to.have.status(201);
+      expect(response1.body.data.currentStatus.state).to.equal("ACTIVE");
+
+      // Initially Marking OOO Status from 24th Nov 2022 to 28th Nov 2022
+      const response2 = await chai
+        .request(app)
+        .patch(`/users/status/self`)
+        .set("Cookie", `${cookieName}=${testUserJwt}`)
+        .send(finalDataForFutureStatus);
+      expect(response2).to.have.status(200);
+      expect(response2.body.message).to.equal("User Status updated successfully.");
+      expect(response2.body.data).to.have.own.property("futureStatus");
+      expect(response2.body.data.futureStatus.state).to.equal("OOO");
+      expect(response2.body.data.futureStatus.from).to.equal(1669228200000); // 24th Nov 2022
+      expect(response2.body.data.futureStatus.until).to.equal(1669573800000); // 28th Nov 2022
+
+      // Changing OOO status again from 1st Dec 2022 to 5th Dec 2022
+      const response3 = await chai
+        .request(app)
+        .patch(`/users/status/self`)
+        .set("Cookie", `${cookieName}=${testUserJwt}`)
+        .send(updatedOooDataForFutureStatus);
+      expect(response3).to.have.status(200);
+      expect(response3.body.message).to.equal("User Status updated successfully.");
+      expect(response3.body.data).to.have.own.property("futureStatus");
+      expect(response3.body.data.futureStatus.state).to.equal("OOO");
+      expect(response3.body.data.futureStatus.from).to.equal(1669833000000); // 1st Dec 2022
+      expect(response3.body.data.futureStatus.until).to.equal(1670178600000); // 5th Dec 2022
+
+      // Checking the current status
+      const response4 = await chai.request(app).get(`/users/status/self`).set("Cookie", `${cookieName}=${testUserJwt}`);
+      expect(response4).to.have.status(200);
+      expect(response4.body).to.be.a("object");
+      expect(response4.body.message).to.equal("User Status found successfully.");
+      expect(response4.body.data).to.have.property("currentStatus");
+      expect(response4.body.data.currentStatus.state).to.equal("ACTIVE");
+      expect(response4.body.data).to.have.property("futureStatus");
+      expect(response4.body.data.futureStatus.state).to.equal("OOO");
+      expect(response3.body.data.futureStatus.from).to.equal(1669833000000); // 1st Dec 2022
+      expect(response3.body.data.futureStatus.until).to.equal(1670178600000); // 5th Dec 2022
+    });
+
+    it("should clear future OOO Status if current Status is marked as OOO", async function () {
+      // Initially Marking OOO Status from 24th Nov 2022 to 28th Nov 2022. And today is 12th Nov 2022
+      const response1 = await chai
+        .request(app)
+        .patch(`/users/status/self`)
+        .set("Cookie", `${cookieName}=${testUserJwt}`)
+        .send(finalDataForFutureStatus);
+      expect(response1).to.have.status(201);
+      expect(response1.body.message).to.equal("User Status created successfully.");
+      expect(response1.body.data).to.have.own.property("futureStatus");
+      expect(response1.body.data.futureStatus.state).to.equal("OOO");
+      expect(response1.body.data.futureStatus.from).to.equal(1669228200000); // 24th Nov 2022
+      expect(response1.body.data.futureStatus.until).to.equal(1669573800000); // 28th Nov 2022
+
+      // Changing OOO status from today
+      const response2 = await chai
+        .request(app)
+        .patch(`/users/status/self`)
+        .set("Cookie", `${cookieName}=${testUserJwt}`)
+        .send(oooStatusDataFromToday);
+      expect(response2).to.have.status(200);
+      expect(response2.body.message).to.equal("User Status updated successfully.");
+      expect(response2.body.data).to.have.own.property("currentStatus");
+      expect(response2.body.data.currentStatus.state).to.equal("OOO");
+      expect(response2.body.data.currentStatus.from).to.equal(1668191400000); // 12 Nov 2022
+      expect(response2.body.data.currentStatus.until).to.equal(1668623400000); // 17 Nov 2022
+      expect(response2.body.data.futureStatus.state).to.equal(undefined);
     });
   });
 

--- a/test/integration/userStatus.test.js
+++ b/test/integration/userStatus.test.js
@@ -378,6 +378,24 @@ describe("UserStatus", function () {
         });
     });
 
+    it("Should return error when trying to change OOO without reason for more than 3 days period", function (done) {
+      // marking OOO from 18 Nov 2022 (1668709800000) to 23 Nov 2022 (1669141800000)
+      chai
+        .request(app)
+        .patch(`/users/status/self`)
+        .set("cookie", `${cookieName}=${testUserJwt}`)
+        .send(generateUserStatusData("OOO", 1668191400000, 1668709800000, 1669141800000, ""))
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+          expect(res).to.have.status(400);
+          expect(res.body.error).to.equal(`Bad Request`);
+          expect(res.body.message).to.equal(`"currentStatus.message" is not allowed to be empty`);
+          return done();
+        });
+    });
+
     it("should replace old future OOO Status with new future OOO Status", async function () {
       // creating Active Status from 12th Nov 2022
       const response1 = await chai

--- a/test/integration/userStatus.test.js
+++ b/test/integration/userStatus.test.js
@@ -13,9 +13,8 @@ const superUser = userData[4];
 const {
   userStsDataForNewUser,
   userStsDataForOooState,
-  validUserStsDataforUpdate,
-  invalidUserStsDataforUpdate,
   oooUserStsDataForShortDuration,
+  generateUserStatusData,
 } = require("../fixtures/userStatus/userStatus");
 
 const config = require("config");
@@ -122,12 +121,12 @@ describe("UserStatus", function () {
     });
 
     it("Should update the User Status based on the future dates", async function () {
-      // creating Active Status from 12th Nov 2022
+      // creating Active Status from 12th Nov 2022 (1669401000000)
       const response1 = await chai
         .request(app)
         .patch(`/users/status/self`)
         .set("Cookie", `${cookieName}=${testUserJwt}`)
-        .send(initialDataForFutureStatus);
+        .send(generateUserStatusData("ACTIVE", 1669401000000, 1669401000000));
       expect(response1).to.have.status(201);
       expect(response1.body.data.currentStatus.state).to.equal("ACTIVE");
 
@@ -136,7 +135,7 @@ describe("UserStatus", function () {
         .request(app)
         .patch(`/users/status/self`)
         .set("Cookie", `${cookieName}=${testUserJwt}`)
-        .send(finalDataForFutureStatus);
+        .send(generateUserStatusData("OOO", 1668215609000, 1669228200000, 1669573800000, "Vacation Trip"));
       expect(response2).to.have.status(200);
       expect(response2.body.message).to.equal("User Status updated successfully.");
       expect(response2.body.data).to.have.own.property("futureStatus");
@@ -188,7 +187,7 @@ describe("UserStatus", function () {
         .request(app)
         .patch(`/users/status/self`)
         .set("Cookie", `${cookieName}=${testUserJwt}`)
-        .send(initialDataForFutureStatus);
+        .send(generateUserStatusData("ACTIVE", 1669401000000, 1669401000000));
       expect(response1).to.have.status(201);
       expect(response1.body.data.currentStatus.state).to.equal("ACTIVE");
 
@@ -197,7 +196,7 @@ describe("UserStatus", function () {
         .request(app)
         .patch(`/users/status/self`)
         .set("Cookie", `${cookieName}=${testUserJwt}`)
-        .send(finalDataForFutureStatus);
+        .send(generateUserStatusData("OOO", 1668215609000, 1669228200000, 1669573800000, "Vacation Trip"));
       expect(response2).to.have.status(200);
       expect(response2.body.message).to.equal("User Status updated successfully.");
       expect(response2.body.data).to.have.own.property("futureStatus");
@@ -230,7 +229,7 @@ describe("UserStatus", function () {
         .request(app)
         .patch(`/users/status/self`)
         .set("Cookie", `${cookieName}=${testUserJwt}`)
-        .send(activeStatusDataFromToday);
+        .send(generateUserStatusData("ACTIVE", 1669401000000, 1669401000000));
       expect(response5).to.have.status(200);
       expect(response5.body.message).to.equal("User Status updated successfully.");
       expect(response5.body.data).to.have.own.property("currentStatus");
@@ -298,7 +297,7 @@ describe("UserStatus", function () {
         .request(app)
         .patch(`/users/status/self`)
         .set("cookie", `${cookieName}=${jwt}`)
-        .send(validUserStsDataforUpdate)
+        .send(generateUserStatusData("ACTIVE", 1668215609000, 1668215609000))
         .end((err, res) => {
           if (err) {
             return done(err);
@@ -330,7 +329,7 @@ describe("UserStatus", function () {
         .request(app)
         .patch(`/users/status/${userId}`)
         .set("cookie", `${cookieName}=${superUserAuthToken}`)
-        .send(validUserStsDataforUpdate)
+        .send(generateUserStatusData("ACTIVE", 1668215609000, 1668215609000))
         .end((err, res) => {
           if (err) {
             return done(err);
@@ -363,7 +362,7 @@ describe("UserStatus", function () {
         .request(app)
         .patch(`/users/status/self`)
         .set("cookie", `${cookieName}=${testUserJwt}`)
-        .send(invalidUserStsDataforUpdate)
+        .send(generateUserStatusData("IN_OFFICE", 1668215609000, 1668215609000))
         .end((err, res) => {
           if (err) {
             return done(err);
@@ -385,7 +384,7 @@ describe("UserStatus", function () {
         .request(app)
         .patch(`/users/status/self`)
         .set("Cookie", `${cookieName}=${testUserJwt}`)
-        .send(initialDataForFutureStatus);
+        .send(generateUserStatusData("ACTIVE", 1668215609000, 1668215609000));
       expect(response1).to.have.status(201);
       expect(response1.body.data.currentStatus.state).to.equal("ACTIVE");
 
@@ -394,7 +393,7 @@ describe("UserStatus", function () {
         .request(app)
         .patch(`/users/status/self`)
         .set("Cookie", `${cookieName}=${testUserJwt}`)
-        .send(finalDataForFutureStatus);
+        .send(generateUserStatusData("OOO", 1668215609000, 1669228200000, 1669573800000, "Vacation Trip"));
       expect(response2).to.have.status(200);
       expect(response2.body.message).to.equal("User Status updated successfully.");
       expect(response2.body.data).to.have.own.property("futureStatus");
@@ -407,7 +406,7 @@ describe("UserStatus", function () {
         .request(app)
         .patch(`/users/status/self`)
         .set("Cookie", `${cookieName}=${testUserJwt}`)
-        .send(updatedOooDataForFutureStatus);
+        .send(generateUserStatusData("OOO", 1668215609000, 1669833000000, 1670178600000, "New plan for vacation Trip"));
       expect(response3).to.have.status(200);
       expect(response3.body.message).to.equal("User Status updated successfully.");
       expect(response3.body.data).to.have.own.property("futureStatus");
@@ -434,7 +433,7 @@ describe("UserStatus", function () {
         .request(app)
         .patch(`/users/status/self`)
         .set("Cookie", `${cookieName}=${testUserJwt}`)
-        .send(finalDataForFutureStatus);
+        .send(generateUserStatusData("OOO", 1668215609000, 1669228200000, 1669573800000, "Vacation Trip"));
       expect(response1).to.have.status(201);
       expect(response1.body.message).to.equal("User Status created successfully.");
       expect(response1.body.data).to.have.own.property("futureStatus");
@@ -447,7 +446,9 @@ describe("UserStatus", function () {
         .request(app)
         .patch(`/users/status/self`)
         .set("Cookie", `${cookieName}=${testUserJwt}`)
-        .send(oooStatusDataFromToday);
+        .send(
+          generateUserStatusData("OOO", 1668191400000, 1668191400000, 1668623400000, "Changed plan for vacation Trip")
+        );
       expect(response2).to.have.status(200);
       expect(response2.body.message).to.equal("User Status updated successfully.");
       expect(response2.body.data).to.have.own.property("currentStatus");

--- a/test/integration/userStatus.test.js
+++ b/test/integration/userStatus.test.js
@@ -131,19 +131,20 @@ describe("UserStatus", function () {
       expect(response1.body.data.currentStatus.state).to.equal("ACTIVE");
 
       // Marking OOO Status from 24th Nov 2022 to 28th Nov 2022
+      let fromDate = new Date(2022, 10, 24);
+      fromDate.setHours(0, 0, 0, 0);
+      fromDate = fromDate.getTime();
+      let untilDate = new Date(2022, 10, 28);
+      untilDate.setHours(0, 0, 0, 0);
+      untilDate = untilDate.getTime();
+      let updatedAtDate = new Date(2022, 10, 12);
+      updatedAtDate.setHours(0, 0, 0, 0);
+      updatedAtDate = updatedAtDate.getTime();
       const response2 = await chai
         .request(app)
         .patch(`/users/status/self`)
         .set("Cookie", `${cookieName}=${testUserJwt}`)
-        .send(
-          generateUserStatusData(
-            "OOO",
-            new Date(2022, 10, 12).setHours(0, 0, 0, 0),
-            new Date(2022, 10, 24).setHours(0, 0, 0, 0),
-            new Date(2022, 10, 28).setHours(0, 0, 0, 0),
-            "Vacation Trip"
-          )
-        );
+        .send(generateUserStatusData("OOO", updatedAtDate, fromDate, untilDate, "Vacation Trip"));
       expect(response2).to.have.status(200);
       expect(response2.body.message).to.equal("User Status updated successfully.");
       expect(response2.body.data).to.have.own.property("futureStatus");

--- a/test/integration/userStatus.test.js
+++ b/test/integration/userStatus.test.js
@@ -138,9 +138,9 @@ describe("UserStatus", function () {
         .send(
           generateUserStatusData(
             "OOO",
-            new Date(2022, 10, 12).getTime(),
-            new Date(2022, 10, 24).getTime(),
-            new Date(2022, 10, 28).getTime(),
+            new Date(2022, 10, 12).setHours(0, 0, 0, 0),
+            new Date(2022, 10, 24).setHours(0, 0, 0, 0),
+            new Date(2022, 10, 28).setHours(0, 0, 0, 0),
             "Vacation Trip"
           )
         );

--- a/test/integration/userStatus.test.js
+++ b/test/integration/userStatus.test.js
@@ -135,7 +135,15 @@ describe("UserStatus", function () {
         .request(app)
         .patch(`/users/status/self`)
         .set("Cookie", `${cookieName}=${testUserJwt}`)
-        .send(generateUserStatusData("OOO", 1668215609000, 1669228200000, 1669573800000, "Vacation Trip"));
+        .send(
+          generateUserStatusData(
+            "OOO",
+            new Date(2022, 10, 12).getTime(),
+            new Date(2022, 10, 24).getTime(),
+            new Date(2022, 10, 28).getTime(),
+            "Vacation Trip"
+          )
+        );
       expect(response2).to.have.status(200);
       expect(response2.body.message).to.equal("User Status updated successfully.");
       expect(response2.body.data).to.have.own.property("futureStatus");
@@ -143,7 +151,7 @@ describe("UserStatus", function () {
       expect(response2.body.data.futureStatus.message).to.equal("Vacation Trip");
       expect(response2.body.data.futureStatus.from).to.equal(1669228200000);
       expect(response2.body.data.futureStatus.until).to.equal(1669573800000);
-      expect(response2.body.data.futureStatus.updatedAt).to.equal(1668215609000);
+      expect(response2.body.data.futureStatus.updatedAt).to.equal(1668191400000);
 
       // Mocking date to be 26th Nov 2022
       clock.setSystemTime(new Date(2022, 10, 26).getTime());

--- a/test/integration/userStatus.test.js
+++ b/test/integration/userStatus.test.js
@@ -230,7 +230,6 @@ describe("UserStatus", function () {
         .patch(`/users/status/self`)
         .set("Cookie", `${cookieName}=${testUserJwt}`)
         .send(generateUserStatusData("ACTIVE", 1669401000000, 1669401000000));
-      console.log({response5});
       expect(response5).to.have.status(200);
       expect(response5.body.message).to.equal("User Status updated successfully.");
       expect(response5.body.data).to.have.own.property("currentStatus");
@@ -468,7 +467,6 @@ describe("UserStatus", function () {
         .send(
           generateUserStatusData("OOO", 1668191400000, 1668191400000, 1668623400000, "Changed plan for vacation Trip")
         );
-        console.log({response2});
       expect(response2).to.have.status(200);
       expect(response2.body.message).to.equal("User Status updated successfully.");
       expect(response2.body.data).to.have.own.property("currentStatus");

--- a/test/integration/userStatus.test.js
+++ b/test/integration/userStatus.test.js
@@ -131,9 +131,9 @@ describe("UserStatus", function () {
       expect(response1.body.data.currentStatus.state).to.equal("ACTIVE");
 
       // Marking OOO Status from 24th Nov 2022 to 28th Nov 2022
-      const updatedAtDate = Date.now();
-      const fromDate = updatedAtDate + 12 * 24 * 60 * 60 * 1000;
-      const untilDate = updatedAtDate + 16 * 24 * 60 * 60 * 1000;
+      const updatedAtDate = Date.now(); // 12th Nov 2022
+      const fromDate = updatedAtDate + 12 * 24 * 60 * 60 * 1000; // 24th Nov 2022
+      const untilDate = updatedAtDate + 16 * 24 * 60 * 60 * 1000; // 28th Nov 2022
       const response2 = await chai
         .request(app)
         .patch(`/users/status/self`)
@@ -144,9 +144,9 @@ describe("UserStatus", function () {
       expect(response2.body.data).to.have.own.property("futureStatus");
       expect(response2.body.data.futureStatus.state).to.equal("OOO");
       expect(response2.body.data.futureStatus.message).to.equal("Vacation Trip");
-      expect(response2.body.data.futureStatus.from).to.equal(1669228200000);
-      expect(response2.body.data.futureStatus.until).to.equal(1669573800000);
-      expect(response2.body.data.futureStatus.updatedAt).to.equal(1668191400000);
+      expect(response2.body.data.futureStatus.from).to.equal(fromDate);
+      expect(response2.body.data.futureStatus.until).to.equal(untilDate);
+      expect(response2.body.data.futureStatus.updatedAt).to.equal(updatedAtDate);
 
       // Mocking date to be 26th Nov 2022
       clock.setSystemTime(new Date(2022, 10, 26).getTime());

--- a/test/integration/userStatus.test.js
+++ b/test/integration/userStatus.test.js
@@ -13,7 +13,7 @@ const superUser = userData[4];
 const {
   userStsDataForNewUser,
   userStsDataForOooState,
-  oooUserStsDataForShortDuration,
+  oooStsDataForShortDuration,
   generateUserStatusData,
 } = require("../fixtures/userStatus/userStatus");
 
@@ -313,7 +313,7 @@ describe("UserStatus", function () {
         .request(app)
         .patch(`/users/status/self`)
         .set("cookie", `${cookieName}=${jwt}`)
-        .send(oooUserStsDataForShortDuration)
+        .send(oooStsDataForShortDuration)
         .end((err, res) => {
           if (err) {
             return done(err);

--- a/test/integration/userStatus.test.js
+++ b/test/integration/userStatus.test.js
@@ -230,6 +230,7 @@ describe("UserStatus", function () {
         .patch(`/users/status/self`)
         .set("Cookie", `${cookieName}=${testUserJwt}`)
         .send(generateUserStatusData("ACTIVE", 1669401000000, 1669401000000));
+      console.log({response5});
       expect(response5).to.have.status(200);
       expect(response5.body.message).to.equal("User Status updated successfully.");
       expect(response5.body.data).to.have.own.property("currentStatus");
@@ -467,6 +468,7 @@ describe("UserStatus", function () {
         .send(
           generateUserStatusData("OOO", 1668191400000, 1668191400000, 1668623400000, "Changed plan for vacation Trip")
         );
+        console.log({response2});
       expect(response2).to.have.status(200);
       expect(response2.body.message).to.equal("User Status updated successfully.");
       expect(response2.body.data).to.have.own.property("currentStatus");

--- a/test/integration/userStatus.test.js
+++ b/test/integration/userStatus.test.js
@@ -11,9 +11,9 @@ const cleanDb = require("../utils/cleanDb");
 const userData = require("../fixtures/user/user")();
 const superUser = userData[4];
 const {
-  userStsDataForNewUser,
-  userStsDataForOooState,
-  oooStsDataForShortDuration,
+  userStatusDataForNewUser,
+  userStatusDataForOooState,
+  oooStatusDataForShortDuration,
   generateUserStatusData,
 } = require("../fixtures/userStatus/userStatus");
 
@@ -34,7 +34,7 @@ describe("UserStatus", function () {
     jwt = authService.generateAuthToken({ userId });
     superUserId = await addUser(superUser);
     superUserAuthToken = authService.generateAuthToken({ userId: superUserId });
-    await updateUserStatus(userId, userStsDataForNewUser);
+    await updateUserStatus(userId, userStatusDataForNewUser);
   });
 
   afterEach(async function () {
@@ -261,7 +261,7 @@ describe("UserStatus", function () {
         .request(app)
         .patch(`/users/status/self`)
         .set("Cookie", `${cookieName}=${testUserJwt}`)
-        .send(userStsDataForOooState)
+        .send(userStatusDataForOooState)
         .end((err, res) => {
           if (err) {
             return done(err);
@@ -279,7 +279,7 @@ describe("UserStatus", function () {
         .request(app)
         .patch(`/users/status/${testUserId}`)
         .set("Cookie", `${cookieName}=${superUserAuthToken}`)
-        .send(userStsDataForOooState)
+        .send(userStatusDataForOooState)
         .end((err, res) => {
           if (err) {
             return done(err);
@@ -313,7 +313,7 @@ describe("UserStatus", function () {
         .request(app)
         .patch(`/users/status/self`)
         .set("cookie", `${cookieName}=${jwt}`)
-        .send(oooStsDataForShortDuration)
+        .send(oooStatusDataForShortDuration)
         .end((err, res) => {
           if (err) {
             return done(err);
@@ -345,7 +345,7 @@ describe("UserStatus", function () {
         .request(app)
         .patch(`/users/status/${testUserId}`)
         .set("Cookie", `${cookieName}=""`)
-        .send(userStsDataForOooState)
+        .send(userStatusDataForOooState)
         .end((err, res) => {
           if (err) {
             return done(err);

--- a/test/integration/userStatus.test.js
+++ b/test/integration/userStatus.test.js
@@ -140,6 +140,10 @@ describe("UserStatus", function () {
       expect(response2.body.message).to.equal("User Status updated successfully.");
       expect(response2.body.data).to.have.own.property("futureStatus");
       expect(response2.body.data.futureStatus.state).to.equal("OOO");
+      expect(response2.body.data.futureStatus.message).to.equal("Vacation Trip");
+      expect(response2.body.data.futureStatus.from).to.equal(1669228200000);
+      expect(response2.body.data.futureStatus.until).to.equal(1669573800000);
+      expect(response2.body.data.futureStatus.updatedAt).to.equal(1668215609000);
 
       // Mocking date to be 26th Nov 2022
       clock.setSystemTime(new Date(2022, 10, 26).getTime());

--- a/test/integration/userStatus.test.js
+++ b/test/integration/userStatus.test.js
@@ -131,15 +131,9 @@ describe("UserStatus", function () {
       expect(response1.body.data.currentStatus.state).to.equal("ACTIVE");
 
       // Marking OOO Status from 24th Nov 2022 to 28th Nov 2022
-      let fromDate = new Date(2022, 10, 24);
-      fromDate.setHours(0, 0, 0, 0);
-      fromDate = fromDate.getTime();
-      let untilDate = new Date(2022, 10, 28);
-      untilDate.setHours(0, 0, 0, 0);
-      untilDate = untilDate.getTime();
-      let updatedAtDate = new Date(2022, 10, 12);
-      updatedAtDate.setHours(0, 0, 0, 0);
-      updatedAtDate = updatedAtDate.getTime();
+      const updatedAtDate = Date.now();
+      const fromDate = updatedAtDate + 12 * 24 * 60 * 60 * 1000;
+      const untilDate = updatedAtDate + 16 * 24 * 60 * 60 * 1000;
       const response2 = await chai
         .request(app)
         .patch(`/users/status/self`)

--- a/utils/userStatus.js
+++ b/utils/userStatus.js
@@ -19,4 +19,13 @@ const getTommorowTimeStamp = () => {
   return today.getTime();
 };
 
-module.exports = { getUserIdBasedOnRoute, getTommorowTimeStamp };
+const getTodayTimeStamp = () => {
+  const today = new Date();
+  today.setHours(0);
+  today.setMinutes(0);
+  today.setSeconds(0);
+  today.setMilliseconds(0);
+  return today.getTime();
+};
+
+module.exports = { getUserIdBasedOnRoute, getTommorowTimeStamp, getTodayTimeStamp };

--- a/utils/userStatus.js
+++ b/utils/userStatus.js
@@ -12,4 +12,11 @@ const getUserIdBasedOnRoute = (req) => {
   return userId;
 };
 
-module.exports = { getUserIdBasedOnRoute };
+const getTommorowTimeStamp = () => {
+  const today = new Date();
+  today.setDate(today.getDate() + 1);
+  today.setHours(0, 0, 0, 0);
+  return today.getTime();
+};
+
+module.exports = { getUserIdBasedOnRoute, getTommorowTimeStamp };


### PR DESCRIPTION
Closes the [issue](https://github.com/Real-Dev-Squad/website-data-models/issues/17)

This is a stacked PR and should be merged after https://github.com/Real-Dev-Squad/website-backend/pull/879

- [x] If the users are currently `active/idle` and they mark themselves as `OOO` for a future date then the new object with the same fields as `current status` will be created and stored in `future status`. once when the future date arrives the values in the `current status` and `future status` will be swapped with the dates adjusted accordingly so that once the users are back in office they have the same status that they had prior to leaving office.
- [x]  If the users are currently `active/idle` and they mark themselves as `OOO` for a future date then the new object will be created and stored in `future status`. Once the future dates start and their status changes to `OOO` and before completing their `OOO` tenure they mark themselves as `IDLE / ACTIVE` we will set the current status as `IDLE / ACTIVE` and remove the `future status` which was waiting to be swapped. 
- [x]  If the users are currently `active/idle` and they mark themselves as `OOO` for a future date and later before their `OOO` dates arrive they again mark themselves `OOO` the latest one will be considered it will overwrite the previously written object in the `future status`.
- [x] if the users have marked themselves as `OOO` for a future date and they change their current status as well with `OOO` then it will remove the old `OOO` from the `future status`. 