### PR TITLE
Fixed request body of discord bot API

### DIFF
--- a/middlewares/validators/discord.js
+++ b/middlewares/validators/discord.js
@@ -4,7 +4,7 @@ const discordData = async (req, res, next) => {
   const schema = joi.object().strict().keys({
     token: joi.string().required(),
     discordId: joi.string().required(),
-    generationTime: joi.number().required(),
+    timestamp: joi.number().required(),
     expiry: joi.number().required(),
     linkStatus: joi.boolean().required(),
   });

--- a/test/fixtures/discord/discord.js
+++ b/test/fixtures/discord/discord.js
@@ -3,14 +3,14 @@ module.exports = () => {
     {
       token: "<TOKEN>",
       discordId: "<DISCORD_ID>",
-      generationTime: 1674041400,
+      timestamp: 1674041400,
       expiry: 1674041460,
       linkStatus: false,
     },
     {
       token: "<TOKEN>",
       discordId: "<DISCORD_ID>",
-      generationTime: 1674041400,
+      timestamp: 1674041400,
       expiry: 1674041460,
       linkStatus: "false",
     },


### PR DESCRIPTION
## Resolves Issue
Closes #919

## What's the change?
- Fixed the Discord Model Validator i.e. changed the `generationTime` field to `timestamp`
**Data Model Reference**
https://github.com/Real-Dev-Squad/website-data-models/tree/main/discord

- Fixed the fixtures of API as well for testing 