### PR TITLE
Created GET API for External Accounts

### DIFF
--- a/controllers/external-accounts.js
+++ b/controllers/external-accounts.js
@@ -1,10 +1,10 @@
 const externalAccountsModel = require("../models/external-accounts");
 
 const addExternalAccountData = async (req, res) => {
-  try {
-    const createdOn = Date.now();
-    const data = { ...req.body, createdOn };
+  const createdOn = Date.now();
 
+  try {
+    const data = { ...req.body, createdOn };
     await externalAccountsModel.addExternalAccountData(data);
 
     return res.status(201).json({ message: "Added external account data successfully" });
@@ -14,4 +14,24 @@ const addExternalAccountData = async (req, res) => {
   }
 };
 
-module.exports = { addExternalAccountData };
+const getExternalAccountData = async (req, res) => {
+  try {
+    const externalAccountData = await externalAccountsModel.fetchExternalAccountData(req.query, req.params.token);
+    if (externalAccountData.length === 0) {
+      return res.status(404).json({ message: "No data found" });
+    }
+
+    const attributes = externalAccountData[0].attributes;
+
+    if (attributes.expiry && attributes.expiry < Date.now()) {
+      return res.status(498).json({ message: "Token Expired. Please generate it again" });
+    }
+
+    return res.status(200).json({ message: "Data returned successfully", attributes: attributes });
+  } catch (error) {
+    logger.error(`Error getting external account data: ${error}`);
+    return res.boom.serverUnavailable("Something went wrong please contact admin");
+  }
+};
+
+module.exports = { addExternalAccountData, getExternalAccountData };

--- a/controllers/external-accounts.js
+++ b/controllers/external-accounts.js
@@ -17,13 +17,13 @@ const addExternalAccountData = async (req, res) => {
 const getExternalAccountData = async (req, res) => {
   try {
     const externalAccountData = await externalAccountsModel.fetchExternalAccountData(req.query, req.params.token);
-    if (externalAccountData.length === 0) {
-      return res.status(404).json({ message: "No data found" });
+    if (!externalAccountData.id) {
+      return res.boom.notFound("No data found");
     }
 
-    const attributes = externalAccountData[0].attributes;
+    const attributes = externalAccountData.attributes;
     if (attributes.expiry && attributes.expiry < Date.now()) {
-      return res.status(498).json({ message: "Token Expired. Please generate it again" });
+      return res.boom.unauthorized("Token Expired. Please generate it again");
     }
 
     return res.status(200).json({ message: "Data returned successfully", attributes: attributes });

--- a/controllers/external-accounts.js
+++ b/controllers/external-accounts.js
@@ -22,7 +22,6 @@ const getExternalAccountData = async (req, res) => {
     }
 
     const attributes = externalAccountData[0].attributes;
-
     if (attributes.expiry && attributes.expiry < Date.now()) {
       return res.status(498).json({ message: "Token Expired. Please generate it again" });
     }

--- a/controllers/external-accounts.js
+++ b/controllers/external-accounts.js
@@ -5,6 +5,13 @@ const addExternalAccountData = async (req, res) => {
 
   try {
     const data = { ...req.body, createdOn };
+
+    // Check if token already exists
+    const dataFound = await externalAccountsModel.fetchExternalAccountData("", data.token);
+    if (dataFound.token && dataFound.token === data.token) {
+      return res.boom.conflict("Token already exists");
+    }
+
     await externalAccountsModel.addExternalAccountData(data);
 
     return res.status(201).json({ message: "Added external account data successfully" });

--- a/models/external-accounts.js
+++ b/models/external-accounts.js
@@ -17,13 +17,11 @@ const fetchExternalAccountData = async (query, param) => {
     let externalAccountData;
 
     externalAccountData = externalAccountsModel.where("token", "==", param);
-
     if (query && query?.type) {
       externalAccountData = externalAccountData.where("type", "==", query?.type);
     }
 
     const querySnapshot = await externalAccountData.limit(1).get();
-
     if (querySnapshot.empty) {
       return userExternalAccountData;
     }

--- a/models/external-accounts.js
+++ b/models/external-accounts.js
@@ -13,26 +13,26 @@ const addExternalAccountData = async (data) => {
 
 const fetchExternalAccountData = async (query, param) => {
   try {
-    const userExternalAccountData = [];
-    let externalAccountData;
+    let externalAccountQuery;
+    let data, id;
 
-    externalAccountData = externalAccountsModel.where("token", "==", param);
+    externalAccountQuery = externalAccountsModel.where("token", "==", param);
     if (query && query?.type) {
-      externalAccountData = externalAccountData.where("type", "==", query?.type);
+      externalAccountQuery = externalAccountQuery.where("type", "==", query?.type);
     }
 
-    const querySnapshot = await externalAccountData.limit(1).get();
-    if (querySnapshot.empty) {
-      return userExternalAccountData;
+    const querySnapshot = await externalAccountQuery.limit(1).get();
+
+    const doc = querySnapshot.docs[0];
+    if (doc) {
+      id = doc.id;
+      data = doc.data();
     }
 
-    const data = querySnapshot.docs[0];
-    userExternalAccountData.push({
-      id: data.id,
-      ...data.data(),
-    });
-
-    return userExternalAccountData;
+    return {
+      id: id,
+      ...data,
+    };
   } catch (err) {
     logger.error("Error in fetching external account data", err);
     throw err;

--- a/models/external-accounts.js
+++ b/models/external-accounts.js
@@ -14,23 +14,24 @@ const addExternalAccountData = async (data) => {
 const fetchExternalAccountData = async (query, param) => {
   try {
     const userExternalAccountData = [];
-
     let externalAccountData;
-    externalAccountData = await externalAccountsModel.where("token", "==", param);
 
-    Object.keys(query).forEach((key) => {
-      if (key === "type") {
-        externalAccountData = externalAccountData.where(key, "==", query?.key);
-      }
-    });
+    externalAccountData = externalAccountsModel.where("token", "==", param);
 
-    externalAccountData = await externalAccountData.limit(1).get();
+    if (query && query?.type) {
+      externalAccountData = externalAccountData.where("type", "==", query?.type);
+    }
 
-    externalAccountData.forEach((data) => {
-      userExternalAccountData.push({
-        id: data.id,
-        ...data.data(),
-      });
+    const querySnapshot = await externalAccountData.limit(1).get();
+
+    if (querySnapshot.empty) {
+      return userExternalAccountData;
+    }
+
+    const data = querySnapshot.docs[0];
+    userExternalAccountData.push({
+      id: data.id,
+      ...data.data(),
     });
 
     return userExternalAccountData;

--- a/models/external-accounts.js
+++ b/models/external-accounts.js
@@ -22,7 +22,6 @@ const fetchExternalAccountData = async (query, param) => {
     }
 
     const querySnapshot = await externalAccountQuery.limit(1).get();
-
     const doc = querySnapshot.docs[0];
     if (doc) {
       id = doc.id;

--- a/models/external-accounts.js
+++ b/models/external-accounts.js
@@ -11,4 +11,33 @@ const addExternalAccountData = async (data) => {
   }
 };
 
-module.exports = { addExternalAccountData };
+const fetchExternalAccountData = async (query, param) => {
+  try {
+    const userExternalAccountData = [];
+
+    let externalAccountData;
+    externalAccountData = await externalAccountsModel.where("token", "==", param);
+
+    Object.keys(query).forEach((key) => {
+      if (key === "type") {
+        externalAccountData = externalAccountData.where(key, "==", query?.key);
+      }
+    });
+
+    externalAccountData = await externalAccountData.limit(1).get();
+
+    externalAccountData.forEach((data) => {
+      userExternalAccountData.push({
+        id: data.id,
+        ...data.data(),
+      });
+    });
+
+    return userExternalAccountData;
+  } catch (err) {
+    logger.error("Error in fetching external account data", err);
+    throw err;
+  }
+};
+
+module.exports = { addExternalAccountData, fetchExternalAccountData };

--- a/routes/external-accounts.js
+++ b/routes/external-accounts.js
@@ -3,7 +3,9 @@ const router = express.Router();
 const authorizeBot = require("../middlewares/authorizeBot");
 const validator = require("../middlewares/validators/external-accounts");
 const externalAccount = require("../controllers/external-accounts");
+const authenticate = require("../middlewares/authenticate");
 
 router.post("/", validator.externalAccountData, authorizeBot, externalAccount.addExternalAccountData);
+router.get("/:token", authenticate, externalAccount.getExternalAccountData);
 
 module.exports = router;

--- a/test/fixtures/external-accounts/external-accounts.js
+++ b/test/fixtures/external-accounts/external-accounts.js
@@ -5,15 +5,32 @@ module.exports = () => {
       token: "<TOKEN>",
       attributes: {
         discordId: "<DISCORD_ID>",
-        expiry: 1674041460,
+        expiry: 1674041460211,
       },
     },
     {
+      // Bad Data
       type: "discord",
       token: 123,
       attributes: {
         discordId: "<DISCORD_ID>",
-        expiry: 1674041460,
+        expiry: 1674041460211,
+      },
+    },
+    {
+      type: "discord",
+      token: "<TOKEN>",
+      attributes: {
+        discordId: "<DISCORD_ID>",
+        expiry: Date.now() + 600000,
+      },
+    },
+    {
+      type: "discord",
+      token: "<TOKEN_1>",
+      attributes: {
+        discordId: "<DISCORD_ID>",
+        expiry: Date.now() - 600000,
       },
     },
   ];

--- a/test/integration/external-accounts.test.js
+++ b/test/integration/external-accounts.test.js
@@ -103,6 +103,29 @@ describe("External Accounts", function () {
           return done();
         });
     });
+
+    it("Should return 409 when token already exists", function (done) {
+      externalAccountsModel.addExternalAccountData(externalAccountData[0]);
+      chai
+        .request(app)
+        .post("/external-accounts")
+        .set("Authorization", `Bearer ${jwtToken}`)
+        .send(externalAccountData[0])
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          expect(res).to.have.status(409);
+          expect(res.body).to.be.eql({
+            statusCode: 409,
+            error: "Conflict",
+            message: "Token already exists",
+          });
+
+          return done();
+        });
+    });
   });
 
   describe("GET /external-accounts/:token", function () {

--- a/test/integration/external-accounts.test.js
+++ b/test/integration/external-accounts.test.js
@@ -3,24 +3,27 @@ const { expect } = chai;
 const chaiHttp = require("chai-http");
 const app = require("../../server");
 const cleanDb = require("../utils/cleanDb");
-const externalAccountData = require("../fixtures/external-accounts/external-accounts")();
 const bot = require("../utils/generateBotToken");
+const addUser = require("../utils/addUser");
 const { BAD_TOKEN, CLOUDFLARE_WORKER } = require("../../constants/bot");
+const authService = require("../../services/authService");
+const externalAccountData = require("../fixtures/external-accounts/external-accounts")();
+const externalAccountsModel = require("../../models/external-accounts");
 
 chai.use(chaiHttp);
 
 describe("External Accounts", function () {
-  let jwtToken;
-
-  beforeEach(async function () {
-    jwtToken = bot.generateToken({ name: CLOUDFLARE_WORKER });
-  });
-
-  afterEach(async function () {
-    await cleanDb();
-  });
-
   describe("POST /external-accounts", function () {
+    let jwtToken;
+
+    beforeEach(async function () {
+      jwtToken = bot.generateToken({ name: CLOUDFLARE_WORKER });
+    });
+
+    afterEach(async function () {
+      await cleanDb();
+    });
+
     it("Should create a new external account data in firestore", function (done) {
       chai
         .request(app)
@@ -96,6 +99,95 @@ describe("External Accounts", function () {
           expect(res.body).to.have.property("error");
           expect(res.body.message).to.equal("Unauthorized Bot");
           expect(res.body.error).to.equal("Unauthorized");
+
+          return done();
+        });
+    });
+  });
+
+  describe("GET /external-accounts/:token", function () {
+    let jwt;
+
+    beforeEach(async function () {
+      const userId = await addUser();
+      jwt = authService.generateAuthToken({ userId });
+      await externalAccountsModel.addExternalAccountData(externalAccountData[2]);
+      await externalAccountsModel.addExternalAccountData(externalAccountData[3]);
+    });
+
+    afterEach(async function () {
+      await cleanDb();
+    });
+
+    it("Should return 200 when data is returned successfully", function (done) {
+      chai
+        .request(app)
+        .get("/external-accounts/<TOKEN>")
+        .set("Authorization", `Bearer ${jwt}`)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+          expect(res).to.have.status(200);
+          expect(res.body).to.have.property("message");
+          expect(res.body.message).to.equal("Data returned successfully");
+          expect(res.body).to.have.property("attributes");
+          expect(res.body.attributes).to.have.property("discordId");
+          expect(res.body.attributes).to.have.property("expiry");
+          expect(res.body.attributes.discordId).to.equal("<DISCORD_ID>");
+          return done();
+        });
+    });
+
+    it("Should return 404 when no data found", function (done) {
+      chai
+        .request(app)
+        .get("/external-accounts/<TOKEN_2>")
+        .set("Authorization", `Bearer ${jwt}`)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+          expect(res).to.have.status(404);
+          expect(res.body).to.have.property("message");
+          expect(res.body.message).to.equal("No data found");
+
+          return done();
+        });
+    });
+
+    it("Should return 498 when token is expired", function (done) {
+      chai
+        .request(app)
+        .get("/external-accounts/<TOKEN_1>")
+        .set("Authorization", `Bearer ${jwt}`)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+          expect(res).to.have.status(498);
+          expect(res.body).to.have.property("message");
+          expect(res.body.message).to.equal("Token Expired. Please generate it again");
+
+          return done();
+        });
+    });
+
+    it("Should return 401 when user is not authenticated", function (done) {
+      chai
+        .request(app)
+        .get("/external-accounts/<TOKEN>")
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+          expect(res).to.have.status(401);
+          expect(res.body).to.be.an("object");
+          expect(res.body).to.eql({
+            statusCode: 401,
+            error: "Unauthorized",
+            message: "Unauthenticated User",
+          });
 
           return done();
         });

--- a/test/integration/external-accounts.test.js
+++ b/test/integration/external-accounts.test.js
@@ -156,7 +156,7 @@ describe("External Accounts", function () {
         });
     });
 
-    it("Should return 498 when token is expired", function (done) {
+    it("Should return 401 when token is expired", function (done) {
       chai
         .request(app)
         .get("/external-accounts/<TOKEN_1>")
@@ -165,9 +165,13 @@ describe("External Accounts", function () {
           if (err) {
             return done(err);
           }
-          expect(res).to.have.status(498);
-          expect(res.body).to.have.property("message");
-          expect(res.body.message).to.equal("Token Expired. Please generate it again");
+          expect(res).to.have.status(401);
+          expect(res.body).to.be.an("object");
+          expect(res.body).to.eql({
+            statusCode: 401,
+            error: "Unauthorized",
+            message: "Token Expired. Please generate it again",
+          });
 
           return done();
         });

--- a/test/unit/models/external-accounts.test.js
+++ b/test/unit/models/external-accounts.test.js
@@ -18,4 +18,31 @@ describe("External Accounts", function () {
       expect(response.message).to.equal("Added data successfully");
     });
   });
+
+  describe("fetchDiscordData", function () {
+    it("should return discord data having given token", async function () {
+      await externalAccountsModel.addExternalAccountData(externalAccountData[2]);
+      const data = await externalAccountsModel.fetchExternalAccountData("", externalAccountData[2].token);
+      const response = data[0];
+
+      expect(response).to.be.an("object");
+      expect(response).to.have.property("id");
+      expect(response).to.have.property("type");
+      expect(response).to.have.property("token");
+      expect(response).to.have.property("attributes");
+      expect(response.type).to.equal(externalAccountData[2].type);
+      expect(response.token).to.equal(externalAccountData[2].token);
+      expect(response.attributes).to.be.eql({
+        discordId: externalAccountData[2].attributes.discordId,
+        expiry: externalAccountData[2].attributes.expiry,
+      });
+    });
+
+    it("should return empty array when no data found", async function () {
+      const response = await externalAccountsModel.fetchExternalAccountData("", externalAccountData[0].token);
+
+      expect(response).to.be.an("array");
+      expect(response).to.have.length(0);
+    });
+  });
 });

--- a/test/unit/models/external-accounts.test.js
+++ b/test/unit/models/external-accounts.test.js
@@ -22,8 +22,7 @@ describe("External Accounts", function () {
   describe("fetchDiscordData", function () {
     it("should return discord data having given token", async function () {
       await externalAccountsModel.addExternalAccountData(externalAccountData[2]);
-      const data = await externalAccountsModel.fetchExternalAccountData("", externalAccountData[2].token);
-      const response = data[0];
+      const response = await externalAccountsModel.fetchExternalAccountData("", externalAccountData[2].token);
 
       expect(response).to.be.an("object");
       expect(response).to.have.property("id");
@@ -38,11 +37,11 @@ describe("External Accounts", function () {
       });
     });
 
-    it("should return empty array when no data found", async function () {
+    it("should return undefined id when no data found", async function () {
       const response = await externalAccountsModel.fetchExternalAccountData("", externalAccountData[0].token);
 
-      expect(response).to.be.an("array");
-      expect(response).to.have.length(0);
+      expect(response).to.be.an("object");
+      expect(response.id).to.be.equal(undefined);
     });
   });
 });


### PR DESCRIPTION
## Issue
#912 

## What's the change
- Created a GET endpoint to get the data of the external account
- **GET** `/external-accounts/:token`
- Data returned from the API
- Added a duplicate token check in `POST` `/external-accounts` API
```json
{
  "message": "Data returned successfully",
  "attributes": "<object>"
}
```