### PR TITLE
fix: Incorrect return type to addUser causes lint warning

### DIFF
--- a/test/utils/addUser.js
+++ b/test/utils/addUser.js
@@ -6,7 +6,7 @@ const userData = require("../fixtures/user/user")();
 /**
  * File to be required in every test file where userId is required to generate the JWT
  *
- * @return {string} userId - userId for the added user
+ * @return {Promise<string>} userId - userId for the added user
  */
 module.exports = async (user) => {
   const isValid = user && Object.keys(user).length !== 0 && user.constructor === Object;


### PR DESCRIPTION
 fixes #949 

     addUser is an async function however its return type was not
     wrapped in a promise which is why the when using the function with
     `await` there was a lint warning that showed up that saying `await
     is not needed`, but without await the function won't work
     properly.