### PR TITLE
Feat: One-Click Issue to Task Conversion

### DIFF
--- a/controllers/issues.js
+++ b/controllers/issues.js
@@ -1,8 +1,8 @@
 const issuesService = require("../services/issuesService");
 const tasks = require("../models/tasks");
 const { getIssueAssigneeRdsInfo } = require("../models/users");
+const { SOMETHING_WENT_WRONG } = require("../constants/errorMessages");
 
-const ERROR_MESSAGE = "Something went wrong. Please try again or contact admin";
 /**
  * Get the  issues of the repo
  * @param {Object} req - Express request object
@@ -29,7 +29,7 @@ const getIssues = async (req, res) => {
     });
   } catch (err) {
     logger.error(`Error while retriving issues ${err}`);
-    return res.boom.badImplementation(ERROR_MESSAGE);
+    return res.boom.badImplementation(SOMETHING_WENT_WRONG);
   }
 };
 
@@ -91,7 +91,7 @@ const issueUpdates = async (req, res) => {
     });
   } catch (err) {
     logger.error(`Error while retriving issues ${err}`);
-    return res.boom.badImplementation(ERROR_MESSAGE);
+    return res.boom.badImplementation(SOMETHING_WENT_WRONG);
   }
 };
 

--- a/controllers/issues.js
+++ b/controllers/issues.js
@@ -11,8 +11,9 @@ const ERROR_MESSAGE = "Something went wrong. Please try again or contact admin";
 
 const getIssues = async (req, res) => {
   try {
-    const issues = await issuesService.getRepoIssues();
+    const issues = await issuesService.getOrgIssues();
     let issuesData = issues.data.length > 0 ? issues.data : [];
+    issuesData = issuesData.filter((issue) => !Object.keys(issue).includes("pull_request"));
     issuesData = issuesData.map(async (issue) => {
       const taskData = await tasks.fetchTaskByIssueId(issue.id);
       if (taskData) {

--- a/controllers/issues.js
+++ b/controllers/issues.js
@@ -1,6 +1,6 @@
 const issuesService = require("../services/issuesService");
 const tasks = require("../models/tasks");
-const { getIssueAssigneeRdsInfo } = require("../models/users");
+const { getRdsUserInfoByGitHubUsername } = require("../models/users");
 const { SOMETHING_WENT_WRONG } = require("../constants/errorMessages");
 
 /**
@@ -60,7 +60,7 @@ const issueUpdates = async (req, res) => {
         if (issue.assignee) {
           // If there are no previous assignees or the task was not assigned before
           if (!updatedTaskData.github.issue.assignee || !updatedTaskData.assignee) {
-            const user = await getIssueAssigneeRdsInfo(issue.assignee.login);
+            const user = await getRdsUserInfoByGitHubUsername(issue.assignee.login);
 
             updatedTaskData.github.issue.assignee = issue.assignee.login;
             updatedTaskData.github.issue.assigneeRdsInfo = user;

--- a/controllers/issues.js
+++ b/controllers/issues.js
@@ -1,6 +1,5 @@
 const issuesService = require("../services/issuesService");
 const tasks = require("../models/tasks");
-const { getRdsUserInfoByGitHubUsername } = require("../models/users");
 const { SOMETHING_WENT_WRONG } = require("../constants/errorMessages");
 
 /**
@@ -60,16 +59,12 @@ const issueUpdates = async (req, res) => {
         if (issue.assignee) {
           // If there are no previous assignees or the task was not assigned before
           if (!updatedTaskData.github.issue.assignee || !updatedTaskData.assignee) {
-            const user = await getRdsUserInfoByGitHubUsername(issue.assignee.login);
-
             updatedTaskData.github.issue.assignee = issue.assignee.login;
-            updatedTaskData.github.issue.assigneeRdsInfo = user;
           }
         }
         // If the issue assignee was removed and task was not assigned
         else if (updatedTaskData.github.issue.assignee && !updatedTaskData.assignee) {
           delete updatedTaskData.github.issue.assignee;
-          delete updatedTaskData.github.issue.assigneeRdsInfo;
         }
 
         if (issue.state === "closed") {

--- a/controllers/issues.js
+++ b/controllers/issues.js
@@ -1,0 +1,100 @@
+const issuesService = require("../services/issuesService");
+const tasks = require("../models/tasks");
+const { getIssueAssigneeRdsInfo } = require("../models/users");
+
+const ERROR_MESSAGE = "Something went wrong. Please try again or contact admin";
+/**
+ * Get the  issues of the repo
+ * @param {Object} req - Express request object
+ * @param {Object} res - Express response object
+ */
+
+const getIssues = async (req, res) => {
+  try {
+    const issues = await issuesService.getRepoIssues();
+    let issuesData = issues.data.length > 0 ? issues.data : [];
+    issuesData = issuesData.map(async (issue) => {
+      const taskData = await tasks.fetchTaskByIssueId(issue.id);
+      if (taskData) {
+        issue.taskExists = true;
+      }
+
+      return issue;
+    });
+    const updatedIsuees = await Promise.all(issuesData);
+    return res.json({
+      message: "Issues returned successfully!",
+      issues: updatedIsuees,
+    });
+  } catch (err) {
+    logger.error(`Error while retriving issues ${err}`);
+    return res.boom.badImplementation(ERROR_MESSAGE);
+  }
+};
+
+/**
+ * Receive updated issue information from webhook
+ * @param {Object} req - Express request object
+ * @param {Object} res - Express response object
+ */
+const issueUpdates = async (req, res) => {
+  try {
+    const response = req.body;
+    if ("issue" in response) {
+      const { issue } = response;
+      const taskData = await tasks.fetchTaskByIssueId(issue.id);
+      if (taskData) {
+        // filtering properties with undefined or null values
+        const updatedTaskData = Object.fromEntries(Object.entries(taskData).filter(([_, value]) => value ?? false));
+
+        updatedTaskData.title = issue.title;
+        updatedTaskData.github = {
+          issue: {
+            ...updatedTaskData.github.issue,
+            status: issue.state,
+          },
+        };
+
+        // If the issue has any updates with the assignee
+        if (issue.assignee) {
+          // If there are no previous assignees or the task was not assigned before
+          if (!updatedTaskData.github.issue.assignee || !updatedTaskData.assignee) {
+            const user = await getIssueAssigneeRdsInfo(issue.assignee.login);
+
+            updatedTaskData.github.issue.assignee = issue.assignee.login;
+            updatedTaskData.github.issue.assigneeRdsInfo = user;
+          }
+        }
+        // If the issue assignee was removed and task was not assigned
+        else if (updatedTaskData.github.issue.assignee && !updatedTaskData.assignee) {
+          delete updatedTaskData.github.issue.assignee;
+          delete updatedTaskData.github.issue.assigneeRdsInfo;
+        }
+
+        if (issue.state === "closed") {
+          updatedTaskData.github.issue.closedAt = issue.closed_at;
+        }
+
+        await tasks.updateTask(updatedTaskData, taskData.id);
+        return res.json({
+          message: "Task updated successfully",
+        });
+      } else {
+        return res.json({
+          message: "No task was found for the updated issue",
+        });
+      }
+    }
+    return res.json({
+      message: "No issue was updated",
+    });
+  } catch (err) {
+    logger.error(`Error while retriving issues ${err}`);
+    return res.boom.badImplementation(ERROR_MESSAGE);
+  }
+};
+
+module.exports = {
+  getIssues,
+  issueUpdates,
+};

--- a/controllers/issues.js
+++ b/controllers/issues.js
@@ -4,7 +4,7 @@ const { getIssueAssigneeRdsInfo } = require("../models/users");
 const { SOMETHING_WENT_WRONG } = require("../constants/errorMessages");
 
 /**
- * Get the  issues of the repo
+ * Get the issues of the repo
  * @param {Object} req - Express request object
  * @param {Object} res - Express response object
  */

--- a/controllers/tasks.js
+++ b/controllers/tasks.js
@@ -2,7 +2,7 @@ const tasks = require("../models/tasks");
 const { TASK_STATUS, TASK_STATUS_OLD } = require("../constants/tasks");
 const { addLog } = require("../models/logs");
 const { USER_STATUS } = require("../constants/users");
-const { addOrUpdate, fetchUser } = require("../models/users");
+const { addOrUpdate, getRdsUserInfoByGitHubUsername } = require("../models/users");
 const { OLD_ACTIVE, OLD_BLOCKED, OLD_PENDING } = TASK_STATUS_OLD;
 const { IN_PROGRESS, BLOCKED, SMOKE_TESTING, ASSIGNED } = TASK_STATUS;
 const { INTERNAL_SERVER_ERROR, SOMETHING_WENT_WRONG } = require("../constants/errorMessages");
@@ -24,12 +24,8 @@ const addNewTask = async (req, res) => {
     // Retrieve the issue assignee's RDS user info
     if (Object.keys(body).includes("github")) {
       if (Object.keys(body.github.issue).includes("assignee")) {
-        const { user } = await fetchUser({ githubUsername: body.github.issue.assignee });
-        body.github.issue.assigneeRdsInfo = {
-          username: user.username ?? "",
-          firstName: user.first_name ?? "",
-          lastName: user.last_name ?? "",
-        };
+        const user = await getRdsUserInfoByGitHubUsername(body.github.issue.assignee);
+        body.github.issue.assigneeRdsInfo = user;
       }
     }
 

--- a/middlewares/validators/tasks.js
+++ b/middlewares/validators/tasks.js
@@ -50,14 +50,6 @@ const createTask = async (req, res, next) => {
             assignee: joi.string().optional(),
             id: joi.number().optional(),
             closedAt: joi.string().optional(),
-            assigneeRdsInfo: joi
-              .object()
-              .keys({
-                firstName: joi.string(),
-                lastName: joi.string(),
-                username: joi.string(),
-              })
-              .optional(),
           }),
         })
         .optional(),

--- a/middlewares/validators/tasks.js
+++ b/middlewares/validators/tasks.js
@@ -42,6 +42,25 @@ const createTask = async (req, res, next) => {
         })
         .optional(),
       isNoteworthy: joi.bool().optional(),
+      github: joi
+        .object()
+        .keys({
+          issue: joi.object().keys({
+            status: joi.string().optional(),
+            assignee: joi.string().optional(),
+            id: joi.number().optional(),
+            closedAt: joi.string().optional(),
+            assigneeRdsInfo: joi
+              .object()
+              .keys({
+                firstName: joi.string(),
+                lastName: joi.string(),
+                username: joi.string(),
+              })
+              .optional(),
+          }),
+        })
+        .optional(),
     });
 
   try {

--- a/models/tasks.js
+++ b/models/tasks.js
@@ -126,7 +126,7 @@ const fetchTaskByIssueId = async (issueId) => {
 
     return taskData;
   } catch (err) {
-    logger.error("Error retrieving task data", err);
+    logger.error("Error retrieving task data from issue Id", err);
     throw err;
   }
 };

--- a/models/tasks.js
+++ b/models/tasks.js
@@ -106,6 +106,32 @@ const fetchTask = async (taskId) => {
 };
 
 /**
+ * Fetch a task against the IssueId
+ * @param taskId { string }: taskid which will be used to fetch the task
+ * @return {Promise<taskData|Object>}
+ */
+const fetchTaskByIssueId = async (issueId) => {
+  try {
+    const task = await tasksModel.where("github.issue.id", "==", issueId).get();
+    const [taskDoc] = task.docs;
+    let updatedTaskData;
+    if (taskDoc) {
+      updatedTaskData = { id: taskDoc.id, ...taskDoc.data() };
+    }
+    const taskData = await fromFirestoreData(updatedTaskData);
+
+    if (taskData?.status) {
+      taskData.status = TASK_STATUS[taskData.status.toUpperCase()] || task.status;
+    }
+
+    return taskData;
+  } catch (err) {
+    logger.error("Error retrieving task data", err);
+    throw err;
+  }
+};
+
+/**
  * Fetch assigned self task
  * @param taskId { string }: taskId which will be used to fetch the task
  * @param id { string }: id to check task is assigned to self or not
@@ -326,4 +352,5 @@ module.exports = {
   fetchSelfTask,
   fetchSkillLevelTask,
   overdueTasks,
+  fetchTaskByIssueId,
 };

--- a/models/tasks.js
+++ b/models/tasks.js
@@ -107,7 +107,7 @@ const fetchTask = async (taskId) => {
 
 /**
  * Fetch a task against the IssueId
- * @param taskId { string }: taskid which will be used to fetch the task
+ * @param taskId { string }: issueId which will be used to fetch the task
  * @return {Promise<taskData|Object>}
  */
 const fetchTaskByIssueId = async (issueId) => {

--- a/models/tasks.js
+++ b/models/tasks.js
@@ -121,7 +121,7 @@ const fetchTaskByIssueId = async (issueId) => {
     const taskData = await fromFirestoreData(updatedTaskData);
 
     if (taskData?.status) {
-      taskData.status = TASK_STATUS[taskData.status.toUpperCase()] || task.status;
+      taskData.status = TASK_STATUS[taskData.status.toUpperCase()];
     }
 
     return taskData;

--- a/models/tasks.js
+++ b/models/tasks.js
@@ -4,7 +4,6 @@ const ItemModel = firestore.collection("itemTags");
 const userUtils = require("../utils/users");
 const { fromFirestoreData, toFirestoreData, buildTasks } = require("../utils/tasks");
 const { TASK_TYPE, TASK_STATUS, TASK_STATUS_OLD } = require("../constants/tasks");
-const { getRdsUserInfoByGitHubUsername } = require("./users");
 const { IN_PROGRESS, BLOCKED, SMOKE_TESTING, COMPLETED } = TASK_STATUS;
 const { OLD_ACTIVE, OLD_BLOCKED, OLD_PENDING, OLD_COMPLETED } = TASK_STATUS_OLD;
 /**
@@ -52,27 +51,7 @@ const fetchTasks = async () => {
     const tasks = buildTasks(tasksSnapshot);
     const promises = tasks.map(async (task) => fromFirestoreData(task));
     const updatedTasks = await Promise.all(promises);
-    const fetchTasksWithRdsAssigneeInfo = updatedTasks.map(async (task) => {
-      if (Object.keys(task).includes("github")) {
-        if (Object.keys(task.github.issue).includes("assignee")) {
-          return {
-            ...task,
-            github: {
-              ...task.github,
-              issue: {
-                ...task.github.issue,
-                assigneeRdsInfo: await getRdsUserInfoByGitHubUsername(task.github.issue.assignee),
-              },
-            },
-          };
-        }
-      }
-      return task;
-    });
-
-    const tasksWithRdsAssigneeInfo = await Promise.all(fetchTasksWithRdsAssigneeInfo);
-
-    const taskList = tasksWithRdsAssigneeInfo.map((task) => {
+    const taskList = updatedTasks.map((task) => {
       task.status = TASK_STATUS[task.status.toUpperCase()] || task.status;
       return task;
     });

--- a/models/tasks.js
+++ b/models/tasks.js
@@ -107,7 +107,7 @@ const fetchTask = async (taskId) => {
 
 /**
  * Fetch a task against the IssueId
- * @param taskId { string }: issueId which will be used to fetch the task
+ * @param issueId { number }: issueId which will be used to fetch the task
  * @return {Promise<taskData|Object>}
  */
 const fetchTaskByIssueId = async (issueId) => {

--- a/models/users.js
+++ b/models/users.js
@@ -345,9 +345,9 @@ const getRdsUserInfoByGitHubUsername = async (githubUsername) => {
   const { user } = await fetchUser({ githubUsername });
 
   return {
-    firstName: user.first_name,
-    lastName: user.last_name,
-    username: user.username,
+    firstName: user.first_name ?? "",
+    lastName: user.last_name ?? "",
+    username: user.username ?? "",
   };
 };
 

--- a/models/users.js
+++ b/models/users.js
@@ -341,7 +341,7 @@ const fetchUserSkills = async (id) => {
   }
 };
 
-const getIssueAssigneeRdsInfo = async (githubUsername) => {
+const getRdsUserInfoByGitHubUsername = async (githubUsername) => {
   const { user } = await fetchUser({ githubUsername });
 
   return {
@@ -421,7 +421,7 @@ module.exports = {
   getJoinData,
   getSuggestedUsers,
   fetchUserSkills,
-  getIssueAssigneeRdsInfo,
+  getRdsUserInfoByGitHubUsername,
   fetchUsers,
   getUsersBasedOnFilter,
 };

--- a/models/users.js
+++ b/models/users.js
@@ -349,7 +349,7 @@ const getIssueAssigneeRdsInfo = async (githubUsername) => {
     lastName: user.last_name,
     username: user.username,
   };
-}
+};
 
 /**
  * Fetches user data based on the filter query

--- a/models/users.js
+++ b/models/users.js
@@ -181,7 +181,7 @@ const fetchUsers = async (query) => {
  * @param { Object }: Object with username and userId, any of the two can be used
  * @return {Promise<{userExists: boolean, user: <userModel>}|{userExists: boolean, user: <userModel>}>}
  */
-const fetchUser = async ({ userId = null, username = null }) => {
+const fetchUser = async ({ userId = null, username = null, githubUsername = null }) => {
   try {
     let userData, id;
     if (username) {
@@ -195,6 +195,12 @@ const fetchUser = async ({ userId = null, username = null }) => {
       const user = await userModel.doc(userId).get();
       id = userId;
       userData = user.data();
+    } else if (githubUsername) {
+      const user = await userModel.where("github_id", "==", githubUsername).limit(1).get();
+      user.forEach((doc) => {
+        id = doc.id;
+        userData = doc.data();
+      });
     }
     return {
       userExists: !!userData,
@@ -292,6 +298,16 @@ const fetchUserSkills = async (id) => {
   }
 };
 
+const getIssueAssigneeRdsInfo = async (githubUsername) => {
+  const { user } = await fetchUser({ githubUsername });
+
+  return {
+    firstName: user.first_name,
+    lastName: user.last_name,
+    username: user.username,
+  };
+};
+
 module.exports = {
   addOrUpdate,
   fetchUsers,
@@ -304,4 +320,5 @@ module.exports = {
   getJoinData,
   getSuggestedUsers,
   fetchUserSkills,
+  getIssueAssigneeRdsInfo,
 };

--- a/routes/index.js
+++ b/routes/index.js
@@ -24,5 +24,6 @@ app.use("/levels", require("./levels.js"));
 app.use("/items", require("./items.js"));
 app.use("/cache", require("./cloudflareCache.js"));
 app.use("/external-accounts", require("./external-accounts.js"));
+app.use("/issues", require("./issues.js"));
 
 module.exports = app;

--- a/routes/issues.js
+++ b/routes/issues.js
@@ -1,6 +1,6 @@
 const express = require("express");
-const router = express.Router();
 const issues = require("../controllers/issues");
+const router = express.Router();
 
 router.get("/", issues.getIssues);
 router.post("/updates", issues.issueUpdates);

--- a/routes/issues.js
+++ b/routes/issues.js
@@ -1,0 +1,8 @@
+const express = require("express");
+const router = express.Router();
+const issues = require("../controllers/issues");
+
+router.get("/:repo", issues.getIssues);
+router.post("/updates", issues.issueUpdates);
+
+module.exports = router;

--- a/routes/issues.js
+++ b/routes/issues.js
@@ -2,7 +2,7 @@ const express = require("express");
 const router = express.Router();
 const issues = require("../controllers/issues");
 
-router.get("/:repo", issues.getIssues);
+router.get("/", issues.getIssues);
 router.post("/updates", issues.issueUpdates);
 
 module.exports = router;

--- a/services/githubService.js
+++ b/services/githubService.js
@@ -180,7 +180,7 @@ const fetchIssues = async () => {
       {
         Accept: "application/vnd.github+json",
         Authorization: `Bearer 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`,
-        org: "Real-Dev-Squad",
+        org: config.get("githubApi.org"),
       }
     );
     return res;

--- a/services/githubService.js
+++ b/services/githubService.js
@@ -179,7 +179,8 @@ const fetchIssues = async () => {
       },
       {
         Accept: "application/vnd.github+json",
-        Authorization: `Bearer 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`,
+        // TODO: replace <AUTH-TOKEN> with RDS org PAT
+        Authorization: `Bearer <AUTH-TOKEN>`,
         org: config.get("githubApi.org"),
       }
     );

--- a/services/githubService.js
+++ b/services/githubService.js
@@ -84,8 +84,13 @@ const getGithubURL = (searchParams, resultsOptions = {}) => {
  * @access private
  * @param url {string} - URL on github to call
  */
-function getFetch(url, params = null, data = null, headers = null) {
-  return utils.fetch(url, "get", params, data, headers);
+function getFetch(url) {
+  return utils.fetch(url, "get", null, null, null, {
+    auth: {
+      username: config.get("githubOauth.clientId"),
+      password: config.get("githubOauth.clientSecret"),
+    },
+  });
 }
 
 /**

--- a/services/githubService.js
+++ b/services/githubService.js
@@ -1,6 +1,5 @@
 const utils = require("../utils/fetch");
 const { fetchUser } = require("../models/users");
-const ORG = "Real-Dev-Squad";
 
 /**
  * Extracts only the necessary details required from the object returned by Github API
@@ -171,7 +170,7 @@ const fetchIssues = async () => {
     const baseURL = config.get("githubApi.baseUrl");
     const issues = "/issues";
     const urlObj = new URL(baseURL);
-    urlObj.pathname = "orgs" + "/" + ORG + issues;
+    urlObj.pathname = "orgs" + "/" + config.get("githubApi.org") + issues;
     const createdURL = urlObj.href;
     const res = await getFetchWithAuthToken(
       createdURL,

--- a/services/issuesService.js
+++ b/services/issuesService.js
@@ -4,11 +4,11 @@ const githubService = require("./githubService");
  * @param {string} username
  */
 
-const getRepoIssues = async () => {
+const getOrgIssues = async () => {
   const data = await githubService.fetchIssues();
   return data;
 };
 
 module.exports = {
-  getRepoIssues,
+  getOrgIssues,
 };

--- a/services/issuesService.js
+++ b/services/issuesService.js
@@ -4,8 +4,8 @@ const githubService = require("./githubService");
  * @param {string} username
  */
 
-const getRepoIssues = async (repo) => {
-  const data = await githubService.fetchIssues(repo);
+const getRepoIssues = async () => {
+  const data = await githubService.fetchIssues();
   return data;
 };
 

--- a/services/issuesService.js
+++ b/services/issuesService.js
@@ -1,0 +1,14 @@
+const githubService = require("./githubService");
+/**
+ * Get the contributions of the user
+ * @param {string} username
+ */
+
+const getRepoIssues = async (repo) => {
+  const data = await githubService.fetchIssues(repo);
+  return data;
+};
+
+module.exports = {
+  getRepoIssues,
+};

--- a/test/unit/models/users.test.js
+++ b/test/unit/models/users.test.js
@@ -72,5 +72,20 @@ describe("users", function () {
       expect(isNewUser).to.equal(true);
       expect(updatedIsNewUserFlag).to.equal(false);
     });
+
+    it("should return the user information when github username is passed", async function () {
+      const userData = userDataArray[0];
+      await users.addOrUpdate(userData);
+      const githubUsername = "ankur";
+      const { user, userExists } = await users.fetchUser({ githubUsername });
+      expect(user).to.haveOwnProperty("id");
+      expect(user).to.haveOwnProperty("username");
+      expect(user).to.haveOwnProperty("first_name");
+      expect(user).to.haveOwnProperty("last_name");
+
+      expect(user.first_name).to.equal(userData.first_name);
+      expect(user.last_name).to.equal(userData.last_name);
+      expect(userExists).to.equal(true);
+    });
   });
 });

--- a/test/unit/services/githubService.test.js
+++ b/test/unit/services/githubService.test.js
@@ -44,4 +44,11 @@ describe("githubService", function () {
       );
     });
   });
+
+  describe("fetchIssues", function () {
+    it("Should generate the correct url", async function () {
+      const response = await githubService.fetchIssues();
+      expect(response).to.be.equal(`https://api.github.com/orgs/Real-Dev-Squad/issues`);
+    });
+  });
 });


### PR DESCRIPTION
# Feat: One-Click Issue to Task Conversion

- The following PR introduces Issue API routes and controllers for the [One-Click task conversion feature](https://github.com/Real-Dev-Squad/todo-action-items/issues/92).
  - `GET` route to fetch all the issues on GitHub across all repositories from RDS's organization.
  - `POST` route that receives updates from RDS organization webhook when there's a change in any issue.
  - Issues controller to:
    - Fetch and send issues
    - Receive issue event changes and update associated task if found.

- The changes also include:
  - Models to fetch:
    - Task associated with an issue id 
    -  Retrieve RDS user information by GitHub username.
  - Test cases to validate:
     - GitHub service to fetch issues  
     - Users model to fetch RDS user information with GitHub username