### PR TITLE
add and skip tests for the mark standup api

### DIFF
--- a/test/fixtures/standup/standup.js
+++ b/test/fixtures/standup/standup.js
@@ -1,0 +1,15 @@
+module.exports = () => {
+  return [
+    {
+      timestamp: "2023-04-20T16:23:58Z",
+      yesterday: "Did something",
+      today: "will do something",
+      blockers: "nothing",
+    },
+    {
+      yesterday: "Did something",
+      today: "will do something",
+      blockers: "nothing",
+    },
+  ];
+};

--- a/test/integration/standup.test.js
+++ b/test/integration/standup.test.js
@@ -1,6 +1,4 @@
 const chai = require("chai");
-const { object } = require("joi");
-const { expect } = chai;
 
 const app = require("../../server");
 
@@ -16,6 +14,8 @@ const standupData = require("../fixtures/standup/standup");
 
 const cookieName = config.get("userToken.cookieName");
 const superUser = userData[4];
+const { object } = require("joi");
+const { expect } = chai;
 
 // eslint-disable-next-line mocha/no-skipped-tests
 describe.skip("Test standup api", function () {

--- a/test/integration/standup.test.js
+++ b/test/integration/standup.test.js
@@ -4,7 +4,7 @@ const { expect } = chai;
 
 const app = require("../../server");
 const addUser = require("../utils/addUser");
-const userQuery = require("../models/users");
+const userQuery = require("../../models/users");
 const userData = require("../fixtures/user/user")();
 const authService = require("../../services/authService");
 const cleanDb = require("../utils/cleanDb");

--- a/test/integration/standup.test.js
+++ b/test/integration/standup.test.js
@@ -52,6 +52,27 @@ describe.skip("Test standup api", function () {
           return done();
         });
     });
+    it("Checks superuser can un-mark a user from monitoring", function (done) {
+      chai
+        .request(app)
+        .post(`/standup/${userId}`)
+        .set("Cookie", `${cookieName}=${superUserAuthToken}`)
+        .send({
+          monitor: false,
+        })
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+          const userData = userQuery.fetchUser({ userId: userId });
+          expect(res).to.have.status(200);
+          expect(res.body).to.be.a(object);
+          expect(res.body.message).to.equal("User marked for standup successfully.");
+          expect(userData.roles).to.have.property("monitored");
+          expect(userData.roles.monitored).to.be.equal(false);
+          return done();
+        });
+    });
     it("Should return 401 for other/un-authenticated users", function (done) {
       chai
         .request(app)

--- a/test/integration/standup.test.js
+++ b/test/integration/standup.test.js
@@ -67,7 +67,7 @@ describe.skip("Test standup api", function () {
           const userData = userQuery.fetchUser({ userId: userId });
           expect(res).to.have.status(200);
           expect(res.body).to.be.a(object);
-          expect(res.body.message).to.equal("User marked for standup successfully.");
+          expect(res.body.message).to.equal("User unmarked for standup successfully.");
           expect(userData.roles).to.have.property("monitored");
           expect(userData.roles.monitored).to.be.equal(false);
           return done();
@@ -95,13 +95,14 @@ describe.skip("Test standup api", function () {
       chai
         .request(app)
         .post(`/standup/123`)
-        .set("Cookie", `${cookieName}=${jwt}`)
+        .set("Cookie", `${cookieName}=${superUserAuthToken}`)
         .end((err, res) => {
           if (err) {
             return done(err);
           }
           expect(res).to.have.status(404);
           expect(res.body).to.be.a(object);
+          expect(res.body.message).to.equal("UserId not found");
           return done();
         });
     });
@@ -118,10 +119,7 @@ describe.skip("Test standup api", function () {
           }
           expect(res).to.have.status(200);
           expect(res.body).to.be.a(object);
-          expect(res.body).to.have.property("yesterday");
-          expect(res.body).to.have.property("today");
-          expect(res.body).to.have.property("blockers");
-          expect(res.body).to.have.property("timestamp");
+          expect(res.body).to.include.keys(["yesterday", "today", "blockers", "timestamp"]);
           return done();
         });
     });
@@ -136,6 +134,7 @@ describe.skip("Test standup api", function () {
           }
           expect(res).to.have.status(404);
           expect(res.body).to.be.a(object);
+          expect(res.body.message).to.equal("UserId not found");
           return done();
         });
     });

--- a/test/integration/standup.test.js
+++ b/test/integration/standup.test.js
@@ -61,7 +61,7 @@ describe.skip("Test standup api", function () {
     it("Should return 404 for invalid user id", function (done) {
       chai
         .request(app)
-        .post(`/standup/${userId}`)
+        .post(`/standup/123`)
         .set("Cookie", `${cookieName}=${jwt}`)
         .end((err, res) => {
           if (err) {

--- a/test/integration/standup.test.js
+++ b/test/integration/standup.test.js
@@ -3,11 +3,15 @@ const { object } = require("joi");
 const { expect } = chai;
 
 const app = require("../../server");
-const addUser = require("../utils/addUser");
-const userQuery = require("../../models/users");
-const userData = require("../fixtures/user/user")();
+
 const authService = require("../../services/authService");
+
+const userQuery = require("../../models/users");
+
+const addUser = require("../utils/addUser");
 const cleanDb = require("../utils/cleanDb");
+
+const userData = require("../fixtures/user/user")();
 const standupData = require("../fixtures/standup/standup");
 
 const cookieName = config.get("userToken.cookieName");
@@ -61,9 +65,7 @@ describe.skip("Test standup api", function () {
           monitor: false,
         })
         .end((err, res) => {
-          if (err) {
-            return done(err);
-          }
+          if (err) return done(err);
           const userData = userQuery.fetchUser({ userId: userId });
           expect(res).to.have.status(200);
           expect(res.body).to.be.a(object);
@@ -82,9 +84,7 @@ describe.skip("Test standup api", function () {
           monitor: true,
         })
         .end((err, res) => {
-          if (err) {
-            return done(err);
-          }
+          if (err) return done(err);
           expect(res).to.have.status(401);
           expect(res.body).to.be.a(object);
           expect(res.body.message).to.equal("Unauthenticated User");
@@ -97,9 +97,7 @@ describe.skip("Test standup api", function () {
         .post(`/standup/123`)
         .set("Cookie", `${cookieName}=${superUserAuthToken}`)
         .end((err, res) => {
-          if (err) {
-            return done(err);
-          }
+          if (err) return done(err);
           expect(res).to.have.status(404);
           expect(res.body).to.be.a(object);
           expect(res.body.message).to.equal("UserId not found");
@@ -114,9 +112,7 @@ describe.skip("Test standup api", function () {
         .request(app)
         .get(`/standup/${userId}`)
         .end((err, res) => {
-          if (err) {
-            return done(err);
-          }
+          if (err) return done(err);
           expect(res).to.have.status(200);
           expect(res.body).to.be.a(object);
           expect(res.body).to.include.keys(["yesterday", "today", "blockers", "timestamp"]);
@@ -129,9 +125,7 @@ describe.skip("Test standup api", function () {
         .request(app)
         .get("/standup/123")
         .end((err, res) => {
-          if (err) {
-            return done(err);
-          }
+          if (err) return done(err);
           expect(res).to.have.status(404);
           expect(res.body).to.be.a(object);
           expect(res.body.message).to.equal("UserId not found");
@@ -148,9 +142,7 @@ describe.skip("Test standup api", function () {
         .set("Cookie", `${cookieName}=${jwt}`)
         .send(standupData()[0])
         .end((err, res) => {
-          if (err) {
-            return done(err);
-          }
+          if (err) return done(err);
           expect(res).to.have.status(200);
           expect(res.body).to.be.a(object);
           expect(res.body).to.have.property("message");
@@ -166,9 +158,7 @@ describe.skip("Test standup api", function () {
         .set("Cookie", `${cookieName}=${jwt}`)
         .send(standupData()[1])
         .end((err, res) => {
-          if (err) {
-            return done(err);
-          }
+          if (err) return done(err);
           expect(res).to.have.status(400);
           expect(res.body).to.be.a(object);
           expect(res.body).to.have.property("message");
@@ -183,9 +173,7 @@ describe.skip("Test standup api", function () {
         .post("/standup")
         .send(standupData[0])
         .end((err, res) => {
-          if (err) {
-            return done(err);
-          }
+          if (err) return done(err);
           expect(res).to.have.status(401);
           expect(res.body).to.be.a(object);
           expect(res.body.message).to.equal("Unauthenticated User");

--- a/test/integration/standup.test.js
+++ b/test/integration/standup.test.js
@@ -31,7 +31,7 @@ describe.skip("Test standup api", function () {
     it("Superuser can mark a user as monitored", function (done) {
       chai
         .request(app)
-        .post("/standup/:id")
+        .post(`/standup/${userId}`)
         .set("Cookie", `${cookieName}=${superUserAuthToken}`)
         .end((err, res) => {
           if (err) {
@@ -46,7 +46,7 @@ describe.skip("Test standup api", function () {
     it("Should return 401 for other/un-authenticated users", function (done) {
       chai
         .request(app)
-        .post("/standup/:id")
+        .post(`/standup/${userId}`)
         .set("Cookie", `${cookieName}=${jwt}`)
         .end((err, res) => {
           if (err) {

--- a/test/integration/standup.test.js
+++ b/test/integration/standup.test.js
@@ -61,7 +61,7 @@ describe.skip("Test standup api", function () {
     it("Should return 404 for invalid user id", function (done) {
       chai
         .request(app)
-        .post("/standup/:id")
+        .post(`/standup/${userId}`)
         .set("Cookie", `${cookieName}=${jwt}`)
         .end((err, res) => {
           if (err) {

--- a/test/integration/standup.test.js
+++ b/test/integration/standup.test.js
@@ -1,0 +1,76 @@
+const chai = require("chai");
+const app = require("../../server");
+const addUser = require("../utils/addUser");
+const userData = require("../fixtures/user/user")();
+const authService = require("../../services/authService");
+const cleanDb = require("../utils/cleanDb");
+const { object } = require("joi");
+const { expect } = chai;
+
+const cookieName = config.get("userToken.cookieName");
+const superUser = userData[4];
+
+// eslint-disable-next-line mocha/no-skipped-tests
+describe.skip("Test standup api", function () {
+  let superUserId;
+  let superUserAuthToken;
+  let jwt;
+  let userId = "";
+  beforeEach(async function () {
+    userId = await addUser();
+    jwt = authService.generateAuthToken({ userId });
+    superUserId = await addUser(superUser);
+    superUserAuthToken = authService.generateAuthToken({ userId: superUserId });
+  });
+
+  afterEach(async function () {
+    await cleanDb();
+  });
+
+  describe("Test the mark api", function () {
+    it("Superuser can mark a user as monitored", function (done) {
+      chai
+        .request(app)
+        .post("/standup/:id")
+        .set("Cookie", `${cookieName}=${superUserAuthToken}`)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+          expect(res).to.have.status(200);
+          expect(res.body).to.be.a(object);
+          expect(res.body.message).to.equal("User marked for standup successfully.");
+          return done();
+        });
+    });
+    it("Should return 401 for other/un-authenticated users", function (done) {
+      chai
+        .request(app)
+        .post("/standup/:id")
+        .set("Cookie", `${cookieName}=${jwt}`)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+          expect(res).to.have.status(401);
+          expect(res.body).to.be.a(object);
+          expect(res.body.message).to.equal("Unauthenticated User");
+          return done();
+        });
+    });
+    it("Should return 404 for invalid user id", function (done) {
+      chai
+        .request(app)
+        .post("/standup/:id")
+        .set("Cookie", `${cookieName}=${jwt}`)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+          expect(res).to.have.status(404);
+          expect(res.body).to.be.a(object);
+          return done();
+        });
+    });
+  });
+});


### PR DESCRIPTION
# Standup API Tests

This pull request includes tests for the standup API. The standup API has three parts: 

1. **Marking a user for standup**, which is a superuser feature. This allows a superuser to mark a user as monitored for standup, meaning that the user will be expected to give a standup update every day.
2. **Saving a user's standup**, which is an authenticated route. This allows a user to save their daily standup update.
3. **Getting a user's standup**, which is accessible throughout as in the future it will be retrieved via Discord slash commands. This allows anyone to view a user's standup updates.

The tests are being pushed and skipped for now to ignore GitHub warnings since the feature does not exist yet. These tests will promote test-driven development during the development of the feature, ensuring that the API is functioning as intended and allowing developers to make any necessary changes before it is deployed.
