### PR TITLE
add and skip tests for the progress updates API

### DIFF
--- a/test/fixtures/progressUpdates/progressUpdates.js
+++ b/test/fixtures/progressUpdates/progressUpdates.js
@@ -1,0 +1,16 @@
+module.exports = () => {
+  return [
+    {
+      timestamp: "2023-04-20T16:23:58Z",
+      progress: "some progress",
+      plan: "some plan",
+      blockers: "Some blockers",
+    },
+    {
+      timestamp: "2023-04-20T16:23:58Z",
+      progress: "some progress",
+      plan: "some plan",
+      blockers: "Some blockers",
+    },
+  ];
+};

--- a/test/fixtures/tasks/tasks.js
+++ b/test/fixtures/tasks/tasks.js
@@ -67,5 +67,17 @@ module.exports = () => {
 
       isNoteworthy: true,
     },
+    {
+      title: "check is task form is working",
+      purpose: "test",
+      type: "feature",
+      assignee: adminuser.username,
+      createdBy: "nikhil",
+      status: "AVAILABLE",
+      percentCompleted: 50,
+      endsOn: 1650032259,
+      startedOn: 1644753600,
+      monitored: true,
+    },
   ];
 };

--- a/test/integration/progressUpdates.test.js
+++ b/test/integration/progressUpdates.test.js
@@ -1,5 +1,5 @@
 const chai = require("chai");
-const Joi = require("joi");
+const joi = require("joi");
 
 const app = require("../../server");
 
@@ -16,7 +16,7 @@ const progressData = require("../fixtures/progressUpdates/progressUpdates")();
 
 const cookieName = config.get("userToken.cookieName");
 const superUser = userData[4];
-const { object } = Joi;
+const { object } = joi;
 const { expect } = chai;
 
 // eslint-disable-next-line mocha/no-skipped-tests

--- a/test/integration/progressUpdates.test.js
+++ b/test/integration/progressUpdates.test.js
@@ -1,0 +1,203 @@
+const chai = require("chai");
+
+const app = require("../../server");
+
+const authService = require("../../services/authService");
+
+const tasks = require("../../models/tasks");
+
+const addUser = require("../utils/addUser");
+const cleanDb = require("../utils/cleanDb");
+
+const userData = require("../fixtures/user/user")();
+const taskData = require("../fixtures/tasks/tasks")();
+const progressData = require("../fixtures/progressUpdates/progressUpdates")();
+
+const cookieName = config.get("userToken.cookieName");
+const superUser = userData[4];
+const { object } = require("joi");
+const { expect } = chai;
+
+// eslint-disable-next-line mocha/no-skipped-tests
+describe.skip("Test Progress Updates API", function () {
+  let superUserId;
+  let superUserAuthToken;
+  let jwt;
+  let taskId;
+  let userId = "";
+  beforeEach(async function () {
+    userId = await addUser();
+    jwt = authService.generateAuthToken({ userId });
+    superUserId = await addUser(superUser);
+    superUserAuthToken = authService.generateAuthToken({ userId: superUserId });
+    taskId = tasks.updateTask(taskData[0]);
+  });
+
+  afterEach(async function () {
+    await cleanDb();
+  });
+
+  describe("Test the mark api", function () {
+    it("Marked the task as monitored by superuser", function (done) {
+      chai
+        .request(app)
+        .post(`/progressupdates/${taskId}`)
+        .set("Cookie", `${cookieName}=${superUserAuthToken}`)
+        .send({
+          monitor: true,
+          frequency: 2,
+        })
+        .end((err, res) => {
+          if (err) return done(err);
+          expect(res).to.have.status(200);
+          expect(res.body).to.be.a(object);
+          expect(res.body).to.have.keys(["message", "id"]);
+          expect(res.body.id).to.be.equal(taskId);
+          expect(res.body.message).to.be.equal("task marked for progress updates");
+          const storedTask = tasks.fetchTask(taskId);
+          expect(storedTask.monitored).to.be.equal(true);
+          expect(storedTask.frequency).to.be.equal(2);
+          return done();
+        });
+    });
+
+    it("Unmarked the task as monitored by superuser", function (done) {
+      taskId = tasks.updateTask(taskData[5]);
+      chai
+        .request(app)
+        .post(`/progressupdates/${taskId}`)
+        .set("Cookie", `${cookieName}=${superUserAuthToken}`)
+        .send({
+          monitor: false,
+        })
+        .end((err, res) => {
+          if (err) return done(err);
+          expect(res).to.have.status(200);
+          expect(res.body).to.be.a(object);
+          expect(res.body).to.have.keys(["message", "id"]);
+          expect(res.body.id).to.be.equal(taskId);
+          expect(res.body.message).to.be.equal("task unmarked for progress updates");
+          const storedTask = tasks.fetchTask(taskId);
+          expect(storedTask.monitored).to.be.equal(false);
+          return done();
+        });
+    });
+
+    it("Returns 401 for normal users", function (done) {
+      taskId = tasks.updateTask(taskData[5]);
+      chai
+        .request(app)
+        .post(`/progressupdates/${taskId}`)
+        .set("Cookie", `${cookieName}=${jwt}`)
+        .send({
+          monitor: false,
+        })
+        .end((err, res) => {
+          if (err) return done(err);
+          expect(res).to.have.status(401);
+          expect(res.body.message).to.be.equal("Unauthenticated User");
+          return done();
+        });
+    });
+
+    it("Returns 404 for invalid task id's", function (done) {
+      chai
+        .request(app)
+        .post(`/progressupdates/123`)
+        .set("Cookie", `${cookieName}=${jwt}`)
+        .send({
+          monitor: false,
+        })
+        .end((err, res) => {
+          if (err) return done(err);
+          expect(res).to.have.status(404);
+          expect(res.body.message).to.be.equal("Task id not found");
+          return done();
+        });
+    });
+  });
+
+  describe("Test the save api", function () {
+    it("Saves the progress updates", function (done) {
+      chai
+        .request(app)
+        .post(`progressupdates/save/${taskId}`)
+        .set("Cookie", `${cookieName}=${jwt}`)
+        .send(progressData[0])
+        .end((err, res) => {
+          if (err) return done(err);
+          expect(res).to.have.status(200);
+          expect(res.body.message).to.be.equal("task update added successfully");
+          expect(res.body.id).to.be.equal(taskId);
+          return done();
+        });
+    });
+
+    it("Gives 400 for invalid request body", function (done) {
+      chai
+        .request(app)
+        .post(`progressupdates/save/${taskId}`)
+        .set("Cookie", `${cookieName}=${jwt}`)
+        .send(progressData[1])
+        .end((err, res) => {
+          if (err) return done(err);
+          expect(res).to.have.status(400);
+          expect(res.body.message).to.be.equal("timestamp is required");
+          return done();
+        });
+    });
+
+    it("Gives 401 for unauthenticated user", function (done) {
+      chai
+        .request(app)
+        .post(`progressupdates/save/${taskId}`)
+        .send(progressData[1])
+        .end((err, res) => {
+          if (err) return done(err);
+          expect(res).to.have.status(401);
+          expect(res.body.message).to.be.equal("Unauthenticated user");
+          return done();
+        });
+    });
+
+    it("Gives 404 for invalid task id", function (done) {
+      chai
+        .request(app)
+        .post(`progressupdates/save/123`)
+        .set("Cookie", `${cookieName}=${jwt}`)
+        .send(progressData[0])
+        .end((err, res) => {
+          if (err) return done(err);
+          expect(res).to.have.status(404);
+          expect(res.body.message).to.be.equal("task id not found");
+          return done();
+        });
+    });
+  });
+
+  describe("Test the get Updates API", function () {
+    it("Returns the latest progress detail", function (done) {
+      chai
+        .request(app)
+        .get(`/progressupdates/${taskId}`)
+        .end((err, res) => {
+          if (err) return done(err);
+          expect(res).to.have.status(200);
+          expect(res.body).to.have.keys(["timestamp", "progress", "plan", "blockers"]);
+          return done();
+        });
+    });
+
+    it("Returns 404 for invalid task id", function (done) {
+      chai
+        .request(app)
+        .get(`/progressupdates/${taskId}`)
+        .end((err, res) => {
+          if (err) return done(err);
+          expect(res).to.have.status(404);
+          expect(res.body.message).to.be.equal("task id not found");
+          return done();
+        });
+    });
+  });
+});

--- a/test/integration/progressUpdates.test.js
+++ b/test/integration/progressUpdates.test.js
@@ -1,4 +1,5 @@
 const chai = require("chai");
+const Joi = require("joi");
 
 const app = require("../../server");
 
@@ -15,7 +16,7 @@ const progressData = require("../fixtures/progressUpdates/progressUpdates")();
 
 const cookieName = config.get("userToken.cookieName");
 const superUser = userData[4];
-const { object } = require("joi");
+const { object } = Joi;
 const { expect } = chai;
 
 // eslint-disable-next-line mocha/no-skipped-tests


### PR DESCRIPTION
### Navigation
| [Overview](https://github.com/Real-Dev-Squad/todo-action-items/issues/147#issue-1682398477) | [Activity Diagram](https://github.com/Real-Dev-Squad/todo-action-items/issues/147#issuecomment-1521132693) | [Features Breakdown](https://github.com/Real-Dev-Squad/todo-action-items/issues/147#issuecomment-1521142621) | [API Specifications](https://github.com/Real-Dev-Squad/todo-action-items/issues/147#issuecomment-1521279764) | [Other PRs raised](https://github.com/Real-Dev-Squad/todo-action-items/issues/147#issuecomment-1522728421)
|-----------|---------------------------------|----------------|------------------------|-------------------|

# Progress updates API Tests

This pull request includes tests for the progress updates API. The standup API has three parts: 

1. **Marking a task monitores**, which is a superuser feature. This allows a superuser to mark a task as monitored for updates, meaning that the user will be expected to give a standup update based on the frequency provided.
2. **Saving a task's progress**, which is an authenticated route. This allows a user to save their updates on the task.
3. **Getting a task's progress**, which is accessible throughout as in the future it will be retrieved via Discord slash commands. This allows anyone to view a task's updates.

The tests are being pushed and skipped for now to ignore GitHub warnings since the feature does not exist yet. These tests will promote test-driven development during the development of the feature, ensuring that the API is functioning as intended and allowing developers to make any necessary changes before it is deployed.
