### PR TITLE
add validators for the progress updates API

### DIFF
--- a/middlewares/validators/progressUpdates.js
+++ b/middlewares/validators/progressUpdates.js
@@ -1,0 +1,36 @@
+const Joi = require("joi");
+
+const validateMarkBody = async (req, res, next) => {
+  const schema = Joi.object({
+    monitor: Joi.boolean().required(),
+    frequency: Joi.number().integer().required(),
+  });
+  try {
+    await schema.validateAsync(req.body);
+    next();
+  } catch (error) {
+    logger.error(`Error validating markTask payload : ${error}`);
+    res.boom.badRequest(error.details[0].message);
+  }
+};
+
+const validateProgressBody = async (req, res, next) => {
+  const schema = Joi.object({
+    timestamp: Joi.string().required(),
+    progress: Joi.string().required(),
+    plan: Joi.string().required(),
+    blockers: Joi.string().required(),
+  });
+  try {
+    await schema.validateAsync(req.body);
+    next();
+  } catch (error) {
+    logger.error(`Error validating SaveProgress payload : ${error}`);
+    res.boom.badRequest(error.details[0].message);
+  }
+};
+
+module.exports = {
+  validateMarkBody,
+  validateProgressBody,
+};


### PR DESCRIPTION
### Navigation
| [Overview](https://github.com/Real-Dev-Squad/todo-action-items/issues/147#issue-1682398477) | [Activity Diagram](https://github.com/Real-Dev-Squad/todo-action-items/issues/147#issuecomment-1521132693) | [Features Breakdown](https://github.com/Real-Dev-Squad/todo-action-items/issues/147#issuecomment-1521142621) | [API Specifications](https://github.com/Real-Dev-Squad/todo-action-items/issues/147#issuecomment-1521279764) | [Other PRs raised](https://github.com/Real-Dev-Squad/todo-action-items/issues/147#issuecomment-1522728421)
|-----------|---------------------------------|----------------|------------------------|-------------------|

# Progress Updates Feature request validators

- Proper Joi validators have been added for the progress updates feature.
- There are two validators: one to check the marking task for updates API and another to check the progress updates sent in by the user.
- The pull request includes a commit that adds these validators to the `middlewares/validators/progressUpdates.js` file.
- The first validator, `validateMarkBody`, checks if the request body contains the required fields `monitor` and `frequency`.
- The second validator, `validateProgressBody`, checks if the request body contains the required fields `timestamp`, `progress`, `plan`, and `blockers`.
- These validators help ensure that the data sent to the API is in the correct format and meets the requirements for processing.