### PR TITLE
Feature: Search issues using GitHub Search API

### DIFF
--- a/controllers/issues.js
+++ b/controllers/issues.js
@@ -10,7 +10,15 @@ const { SOMETHING_WENT_WRONG } = require("../constants/errorMessages");
 
 const getIssues = async (req, res) => {
   try {
-    const issues = await issuesService.getOrgIssues();
+    const { q: queryString } = req.query;
+    let issues = {};
+    if (queryString) {
+      const searchedIssues = await issuesService.searchOrgIssues(queryString);
+      issues.data = searchedIssues?.data?.items ?? [];
+    } else {
+      issues = await issuesService.getOrgIssues();
+    }
+
     let issuesData = issues.data.length > 0 ? issues.data : [];
     issuesData = issuesData.filter((issue) => !Object.keys(issue).includes("pull_request"));
     issuesData = issuesData.map(async (issue) => {

--- a/services/githubService.js
+++ b/services/githubService.js
@@ -48,7 +48,7 @@ const extractPRdetails = (data) => {
  * @param searchParams {Object} - List of params to create github API URL
  * @param resultsOptions {Object} - Ordering and pagination of results
  */
-const getGithubURL = (searchParams, resultsOptions = {}) => {
+const getGithubURL = (searchParams, resultsOptions = {}, searchString) => {
   const baseURL = config.get("githubApi.baseUrl");
   const issuesAndPRsPath = "/search/issues";
 
@@ -65,7 +65,11 @@ const getGithubURL = (searchParams, resultsOptions = {}) => {
   const paramsStrArr = paramsObjArr.map(([key, value]) => `${key}:${value}`);
 
   // The string that can be entrered as text on Github website for simple search
-  const prsSearchText = paramsStrArr.join(" ");
+  let prsSearchText = paramsStrArr.join(" ");
+
+  if (searchString) {
+    prsSearchText = `${searchString} ${prsSearchText}`;
+  }
 
   urlObj.searchParams.append("q", prsSearchText);
 
@@ -178,7 +182,7 @@ const fetchMergedPRs = async (params = {}) => {
 };
 
 const fetchOpenIssues = async (params = {}) => {
-  const { perPage = 100, page = 1, searchParams = {}, resultOptions = {} } = params;
+  const { perPage = 100, page = 1, searchParams = {}, resultOptions = {}, searchString = "" } = params;
 
   try {
     const url = getGithubURL(
@@ -192,7 +196,8 @@ const fetchOpenIssues = async (params = {}) => {
         ...resultOptions,
         per_page: perPage,
         page,
-      }
+      },
+      searchString
     );
     return getFetch(url);
   } catch (err) {
@@ -239,6 +244,7 @@ const fetchIssues = async () => {
       createdURL,
       {
         filter: "all",
+        state: "open",
       },
       {
         Accept: "application/vnd.github+json",

--- a/services/issuesService.js
+++ b/services/issuesService.js
@@ -9,6 +9,15 @@ const getOrgIssues = async () => {
   return data;
 };
 
+const searchOrgIssues = async (searchString) => {
+  const data = await githubService.fetchOpenIssues({
+    searchString,
+  });
+
+  return data;
+};
+
 module.exports = {
   getOrgIssues,
+  searchOrgIssues,
 };

--- a/test/unit/services/githubService.test.js
+++ b/test/unit/services/githubService.test.js
@@ -145,7 +145,7 @@ describe("githubService", function () {
         searchString: "website",
       });
       expect(response).to.be.equal(
-        "https://api.github.com/search/issues?q=website+org%3AReal-Dev-Squad+type%3Aissue+is%3Aopen+created%3A%3E%3D2023-01-01&sort=created&order=desc&per_page=100&page=1"
+        "https://api.github.com/search/issues?q=website+org%3AReal-Dev-Squad+type%3Aissue+is%3Aopen&sort=created&per_page=100&page=1"
       );
     });
   });

--- a/test/unit/services/githubService.test.js
+++ b/test/unit/services/githubService.test.js
@@ -141,12 +141,17 @@ describe("githubService", function () {
 
   describe("fetchOpenIssues with search query param", function () {
     it("Should generate the correct url to fetch open issues with search param", async function () {
+      const searchString = "website";
       const response = await githubService.fetchOpenIssues({
-        searchString: "website",
+        searchString,
       });
-      expect(response).to.be.equal(
-        "https://api.github.com/search/issues?q=website+org%3AReal-Dev-Squad+type%3Aissue+is%3Aopen&sort=created&per_page=100&page=1"
-      );
+
+      const baseURL = config.get("githubApi.baseUrl");
+      const org = config.get("githubApi.org");
+      const path = "search/issues";
+      const searchParams = `org%3A${org}+type%3Aissue+is%3Aopen&sort=created&per_page=100&page=1`;
+
+      expect(response).to.be.equal(`${baseURL}/${path}?q=${searchString}+${searchParams}`);
     });
   });
 });

--- a/test/unit/services/githubService.test.js
+++ b/test/unit/services/githubService.test.js
@@ -138,4 +138,15 @@ describe("githubService", function () {
       expect(response).to.be.equal(`https://api.github.com/orgs/Real-Dev-Squad/issues`);
     });
   });
+
+  describe("fetchOpenIssues with search query param", function () {
+    it("Should generate the correct url to fetch open issues with search param", async function () {
+      const response = await githubService.fetchOpenIssues({
+        searchString: "website",
+      });
+      expect(response).to.be.equal(
+        "https://api.github.com/search/issues?q=website+org%3AReal-Dev-Squad+type%3Aissue+is%3Aopen+created%3A%3E%3D2023-01-01&sort=created&order=desc&per_page=100&page=1"
+      );
+    });
+  });
 });

--- a/test/unit/services/githubService.test.js
+++ b/test/unit/services/githubService.test.js
@@ -151,7 +151,8 @@ describe("githubService", function () {
       const path = "search/issues";
       const searchParams = `org%3A${org}+type%3Aissue+is%3Aopen&sort=created&per_page=100&page=1`;
 
-      expect(response).to.be.equal(`${baseURL}/${path}?q=${searchString}+${searchParams}`);
+      const url = `${baseURL}/${path}?q=${searchString}+${searchParams}`;
+      expect(response).to.be.equal(url);
     });
   });
 });


### PR DESCRIPTION
# Feature: Search Issues using GitHub search API 

This PR closes the following [issue to search for issues across RDS repositories](https://github.com/Real-Dev-Squad/todo-action-items/issues/144)

- Users can search for specific issues using search strings that are passed as request query parameter
- Depending on the value of the query parameter, the relevant API from GitHub is called.
  - If the query param is empty, then the issues are fetched from GitHub issues API
  - Else, the issues are fetched from the GitHub search API

- Existing service to fetch issues is leveraged with an additional parameter for search string.