### PR TITLE
Added JOI Validation for progresses api

### DIFF
--- a/controllers/progresses.js
+++ b/controllers/progresses.js
@@ -1,0 +1,13 @@
+/**
+ * Add Progresses Document
+ *
+ * @param req {Object} - Express request object
+ * @param res {Object} - Express response object
+ */
+const addProgresses = async (req, res) => {
+  return res.json({
+    message: "Progresses document created successfully.",
+  });
+};
+
+module.exports = { addProgresses };

--- a/middlewares/validators/progresses.js
+++ b/middlewares/validators/progresses.js
@@ -1,29 +1,46 @@
 const joi = require("joi");
 
 const validateProgresses = async (req, res, next) => {
-  const schema = joi
+  const baseSchema = joi
     .object()
     .strict()
     .keys({
-      type: joi.string().valid("user", "task").required(),
-      completed: joi.string().required(),
-      planned: joi.string().required(),
-      blockers: joi.string().allow("").required(),
-    });
+      type: joi.string().trim().valid("user", "task").required().messages({
+        "any.required": "Required field 'type' is missing.",
+        "any.only": "Type field is restricted to either 'user' or 'task'.",
+      }),
+      completed: joi.string().trim().required().messages({
+        "any.required": "Required field 'completed' is missing.",
+        "string.trim": "completed must not have leading or trailing whitespace",
+      }),
+      planned: joi.string().trim().required().messages({
+        "any.required": "Required field 'planned' is missing.",
+        "string.trim": "planned must not have leading or trailing whitespace",
+      }),
+      blockers: joi.string().trim().allow("").required().messages({
+        "any.required": "Required field 'blockers' is missing.",
+        "string.trim": "blockers must not have leading or trailing whitespace",
+      }),
+    })
+    .messages({ "object.unknown": "Invalid field provided." });
 
-  if (req.body.type === "task") {
-    schema.keys({ taskId: joi.string().required() });
-  }
+  const taskSchema = joi.object().keys({
+    taskId: joi.string().trim().required().messages({
+      "any.required": "Required field 'taskId' is missing.",
+      "string.trim": "taskId must not have leading or trailing whitespace",
+    }),
+  });
+  const schema = req.body.type === "task" ? baseSchema.concat(taskSchema) : baseSchema;
 
   try {
-    await schema.validateAsync(req.body);
+    await schema.validateAsync(req.body, { abortEarly: false });
     next();
   } catch (error) {
-    logger.error(`Error validating createStock payload: ${error}`);
+    logger.error(`Error validating payload: ${error}`);
     res.boom.badRequest(error.details[0].message);
   }
 };
 
 module.exports = {
-  createStock: validateProgresses,
+  validateProgresses,
 };

--- a/middlewares/validators/progresses.js
+++ b/middlewares/validators/progresses.js
@@ -1,0 +1,29 @@
+const joi = require("joi");
+
+const validateProgresses = async (req, res, next) => {
+  const schema = joi
+    .object()
+    .strict()
+    .keys({
+      type: joi.string().valid("user", "task").required(),
+      completed: joi.string().required(),
+      planned: joi.string().required(),
+      blockers: joi.string().allow("").required(),
+    });
+
+  if (req.body.type === "task") {
+    schema.keys({ taskId: joi.string().required() });
+  }
+
+  try {
+    await schema.validateAsync(req.body);
+    next();
+  } catch (error) {
+    logger.error(`Error validating createStock payload: ${error}`);
+    res.boom.badRequest(error.details[0].message);
+  }
+};
+
+module.exports = {
+  createStock: validateProgresses,
+};

--- a/routes/index.js
+++ b/routes/index.js
@@ -25,5 +25,6 @@ app.use("/items", require("./items.js"));
 app.use("/cache", require("./cloudflareCache.js"));
 app.use("/external-accounts", require("./external-accounts.js"));
 app.use("/issues", require("./issues.js"));
+app.use("/progresses", require("./progresses.js"));
 
 module.exports = app;

--- a/routes/progresses.js
+++ b/routes/progresses.js
@@ -1,0 +1,8 @@
+const express = require("express");
+const router = express.Router();
+const authenticate = require("../middlewares/authenticate");
+const { validateProgresses } = require("../middlewares/validators/progresses");
+
+router.post("/", authenticate, validateProgresses);
+
+module.exports = router;

--- a/routes/progresses.js
+++ b/routes/progresses.js
@@ -2,7 +2,8 @@ const express = require("express");
 const router = express.Router();
 const authenticate = require("../middlewares/authenticate");
 const { validateProgresses } = require("../middlewares/validators/progresses");
+const { addProgresses } = require("../controllers/progresses");
 
-router.post("/", authenticate, validateProgresses);
+router.post("/", authenticate, validateProgresses, addProgresses);
 
 module.exports = router;


### PR DESCRIPTION
Added input validation for the /progresses API endpoint using Joi.  The following fields are now validated:

• type - Must be "user" or "task" 
• completed - string (mandatory)
• planned - string (mandatory)
• blockers - string (mandatory allowed to be empty) 
• taskId - Required when type is "task"