### PR TITLE
Adds tests for tracked progress route

### DIFF
--- a/test/fixtures/trackedProgress/index.js
+++ b/test/fixtures/trackedProgress/index.js
@@ -1,6 +1,6 @@
 const predefinedTrackedProgressDataForUser = {
   type: "user",
-  currentlyTracked: true,
+  monitored: true,
   frequency: 1,
   createdAt: "2023-05-20T03:49:20.298Z",
   updatedAt: "2023-05-20T03:49:20.298Z",
@@ -8,7 +8,7 @@ const predefinedTrackedProgressDataForUser = {
 
 const predefinedTrackedProgressDataForTask = {
   type: "task",
-  currentlyTracked: true,
+  monitored: true,
   frequency: 4,
   createdAt: "2023-05-20T03:49:20.298Z",
   updatedAt: "2023-05-20T03:49:20.298Z",
@@ -16,17 +16,17 @@ const predefinedTrackedProgressDataForTask = {
 
 const trackedProgressUserDataForPost = {
   type: "user",
-  currentlyTracked: true,
+  monitored: true,
 };
 
 const trackedProgressTaskDataForPost = {
   type: "task",
-  currentlyTracked: true,
+  monitored: true,
   frequency: 2,
 };
 
 const trackedProgressDataForPatch = {
-  currentlyTracked: false,
+  monitored: false,
 };
 
 /**

--- a/test/fixtures/trackedProgress/index.js
+++ b/test/fixtures/trackedProgress/index.js
@@ -1,0 +1,50 @@
+const predefinedTrackedProgressDataForUser = {
+  type: "user",
+  currentlyTracked: true,
+  frequency: 1,
+  createdAt: "2023-05-20T03:49:20.298Z",
+  updatedAt: "2023-05-20T03:49:20.298Z",
+};
+
+const predefinedTrackedProgressDataForTask = {
+  type: "task",
+  currentlyTracked: true,
+  frequency: 4,
+  createdAt: "2023-05-20T03:49:20.298Z",
+  updatedAt: "2023-05-20T03:49:20.298Z",
+};
+
+const trackedProgressUserDataForPost = {
+  type: "user",
+  currentlyTracked: true,
+};
+
+const trackedProgressTaskDataForPost = {
+  type: "task",
+  currentlyTracked: true,
+  frequency: 2,
+};
+
+const trackedProgressDataForPatch = {
+  currentlyTracked: false,
+};
+
+/**
+ * Checks if the given value is a valid ISO string representation of a date.
+ *
+ * @param {string} value - The value to check.
+ * @returns {boolean} - Returns true if the value is a valid ISO string, otherwise false.
+ *
+ */
+const isISOString = (value) => {
+  return new Date(value).toISOString() === value;
+};
+
+module.exports = {
+  predefinedTrackedProgressDataForUser,
+  predefinedTrackedProgressDataForTask,
+  trackedProgressUserDataForPost,
+  trackedProgressTaskDataForPost,
+  trackedProgressDataForPatch,
+  isISOString,
+};

--- a/test/integration/monitor.js
+++ b/test/integration/monitor.js
@@ -23,8 +23,7 @@ const [userData0, userData1, , , superUserData] = userData;
 const cookieName = config.get("userToken.cookieName");
 const { expect } = chai;
 
-/* eslint-disable mocha/no-skipped-tests */
-describe.skip("Test the tracked Progress API", function () {
+describe("Test the tracked Progress API", function () {
   let userId0, userId1, superUser;
   let userIdToken0, superUserToken;
   let taskId0, taskId1;

--- a/test/integration/monitor.js
+++ b/test/integration/monitor.js
@@ -24,7 +24,7 @@ const cookieName = config.get("userToken.cookieName");
 const { expect } = chai;
 
 describe("Test the tracked Progress API", function () {
-  let userId0, userId1, superUser;
+  let userId0, userId1, superUserId;
   let userIdToken0, superUserToken;
   let taskId0, taskId1;
 
@@ -32,8 +32,8 @@ describe("Test the tracked Progress API", function () {
     userId0 = await addUser(userData0);
     userIdToken0 = authService.generateAuthToken({ userId: userId0 });
     userId1 = await addUser(userData1);
-    superUser = await addUser(superUserData);
-    superUserToken = authService.generateAuthToken({ userId: superUser });
+    superUserId = await addUser(superUserData);
+    superUserToken = authService.generateAuthToken({ userId: superUserId });
 
     const taskObject0 = await updateTask(taskData[0]);
     taskId0 = taskObject0.taskId;

--- a/test/integration/trackedProgresses.js
+++ b/test/integration/trackedProgresses.js
@@ -1,0 +1,457 @@
+const chai = require("chai");
+
+const firestore = require("../../utils/firestore");
+const app = require("../../server");
+const authService = require("../../services/authService");
+
+const addUser = require("../utils/addUser");
+const cleanDb = require("../utils/cleanDb");
+const taskData = require("../fixtures/tasks/tasks")();
+const { updateTask } = require("../../models/tasks");
+const {
+  predefinedTrackedProgressDataForUser,
+  predefinedTrackedProgressDataForTask,
+  isISOString,
+  trackedProgressUserDataForPost,
+  trackedProgressTaskDataForPost,
+  trackedProgressDataForPatch,
+} = require("../fixtures/trackedProgress");
+
+const userData = require("../fixtures/user/user")();
+const [userData0, userData1, , , superUserData] = userData;
+
+const cookieName = config.get("userToken.cookieName");
+const { expect } = chai;
+
+/* eslint-disable mocha/no-skipped-tests */
+describe.skip("Test the tracked Progress API", function () {
+  let userId0, userId1, superUser;
+  let userIdToken0, superUserToken;
+  let taskId0, taskId1;
+
+  beforeEach(async function () {
+    userId0 = await addUser(userData0);
+    userIdToken0 = authService.generateAuthToken({ userId: userId0 });
+    userId1 = await addUser(userData1);
+    superUser = await addUser(superUserData);
+    superUserToken = authService.generateAuthToken({ userId: superUser });
+
+    const taskObject0 = await updateTask(taskData[0]);
+    taskId0 = taskObject0.taskId;
+    const taskObject1 = await updateTask(taskData[1]);
+    taskId1 = taskObject1.taskId;
+
+    const docRefUser0 = firestore.collection("trackedProgresses").doc();
+    await docRefUser0.set({ ...predefinedTrackedProgressDataForUser, userId: userId0 });
+
+    const docRefTask0 = firestore.collection("trackedProgresses").doc();
+    await docRefTask0.set({ ...predefinedTrackedProgressDataForTask, taskId: taskId0 });
+  });
+
+  afterEach(async function () {
+    await cleanDb();
+  });
+
+  describe("Verify the POST call for tracked progresses", function () {
+    it("stores the tracked progress document for user", async function () {
+      const response = await chai
+        .request(app)
+        .post("/tracked-progresses")
+        .set("cookie", `${cookieName}=${superUserToken}`)
+        .send({
+          ...trackedProgressUserDataForPost,
+          userId: userId1,
+        });
+      expect(response).to.have.status(201);
+      expect(response.body).to.be.an("object");
+      expect(response.body).to.have.property("message").that.equals("Resource created successfully.");
+      expect(response.body).to.have.property("data").that.is.an("object");
+
+      const data = response.body.data;
+      expect(data).to.have.keys(["id", "type", "userId", "currentlyTracked", "frequency", "createdAt", "updatedAt"]);
+      expect(data).to.have.property("id").that.is.a("string");
+      expect(data).to.have.property("type").that.equals("user");
+      expect(data).to.have.property("userId").that.equals(userId1);
+      expect(data).to.have.property("currentlyTracked").that.equals(true);
+      expect(data).to.have.property("frequency").that.equals(1);
+      expect(data).to.have.property("createdAt").that.is.a("string").and.satisfy(isISOString);
+      expect(data).to.have.property("updatedAt").that.is.a("string").and.satisfy(isISOString);
+    });
+
+    it("throws 409 if tracked progress document already exists for the same user", async function () {
+      const response = await chai
+        .request(app)
+        .post("/tracked-progresses")
+        .set("cookie", `${cookieName}=${superUserToken}`)
+        .send({
+          ...trackedProgressUserDataForPost,
+          userId: userId0,
+        });
+      expect(response).to.have.status(409);
+      expect(response.body).to.be.an("object");
+      expect(response.body).to.have.property("message").that.equals("Resource is already being tracked.");
+    });
+
+    it("stores the tracked progress document for task", async function () {
+      const response = await chai
+        .request(app)
+        .post("/tracked-progresses")
+        .set("cookie", `${cookieName}=${superUserToken}`)
+        .send({
+          ...trackedProgressTaskDataForPost,
+          taskId: taskId1,
+        });
+      expect(response).to.have.status(201);
+      expect(response.body).to.be.an("object");
+      expect(response.body).to.have.property("message").that.equals("Resource created successfully.");
+      expect(response.body).to.have.property("data").that.is.an("object");
+
+      const data = response.body.data;
+      expect(data).to.have.keys(["id", "type", "taskId", "currentlyTracked", "frequency", "createdAt", "updatedAt"]);
+      expect(data).to.have.property("id").that.is.a("string");
+      expect(data).to.have.property("type").that.equals("task");
+      expect(data).to.have.property("taskId").that.equals(taskId1);
+      expect(data).to.have.property("currentlyTracked").that.equals(true);
+      expect(data).to.have.property("frequency").that.equals(2);
+      expect(data).to.have.property("createdAt").that.is.a("string").and.satisfy(isISOString);
+      expect(data).to.have.property("updatedAt").that.is.a("string").and.satisfy(isISOString);
+    });
+
+    it("throws 409 if tracked progress document already exists for the same task", async function () {
+      const response = await chai
+        .request(app)
+        .post("/tracked-progresses")
+        .set("cookie", `${cookieName}=${superUserToken}`)
+        .send({
+          ...trackedProgressTaskDataForPost,
+          taskId: taskId0,
+        });
+      expect(response).to.have.status(409);
+      expect(response.body).to.be.an("object");
+      expect(response.body).to.have.property("message").that.equals("Resource is already being tracked.");
+    });
+
+    it("throws 400 Bad Request if the payload is incorrect", async function () {
+      const response = await chai
+        .request(app)
+        .post("/tracked-progresses")
+        .set("cookie", `${cookieName}=${superUserToken}`)
+        .send({
+          ...trackedProgressTaskDataForPost,
+          type: "event", // passing incorrect type
+          taskId: taskId0,
+        });
+      expect(response).to.have.status(400);
+      expect(response.body).to.be.an("object");
+      expect(response.body).to.have.property("error").that.equals("Bad Request");
+      expect(response.body)
+        .to.have.property("message")
+        .that.equals("Type field is restricted to either 'user' or 'task'.");
+    });
+
+    it("Handles unauthenticated user request with 401 Unauthorized", async function () {
+      const response = await chai
+        .request(app)
+        .post("/tracked-progresses")
+        .send({
+          ...trackedProgressUserDataForPost,
+          userId: userId0,
+        });
+      expect(response).to.have.status(401);
+      expect(response.body).to.be.an("object");
+      expect(response.body).to.have.property("error").that.equals("Unauthorized");
+      expect(response.body).to.have.property("message").that.equals("Unauthenticated User");
+    });
+
+    it("handles unauthorized user request who don't have super user permission", async function () {
+      const response = await chai
+        .request(app)
+        .post("/tracked-progresses")
+        .set("cookie", `${cookieName}=${userIdToken0}`)
+        .send({
+          ...trackedProgressUserDataForPost,
+          userId: userId0,
+        });
+      expect(response).to.have.status(401);
+      expect(response.body).to.be.an("object");
+      expect(response.body).to.have.property("error").that.equals("Unauthorized");
+      expect(response.body).to.have.property("message").that.equals("You are not authorized for this action.");
+    });
+
+    it("handles no resource found with 404 if the task / user does not exist", async function () {
+      const response = await chai
+        .request(app)
+        .post("/tracked-progresses")
+        .set("cookie", `${cookieName}=${superUserToken}`)
+        .send({
+          ...trackedProgressUserDataForPost,
+          userId: "invalid-user",
+        });
+      expect(response).to.have.status(404);
+      expect(response.body).to.be.an("object");
+      expect(response.body).to.have.property("message").that.equals("User with id invalid-user does not exist.");
+    });
+  });
+
+  describe("Verify the PATCH call for tracked progresses", function () {
+    it("Updates the tracked progress document for user", async function () {
+      const response = await chai
+        .request(app)
+        .patch(`/tracked-progresses/user/${userId0}`)
+        .set("cookie", `${cookieName}=${superUserToken}`)
+        .send(trackedProgressDataForPatch);
+      expect(response).to.have.status(200);
+      expect(response.body).to.be.an("object");
+      expect(response.body).to.have.property("message").that.equals("Resource updated successfully.");
+      expect(response.body).to.have.property("data").that.is.an("object");
+
+      const data = response.body.data;
+      expect(data).to.have.keys(["id", "type", "userId", "currentlyTracked", "frequency", "createdAt", "updatedAt"]);
+      expect(data).to.have.property("id").that.is.a("string");
+      expect(data).to.have.property("type").that.equals("user");
+      expect(data).to.have.property("userId").that.equals(userId0);
+      expect(data).to.have.property("currentlyTracked").that.equals(false);
+    });
+
+    it("throws 404 if tried to update a user document that doesn't exist", async function () {
+      const response = await chai
+        .request(app)
+        .patch(`/tracked-progresses/user/${userId1}`)
+        .set("cookie", `${cookieName}=${superUserToken}`)
+        .send(trackedProgressDataForPatch);
+      expect(response).to.have.status(404);
+      expect(response.body).to.be.an("object");
+      expect(response.body).to.have.property("message").that.equals("Resource not found.");
+    });
+
+    it("Updates the tracked progress document for task", async function () {
+      const response = await chai
+        .request(app)
+        .patch(`/tracked-progresses/task/${taskId0}`)
+        .set("cookie", `${cookieName}=${superUserToken}`)
+        .send(trackedProgressDataForPatch);
+      expect(response).to.have.status(200);
+      expect(response.body).to.be.an("object");
+      expect(response.body).to.have.property("message").that.equals("Resource updated successfully.");
+      expect(response.body).to.have.property("data").that.is.an("object");
+
+      const data = response.body.data;
+      expect(data).to.have.keys(["id", "type", "taskId", "currentlyTracked", "frequency", "createdAt", "updatedAt"]);
+      expect(data).to.have.property("id").that.is.a("string");
+      expect(data).to.have.property("type").that.equals("task");
+      expect(data).to.have.property("taskId").that.equals(taskId0);
+      expect(data).to.have.property("currentlyTracked").that.equals(false);
+    });
+
+    it("throws 404 if tried to update a task document that doesn't exist", async function () {
+      const response = await chai
+        .request(app)
+        .patch(`/tracked-progresses/task/${taskId1}`)
+        .set("cookie", `${cookieName}=${superUserToken}`)
+        .send(trackedProgressDataForPatch);
+      expect(response).to.have.status(404);
+      expect(response.body).to.be.an("object");
+      expect(response.body).to.have.property("message").that.equals("Resource not found.");
+    });
+
+    it("throws 400 Bad Request if the payload is incorrect", async function () {
+      const response = await chai
+        .request(app)
+        .patch(`/tracked-progresses/user/${taskId0}`)
+        .set("cookie", `${cookieName}=${superUserToken}`)
+        .send({ currentlyTracked: "false" });
+      expect(response).to.have.status(400);
+      expect(response.body).to.be.an("object");
+      expect(response.body).to.have.property("error").that.equals("Bad Request");
+      expect(response.body).to.have.property("message").that.equals("currentlyTracked field must be a boolean value.");
+    });
+
+    it("Handles unauthenticated user request with 401 Unauthorized", async function () {
+      const response = await chai
+        .request(app)
+        .patch(`/tracked-progresses/task/${taskId0}`)
+        .send(trackedProgressDataForPatch);
+      expect(response).to.have.status(401);
+      expect(response.body).to.be.an("object");
+      expect(response.body).to.have.property("error").that.equals("Unauthorized");
+      expect(response.body).to.have.property("message").that.equals("Unauthenticated User");
+    });
+
+    it("handles unauthorized user request who don't have super user permission", async function () {
+      const response = await chai
+        .request(app)
+        .patch(`/tracked-progresses/task/${taskId0}`)
+        .set("cookie", `${cookieName}=${userIdToken0}`)
+        .send(trackedProgressDataForPatch);
+      expect(response).to.have.status(401);
+      expect(response.body).to.be.an("object");
+      expect(response.body).to.have.property("error").that.equals("Unauthorized");
+      expect(response.body).to.have.property("message").that.equals("You are not authorized for this action.");
+    });
+
+    it("handles no resource found with 404 if the task / user does not exist", async function () {
+      const response = await chai
+        .request(app)
+        .patch(`/tracked-progresses/user/invalid-task`)
+        .set("cookie", `${cookieName}=${superUserToken}`)
+        .send(trackedProgressDataForPatch);
+      expect(response).to.have.status(404);
+      expect(response.body).to.be.an("object");
+      expect(response.body).to.have.property("message").that.equals("Resource not found.");
+    });
+  });
+
+  describe("Verify the GET endpoint for retrieving progress document for the user on a particular date", function () {
+    it("Returns the tracked progress document for a specific user", async function () {
+      const response = await chai.request(app).get(`/tracked-progresses/user/${userId0}`);
+      expect(response).to.have.status(200);
+      expect(response.body).to.have.keys(["message", "data"]);
+      expect(response.body.data).to.be.an("object");
+      expect(response.body.message).to.be.equal("Resource retrieved successfully.");
+      expect(response.body.data).to.have.keys([
+        "id",
+        "type",
+        "userId",
+        "currentlyTracked",
+        "frequency",
+        "createdAt",
+        "updatedAt",
+      ]);
+    });
+
+    it("Returns the tracked progress document for a specific task", async function () {
+      const response = await chai.request(app).get(`/tracked-progresses/task/${taskId0}`);
+      expect(response).to.have.status(200);
+      expect(response.body).to.have.keys(["message", "data"]);
+      expect(response.body.data).to.be.an("object");
+      expect(response.body.message).to.be.equal("Resource retrieved successfully.");
+      expect(response.body.data).to.have.keys([
+        "id",
+        "type",
+        "taskId",
+        "currentlyTracked",
+        "frequency",
+        "createdAt",
+        "updatedAt",
+      ]);
+    });
+
+    it("Should return 404 No tracked progress exist in user collection", async function () {
+      const response = await chai.request(app).get(`/tracked-progresses/user/${userId1}`);
+      expect(response).to.have.status(404);
+      expect(response.body).to.be.an("object");
+      expect(response.body).to.have.key("message");
+      expect(response.body.message).to.be.equal("Resource not found.");
+    });
+
+    it("Should return 404 No tracked progress exist in task collection", async function () {
+      const response = await chai.request(app).get(`/tracked-progresses/task/${taskId1}`);
+      expect(response).to.have.status(404);
+      expect(response.body).to.be.an("object");
+      expect(response.body).to.have.key("message");
+      expect(response.body.message).to.be.equal("Resource not found.");
+    });
+
+    it("Returns 404 for invalid user id", async function () {
+      const response = await chai.request(app).get(`/tracked-progresses/user/invalidUserId`);
+      expect(response).to.have.status(404);
+      expect(response.body.message).to.be.equal("User with id invalidUserId does not exist.");
+    });
+
+    it("Returns 404 for invalid task id", async function () {
+      const response = await chai.request(app).get(`/tracked-progresses/task/invalidTaskId`);
+      expect(response).to.have.status(404);
+      expect(response.body.message).to.be.equal("Task with id invalidTaskId does not exist.");
+    });
+  });
+
+  describe("Verify the GET endpoint for retrieving progress documents of specific type", function () {
+    it("Returns the tracked progress document for a user type", async function () {
+      const response = await chai.request(app).get(`/tracked-progresses?type=user`);
+      expect(response).to.have.status(200);
+      expect(response.body).to.be.an("object");
+      expect(response.body).to.have.property("message").that.equals("Resource retrieved successfully.");
+      expect(response.body).to.have.property("data").that.is.an("array").with.lengthOf(1);
+
+      const trackedProgress = response.body.data[0];
+      expect(trackedProgress).to.be.an("object");
+      expect(trackedProgress).to.have.property("id").that.is.a("string");
+      expect(trackedProgress).to.have.property("currentlyTracked").that.is.a("boolean");
+      expect(trackedProgress).to.have.property("createdAt").that.is.a("string").and.satisfy(isISOString);
+      expect(trackedProgress).to.have.property("type").that.is.a("string");
+      expect(trackedProgress).to.have.property("userId").that.is.a("string");
+      expect(trackedProgress).to.have.property("frequency").that.is.a("number");
+      expect(trackedProgress).to.have.property("updatedAt").that.is.a("string").and.satisfy(isISOString);
+    });
+
+    it("Returns the tracked progress document for a user type and currentlyTracked", async function () {
+      const response = await chai.request(app).get(`/tracked-progresses?type=user&currentlyTracked=true`);
+      expect(response).to.have.status(200);
+      expect(response.body).to.be.an("object");
+      expect(response.body).to.have.property("message").that.equals("Resource retrieved successfully.");
+      expect(response.body).to.have.property("data").that.is.an("array").with.lengthOf(1);
+
+      const trackedProgress = response.body.data[0];
+      expect(trackedProgress).to.be.an("object");
+      expect(trackedProgress).to.have.property("id").that.is.a("string");
+      expect(trackedProgress).to.have.property("currentlyTracked").that.is.a("boolean");
+      expect(trackedProgress).to.have.property("createdAt").that.is.a("string").and.satisfy(isISOString);
+      expect(trackedProgress).to.have.property("type").that.is.a("string");
+      expect(trackedProgress).to.have.property("userId").that.is.a("string");
+      expect(trackedProgress).to.have.property("frequency").that.is.a("number");
+      expect(trackedProgress).to.have.property("updatedAt").that.is.a("string").and.satisfy(isISOString);
+    });
+
+    it("Returns an empty array if none of the query matches for user", async function () {
+      const response = await chai.request(app).get(`/tracked-progresses?type=user&currentlyTracked=false`);
+      expect(response).to.have.status(404);
+      expect(response.body).to.be.an("object");
+      expect(response.body).to.have.property("message").that.equals("Resource not found.");
+      expect(response.body).to.have.property("data").that.is.an("array").with.lengthOf(0);
+    });
+
+    it("Returns the tracked progress document for a task type", async function () {
+      const response = await chai.request(app).get(`/tracked-progresses?type=task`);
+      expect(response).to.have.status(200);
+      expect(response.body).to.be.an("object");
+      expect(response.body).to.have.property("message").that.equals("Resource retrieved successfully.");
+      expect(response.body).to.have.property("data").that.is.an("array").with.lengthOf(1);
+
+      const trackedProgress = response.body.data[0];
+      expect(trackedProgress).to.be.an("object");
+      expect(trackedProgress).to.have.property("id").that.is.a("string");
+      expect(trackedProgress).to.have.property("currentlyTracked").that.is.a("boolean");
+      expect(trackedProgress).to.have.property("createdAt").that.is.a("string").and.satisfy(isISOString);
+      expect(trackedProgress).to.have.property("type").that.is.a("string");
+      expect(trackedProgress).to.have.property("taskId").that.is.a("string");
+      expect(trackedProgress).to.have.property("frequency").that.is.a("number");
+      expect(trackedProgress).to.have.property("updatedAt").that.is.a("string").and.satisfy(isISOString);
+    });
+
+    it("Returns the tracked progress document for a task type and currentlyTracked", async function () {
+      const response = await chai.request(app).get(`/tracked-progresses?type=task&currentlyTracked=true`);
+      expect(response).to.have.status(200);
+      expect(response.body).to.be.an("object");
+      expect(response.body).to.have.property("message").that.equals("Resource retrieved successfully.");
+      expect(response.body).to.have.property("data").that.is.an("array").with.lengthOf(1);
+
+      const trackedProgress = response.body.data[0];
+      expect(trackedProgress).to.be.an("object");
+      expect(trackedProgress).to.have.property("id").that.is.a("string");
+      expect(trackedProgress).to.have.property("currentlyTracked").that.is.a("boolean");
+      expect(trackedProgress).to.have.property("createdAt").that.is.a("string").and.satisfy(isISOString);
+      expect(trackedProgress).to.have.property("type").that.is.a("string");
+      expect(trackedProgress).to.have.property("taskId").that.is.a("string");
+      expect(trackedProgress).to.have.property("frequency").that.is.a("number");
+      expect(trackedProgress).to.have.property("updatedAt").that.is.a("string").and.satisfy(isISOString);
+    });
+
+    it("Returns an empty array if none of the query matches for task", async function () {
+      const response = await chai.request(app).get(`/tracked-progresses?type=task&currentlyTracked=false`);
+      expect(response).to.have.status(404);
+      expect(response.body).to.be.an("object");
+      expect(response.body).to.have.property("message").that.equals("Resource not found.");
+      expect(response.body).to.have.property("data").that.is.an("array").with.lengthOf(0);
+    });
+  });
+});

--- a/test/integration/trackedProgresses.js
+++ b/test/integration/trackedProgresses.js
@@ -67,15 +67,23 @@ describe.skip("Test the tracked Progress API", function () {
       expect(response.body).to.have.property("message").that.equals("Resource created successfully.");
       expect(response.body).to.have.property("data").that.is.an("object");
 
-      const data = response.body.data;
-      expect(data).to.have.keys(["id", "type", "userId", "currentlyTracked", "frequency", "createdAt", "updatedAt"]);
-      expect(data).to.have.property("id").that.is.a("string");
-      expect(data).to.have.property("type").that.equals("user");
-      expect(data).to.have.property("userId").that.equals(userId1);
-      expect(data).to.have.property("currentlyTracked").that.equals(true);
-      expect(data).to.have.property("frequency").that.equals(1);
-      expect(data).to.have.property("createdAt").that.is.a("string").and.satisfy(isISOString);
-      expect(data).to.have.property("updatedAt").that.is.a("string").and.satisfy(isISOString);
+      expect(response.body.data).to.have.all.keys([
+        "id",
+        "type",
+        "userId",
+        "currentlyTracked",
+        "frequency",
+        "createdAt",
+        "updatedAt",
+      ]);
+      const { id, type, userId, currentlyTracked, frequency, createdAt, updatedAt } = response.body.data;
+      expect(id).to.be.a("string");
+      expect(type).to.be.equal("user");
+      expect(userId).to.be.equal(userId1);
+      expect(currentlyTracked).to.be.equal(true);
+      expect(frequency).to.be.equal(1);
+      expect(createdAt).to.satisfy(isISOString);
+      expect(updatedAt).to.satisfy(isISOString);
     });
 
     it("throws 409 if tracked progress document already exists for the same user", async function () {
@@ -106,15 +114,23 @@ describe.skip("Test the tracked Progress API", function () {
       expect(response.body).to.have.property("message").that.equals("Resource created successfully.");
       expect(response.body).to.have.property("data").that.is.an("object");
 
-      const data = response.body.data;
-      expect(data).to.have.keys(["id", "type", "taskId", "currentlyTracked", "frequency", "createdAt", "updatedAt"]);
-      expect(data).to.have.property("id").that.is.a("string");
-      expect(data).to.have.property("type").that.equals("task");
-      expect(data).to.have.property("taskId").that.equals(taskId1);
-      expect(data).to.have.property("currentlyTracked").that.equals(true);
-      expect(data).to.have.property("frequency").that.equals(2);
-      expect(data).to.have.property("createdAt").that.is.a("string").and.satisfy(isISOString);
-      expect(data).to.have.property("updatedAt").that.is.a("string").and.satisfy(isISOString);
+      expect(response.body.data).to.have.all.keys([
+        "id",
+        "type",
+        "taskId",
+        "currentlyTracked",
+        "frequency",
+        "createdAt",
+        "updatedAt",
+      ]);
+      const { id, type, taskId, currentlyTracked, frequency, createdAt, updatedAt } = response.body.data;
+      expect(id).to.be.a("string");
+      expect(type).to.be.equal("task");
+      expect(taskId).to.be.equal(taskId1);
+      expect(currentlyTracked).to.be.equal(true);
+      expect(frequency).to.be.equal(2);
+      expect(createdAt).to.satisfy(isISOString);
+      expect(updatedAt).to.satisfy(isISOString);
     });
 
     it("throws 409 if tracked progress document already exists for the same task", async function () {
@@ -159,8 +175,9 @@ describe.skip("Test the tracked Progress API", function () {
         });
       expect(response).to.have.status(401);
       expect(response.body).to.be.an("object");
-      expect(response.body).to.have.property("error").that.equals("Unauthorized");
-      expect(response.body).to.have.property("message").that.equals("Unauthenticated User");
+      expect(response.body).to.have.all.keys(["error", "message", "statusCode"]);
+      expect(response.body.error).to.be.equal("Unauthorized");
+      expect(response.body.message).to.be.equal("Unauthenticated User");
     });
 
     it("handles unauthorized user request who don't have super user permission", async function () {
@@ -174,8 +191,10 @@ describe.skip("Test the tracked Progress API", function () {
         });
       expect(response).to.have.status(401);
       expect(response.body).to.be.an("object");
-      expect(response.body).to.have.property("error").that.equals("Unauthorized");
-      expect(response.body).to.have.property("message").that.equals("You are not authorized for this action.");
+      expect(response.body).to.have.all.keys(["error", "message", "statusCode"]);
+
+      expect(response.body.error).to.equal("Unauthorized");
+      expect(response.body.message).to.equals("You are not authorized for this action.");
     });
 
     it("handles no resource found with 404 if the task / user does not exist", async function () {
@@ -205,12 +224,23 @@ describe.skip("Test the tracked Progress API", function () {
       expect(response.body).to.have.property("message").that.equals("Resource updated successfully.");
       expect(response.body).to.have.property("data").that.is.an("object");
 
-      const data = response.body.data;
-      expect(data).to.have.keys(["id", "type", "userId", "currentlyTracked", "frequency", "createdAt", "updatedAt"]);
-      expect(data).to.have.property("id").that.is.a("string");
-      expect(data).to.have.property("type").that.equals("user");
-      expect(data).to.have.property("userId").that.equals(userId0);
-      expect(data).to.have.property("currentlyTracked").that.equals(false);
+      expect(response.body.data).to.have.all.keys([
+        "id",
+        "type",
+        "userId",
+        "currentlyTracked",
+        "frequency",
+        "createdAt",
+        "updatedAt",
+      ]);
+      const { id, type, userId, currentlyTracked, frequency, createdAt, updatedAt } = response.body.data;
+      expect(id).to.be.a("string");
+      expect(frequency).to.be.a("number");
+      expect(type).to.be.equal("user");
+      expect(userId).to.be.equal(userId0);
+      expect(currentlyTracked).to.be.equal(false);
+      expect(createdAt).to.satisfy(isISOString);
+      expect(updatedAt).to.satisfy(isISOString);
     });
 
     it("throws 404 if tried to update a user document that doesn't exist", async function () {
@@ -234,13 +264,25 @@ describe.skip("Test the tracked Progress API", function () {
       expect(response.body).to.be.an("object");
       expect(response.body).to.have.property("message").that.equals("Resource updated successfully.");
       expect(response.body).to.have.property("data").that.is.an("object");
+      expect(response.body.data).to.have.all.keys([
+        "id",
+        "type",
+        "taskId",
+        "currentlyTracked",
+        "frequency",
+        "createdAt",
+        "updatedAt",
+      ]);
 
-      const data = response.body.data;
-      expect(data).to.have.keys(["id", "type", "taskId", "currentlyTracked", "frequency", "createdAt", "updatedAt"]);
-      expect(data).to.have.property("id").that.is.a("string");
-      expect(data).to.have.property("type").that.equals("task");
-      expect(data).to.have.property("taskId").that.equals(taskId0);
-      expect(data).to.have.property("currentlyTracked").that.equals(false);
+      const { id, type, taskId, currentlyTracked, frequency, createdAt, updatedAt } = response.body.data;
+
+      expect(id).to.be.a("string");
+      expect(frequency).to.be.a("number");
+      expect(type).to.be.equal("task");
+      expect(taskId).to.be.equal(taskId0);
+      expect(currentlyTracked).to.be.equal(false);
+      expect(createdAt).to.satisfy(isISOString);
+      expect(updatedAt).to.satisfy(isISOString);
     });
 
     it("throws 404 if tried to update a task document that doesn't exist", async function () {
@@ -308,7 +350,7 @@ describe.skip("Test the tracked Progress API", function () {
       expect(response.body).to.have.keys(["message", "data"]);
       expect(response.body.data).to.be.an("object");
       expect(response.body.message).to.be.equal("Resource retrieved successfully.");
-      expect(response.body.data).to.have.keys([
+      expect(response.body.data).to.have.all.keys([
         "id",
         "type",
         "userId",
@@ -325,7 +367,7 @@ describe.skip("Test the tracked Progress API", function () {
       expect(response.body).to.have.keys(["message", "data"]);
       expect(response.body.data).to.be.an("object");
       expect(response.body.message).to.be.equal("Resource retrieved successfully.");
-      expect(response.body.data).to.have.keys([
+      expect(response.body.data).to.have.all.keys([
         "id",
         "type",
         "taskId",
@@ -375,13 +417,23 @@ describe.skip("Test the tracked Progress API", function () {
 
       const trackedProgress = response.body.data[0];
       expect(trackedProgress).to.be.an("object");
-      expect(trackedProgress).to.have.property("id").that.is.a("string");
-      expect(trackedProgress).to.have.property("currentlyTracked").that.is.a("boolean");
-      expect(trackedProgress).to.have.property("createdAt").that.is.a("string").and.satisfy(isISOString);
-      expect(trackedProgress).to.have.property("type").that.is.a("string");
-      expect(trackedProgress).to.have.property("userId").that.is.a("string");
-      expect(trackedProgress).to.have.property("frequency").that.is.a("number");
-      expect(trackedProgress).to.have.property("updatedAt").that.is.a("string").and.satisfy(isISOString);
+      expect(trackedProgress).to.have.all.keys([
+        "id",
+        "createdAt",
+        "type",
+        "userId",
+        "frequency",
+        "updatedAt",
+        "currentlyTracked",
+      ]);
+      const { id, createdAt, type, userId, frequency, updatedAt, currentlyTracked } = trackedProgress;
+      expect(id).to.be.a("string");
+      expect(currentlyTracked).to.be.a("boolean");
+      expect(createdAt).to.be.a("string").and.satisfy(isISOString);
+      expect(type).to.be.a("string");
+      expect(userId).to.be.a("string");
+      expect(frequency).to.be.a("number");
+      expect(updatedAt).to.be.a("string").and.satisfy(isISOString);
     });
 
     it("Returns the tracked progress document for a user type and currentlyTracked", async function () {
@@ -393,13 +445,23 @@ describe.skip("Test the tracked Progress API", function () {
 
       const trackedProgress = response.body.data[0];
       expect(trackedProgress).to.be.an("object");
-      expect(trackedProgress).to.have.property("id").that.is.a("string");
-      expect(trackedProgress).to.have.property("currentlyTracked").that.is.a("boolean");
-      expect(trackedProgress).to.have.property("createdAt").that.is.a("string").and.satisfy(isISOString);
-      expect(trackedProgress).to.have.property("type").that.is.a("string");
-      expect(trackedProgress).to.have.property("userId").that.is.a("string");
-      expect(trackedProgress).to.have.property("frequency").that.is.a("number");
-      expect(trackedProgress).to.have.property("updatedAt").that.is.a("string").and.satisfy(isISOString);
+      expect(trackedProgress).to.have.all.keys([
+        "id",
+        "createdAt",
+        "type",
+        "userId",
+        "frequency",
+        "updatedAt",
+        "currentlyTracked",
+      ]);
+      const { id, createdAt, type, userId, frequency, updatedAt, currentlyTracked } = trackedProgress;
+      expect(id).to.be.a("string");
+      expect(currentlyTracked).to.be.a("boolean");
+      expect(createdAt).to.be.a("string").and.satisfy(isISOString);
+      expect(type).to.be.a("string");
+      expect(userId).to.be.a("string");
+      expect(frequency).to.be.a("number");
+      expect(updatedAt).to.be.a("string").and.satisfy(isISOString);
     });
 
     it("Returns an empty array if none of the query matches for user", async function () {
@@ -416,16 +478,25 @@ describe.skip("Test the tracked Progress API", function () {
       expect(response.body).to.be.an("object");
       expect(response.body).to.have.property("message").that.equals("Resource retrieved successfully.");
       expect(response.body).to.have.property("data").that.is.an("array").with.lengthOf(1);
-
       const trackedProgress = response.body.data[0];
       expect(trackedProgress).to.be.an("object");
-      expect(trackedProgress).to.have.property("id").that.is.a("string");
-      expect(trackedProgress).to.have.property("currentlyTracked").that.is.a("boolean");
-      expect(trackedProgress).to.have.property("createdAt").that.is.a("string").and.satisfy(isISOString);
-      expect(trackedProgress).to.have.property("type").that.is.a("string");
-      expect(trackedProgress).to.have.property("taskId").that.is.a("string");
-      expect(trackedProgress).to.have.property("frequency").that.is.a("number");
-      expect(trackedProgress).to.have.property("updatedAt").that.is.a("string").and.satisfy(isISOString);
+      expect(trackedProgress).to.have.all.keys([
+        "id",
+        "type",
+        "taskId",
+        "currentlyTracked",
+        "frequency",
+        "createdAt",
+        "updatedAt",
+      ]);
+      const { id, createdAt, type, taskId, frequency, updatedAt, currentlyTracked } = trackedProgress;
+      expect(id).to.be.a("string");
+      expect(currentlyTracked).to.be.a("boolean");
+      expect(createdAt).to.be.a("string").and.satisfy(isISOString);
+      expect(type).to.be.a("string");
+      expect(taskId).to.be.a("string");
+      expect(frequency).to.be.a("number");
+      expect(updatedAt).to.be.a("string").and.satisfy(isISOString);
     });
 
     it("Returns the tracked progress document for a task type and currentlyTracked", async function () {
@@ -437,13 +508,23 @@ describe.skip("Test the tracked Progress API", function () {
 
       const trackedProgress = response.body.data[0];
       expect(trackedProgress).to.be.an("object");
-      expect(trackedProgress).to.have.property("id").that.is.a("string");
-      expect(trackedProgress).to.have.property("currentlyTracked").that.is.a("boolean");
-      expect(trackedProgress).to.have.property("createdAt").that.is.a("string").and.satisfy(isISOString);
-      expect(trackedProgress).to.have.property("type").that.is.a("string");
-      expect(trackedProgress).to.have.property("taskId").that.is.a("string");
-      expect(trackedProgress).to.have.property("frequency").that.is.a("number");
-      expect(trackedProgress).to.have.property("updatedAt").that.is.a("string").and.satisfy(isISOString);
+      expect(trackedProgress).to.have.all.keys([
+        "id",
+        "type",
+        "taskId",
+        "currentlyTracked",
+        "frequency",
+        "createdAt",
+        "updatedAt",
+      ]);
+      const { id, createdAt, type, taskId, frequency, updatedAt, currentlyTracked } = trackedProgress;
+      expect(id).to.be.a("string");
+      expect(currentlyTracked).to.be.a("boolean");
+      expect(createdAt).to.be.a("string").and.satisfy(isISOString);
+      expect(type).to.be.a("string");
+      expect(taskId).to.be.a("string");
+      expect(frequency).to.be.a("number");
+      expect(updatedAt).to.be.a("string").and.satisfy(isISOString);
     });
 
     it("Returns an empty array if none of the query matches for task", async function () {

--- a/utils/monitor.js
+++ b/utils/monitor.js
@@ -12,7 +12,7 @@ const { RESOURCE_NOT_FOUND } = RESPONSE_MESSAGES;
  * @param {string} queryParams.taskId - The ID of the task (optional).
  * @returns {Firestore.Query} - A Firestore query to check if a document exists.
  */
-const buildTrackedProgressQueryByType = (queryParams) => {
+const buildQueryByTypeId = (queryParams) => {
   const { userId, taskId } = queryParams;
   if (userId) {
     return trackedProgressesCollection.where("type", "==", "user").where("userId", "==", userId);
@@ -39,23 +39,6 @@ const buildQueryForFetchingDocsOfType = (queryParams) => {
 };
 
 /**
- * Builds a Firestore query for fetching a specific tracked progress document based on the provided query parameters.
- *
- * @param {Object} queryParams - The query parameters for fetching a specific tracked progress document.
- * @param {string} queryParams.userId - The userId of the tracked progress document
- * @param {string} queryParams.taskId - The taskId of the tracked progress document
- * @returns {Firestore.Query} - A Firestore query for fetching a specific tracked progress document.
- */
-const buildQueryToFetchTrackedDoc = (queryParams) => {
-  const { userId, taskId } = queryParams;
-  if (userId) {
-    return trackedProgressesCollection.where("type", "==", "user").where("userId", "==", userId);
-  } else {
-    return trackedProgressesCollection.where("type", "==", "task").where("taskId", "==", taskId);
-  }
-};
-
-/**
  * Retrieves progress documents from Firestore based on the given query.
  * @param {Query} query - A Firestore query object for fetching progress documents.
  * @returns {Array.<Object>} An array of objects representing the retrieved tracked progress documents. Each object contains the document ID and its data.
@@ -74,8 +57,7 @@ const getTrackedProgressDocs = async (query) => {
 };
 
 module.exports = {
-  buildTrackedProgressQueryByType,
+  buildQueryByTypeId,
   buildQueryForFetchingDocsOfType,
   getTrackedProgressDocs,
-  buildQueryToFetchTrackedDoc,
 };

--- a/utils/monitor.js
+++ b/utils/monitor.js
@@ -15,9 +15,9 @@ const { RESOURCE_NOT_FOUND } = RESPONSE_MESSAGES;
 const buildTrackedProgressQueryByType = (queryParams) => {
   const { userId, taskId } = queryParams;
   if (userId) {
-    return trackedProgressesCollection.where("userId", "==", userId);
+    return trackedProgressesCollection.where("type", "==", "user").where("userId", "==", userId);
   } else {
-    return trackedProgressesCollection.where("taskId", "==", taskId);
+    return trackedProgressesCollection.where("type", "==", "task").where("taskId", "==", taskId);
   }
 };
 
@@ -49,9 +49,9 @@ const buildQueryForFetchingDocsOfType = (queryParams) => {
 const buildQueryToFetchTrackedDoc = (queryParams) => {
   const { userId, taskId } = queryParams;
   if (userId) {
-    return trackedProgressesCollection.where("userId", "==", userId);
+    return trackedProgressesCollection.where("type", "==", "user").where("userId", "==", userId);
   } else {
-    return trackedProgressesCollection.where("taskId", "==", taskId);
+    return trackedProgressesCollection.where("type", "==", "task").where("taskId", "==", taskId);
   }
 };
 

--- a/utils/progresses.js
+++ b/utils/progresses.js
@@ -32,8 +32,8 @@ const getProgressDateTimestamp = () => {
 const buildQueryForPostingProgress = ({ type, userId, taskId }) => {
   const query =
     type === "user"
-      ? progressesCollection.where("userId", "==", userId)
-      : progressesCollection.where("taskId", "==", taskId);
+      ? progressesCollection.where("type", "==", "user").where("userId", "==", userId)
+      : progressesCollection.where("type", "==", "task").where("taskId", "==", taskId);
   return query;
 };
 
@@ -136,9 +136,9 @@ const buildRangeProgressQuery = (queryParams) => {
   const { userId, taskId, startDate, endDate } = queryParams;
   let query = progressesCollection;
   if (userId) {
-    query = query.where("userId", "==", userId);
+    query = query.where("type", "==", "user").where("userId", "==", userId);
   } else if (taskId) {
-    query = query.where("taskId", "==", taskId);
+    query = query.where("type", "==", "task").where("taskId", "==", taskId);
   } else {
     throw new Error("Either userId or taskId is required.");
   }
@@ -191,14 +191,15 @@ const buildQueryToSearchProgressByDay = (pathParams) => {
   const { userId, taskId, date } = pathParams;
   let query = progressesCollection;
   if (userId) {
-    query = query.where("userId", "==", userId);
+    query = query.where("type", "==", "user").where("userId", "==", userId);
   } else {
-    query = query.where("taskId", "==", taskId);
+    query = query.where("type", "==", "task").where("taskId", "==", taskId);
   }
   const dateTimeStamp = new Date(date).setUTCHours(0, 0, 0, 0);
   query = query.where("date", "==", dateTimeStamp).limit(1);
   return query;
 };
+
 module.exports = {
   getProgressDateTimestamp,
   buildQueryForPostingProgress,


### PR DESCRIPTION
This PR adds tests for the Tracked Progress Collection. The tests cover various scenarios such as creating tracked progress documents, handling errors, retrieving progress documents, and asserting response data.

With this we also make the queries more specific in the util file by specifying the `type`.

Please find the parent ticket [here](https://github.com/Real-Dev-Squad/website-backend/issues/1076)
