### PR TITLE
Set github actions timeout to 5 mins

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     strategy:
       matrix:


### PR DESCRIPTION
At times when there is something wrong in test it doesn't stop and timesout after 360 mins or 6 hr, as that is the GitHub actions timeout, It consumes our free limit of runtime provided for actions 

On average out workflow tests are completed in under 2 mins