### PR TITLE
Fix bug with adding `assigneeRdsInfo` to tasks

### DIFF
--- a/controllers/tasks.js
+++ b/controllers/tasks.js
@@ -51,7 +51,8 @@ const addNewTask = async (req, res) => {
  */
 const fetchTasks = async (req, res) => {
   try {
-    const allTasks = await tasks.fetchTasks();
+    const allTasksPromises = await tasks.fetchTasks();
+    const allTasks = await Promise.all(allTasksPromises);
     const fetchTasksWithRdsAssigneeInfo = allTasks.map(async (task) => {
       /*
        If the issue has a "github.issue" inner object and a property "assignee",

--- a/controllers/tasks.js
+++ b/controllers/tasks.js
@@ -51,8 +51,7 @@ const addNewTask = async (req, res) => {
  */
 const fetchTasks = async (req, res) => {
   try {
-    const allTasksPromises = await tasks.fetchTasks();
-    const allTasks = await Promise.all(allTasksPromises);
+    const allTasks = await tasks.fetchTasks();
     const fetchTasksWithRdsAssigneeInfo = allTasks.map(async (task) => {
       /*
        If the issue has a "github.issue" inner object and a property "assignee",

--- a/models/tasks.js
+++ b/models/tasks.js
@@ -74,7 +74,7 @@ const fetchTasks = async () => {
     const tasks = buildTasks(tasksSnapshot);
     const promises = tasks.map(async (task) => fromFirestoreData(task));
     const updatedTasks = await Promise.all(promises);
-    const taskList = updatedTasks.map(async (task) => {
+    const taskPromises = updatedTasks.map(async (task) => {
       task.status = TASK_STATUS[task.status.toUpperCase()] || task.status;
       const taskId = task.id;
       const dependencySnapshot = await dependencyModel.where("taskId", "==", taskId).get();
@@ -85,6 +85,7 @@ const fetchTasks = async () => {
       });
       return task;
     });
+    const taskList = await Promise.all(taskPromises);
     return taskList;
   } catch (err) {
     logger.error("error getting tasks", err);


### PR DESCRIPTION
Issue ticket : https://github.com/Real-Dev-Squad/website-status/issues/607

This PR fixes a bug where `assigneeRdsInfo` was not being added to the `tasks` object correctly. The issue was caused by asynchronous code, where tasks were being fetched using `tasks.fetchTasks()`, which returns a list of Promises. However, the code was not waiting for all Promises to resolve before adding `assigneeRdsInfo` to the tasks.

To fix this, I updated the code to use `Promise.all` to wait for all Promises to resolve before adding `assigneeRdsInfo` to the tasks.