### PR TITLE
add timestamp for login signup

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -27,6 +27,7 @@ const githubAuth = (req, res, next) => {
         tokens: {
           githubAccessToken: accessToken,
         },
+        githubLinked: Date.now(),
       };
 
       const { userId, incompleteUserDetails } = await users.addOrUpdate(userData);

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -27,7 +27,7 @@ const githubAuth = (req, res, next) => {
         tokens: {
           githubAccessToken: accessToken,
         },
-        githubLinked: Date.now(),
+        githubLinkedOn: Date.now(),
       };
 
       const { userId, incompleteUserDetails } = await users.addOrUpdate(userData);

--- a/models/users.js
+++ b/models/users.js
@@ -276,7 +276,7 @@ const setIncompleteUserDetails = async (userId) => {
   const doc = await userRef.get();
   if (doc.exists) {
     return userRef.update({
-      JoinedAt: Date.now(),
+      joinedAt: Date.now(),
       incompleteUserDetails: false,
     });
   }

--- a/models/users.js
+++ b/models/users.js
@@ -276,6 +276,7 @@ const setIncompleteUserDetails = async (userId) => {
   const doc = await userRef.get();
   if (doc.exists) {
     return userRef.update({
+      JoinedAt: Date.now(),
       incompleteUserDetails: false,
     });
   }

--- a/test/integration/users.test.js
+++ b/test/integration/users.test.js
@@ -136,6 +136,7 @@ describe("Users", function () {
           expect(res.body.users[0]).to.not.have.property("phone");
           expect(res.body.users[0]).to.not.have.property("email");
           expect(res.body.users[0]).to.have.property("joinedAt");
+          expect(res.body.users[0]).to.have.property("githubLinked");
 
           return done();
         });

--- a/test/integration/users.test.js
+++ b/test/integration/users.test.js
@@ -119,7 +119,7 @@ describe("Users", function () {
     afterEach(async function () {
       await cleanDb();
     });
-    // eslint-disable-next-line
+
     it("Should get all the users in system", function (done) {
       chai
         .request(app)

--- a/test/integration/users.test.js
+++ b/test/integration/users.test.js
@@ -135,8 +135,6 @@ describe("Users", function () {
           expect(res.body.users).to.be.a("array");
           expect(res.body.users[0]).to.not.have.property("phone");
           expect(res.body.users[0]).to.not.have.property("email");
-          expect(res.body.users[0]).to.have.property("joinedAt");
-          expect(res.body.users[0]).to.have.property("githubLinked");
 
           return done();
         });

--- a/test/integration/users.test.js
+++ b/test/integration/users.test.js
@@ -119,7 +119,7 @@ describe("Users", function () {
     afterEach(async function () {
       await cleanDb();
     });
-
+    // eslint-disable-next-line
     it("Should get all the users in system", function (done) {
       chai
         .request(app)
@@ -135,6 +135,7 @@ describe("Users", function () {
           expect(res.body.users).to.be.a("array");
           expect(res.body.users[0]).to.not.have.property("phone");
           expect(res.body.users[0]).to.not.have.property("email");
+          expect(res.body.users[0]).to.have.property("joinedAt");
 
           return done();
         });


### PR DESCRIPTION
### This PR does not have test as we do not have tests for what happens to db once user logs in through github
As per recent events happening in the community, we need to save the timestamp for the users when they signup/create an account with github.

After logging in with github
![image](https://github.com/Real-Dev-Squad/website-backend/assets/57758447/75bf60c8-ba4c-4a0b-812f-ef20126d5cbf)

after completing the signup
![image](https://github.com/Real-Dev-Squad/website-backend/assets/57758447/b97a4f1e-83c2-4e25-8c6f-cb1ab64e7ae4)

closes : https://github.com/Real-Dev-Squad/website-backend/issues/1140