### PR TITLE
[Live-Site] Add correct roomId and userId in authToken

### DIFF
--- a/controllers/events.js
+++ b/controllers/events.js
@@ -90,7 +90,7 @@ const getAllEvents = async (req, res) => {
  */
 const joinEvent = async (req, res) => {
   const { roomId, userId, role } = req.body;
-  const payload = { room_id: roomId, user_id: userId, role };
+  const payload = { roomId, userId, role };
   try {
     const token = tokenService.getAuthToken(payload);
     return res.status(201).json({


### PR DESCRIPTION
fixes #1173 

### Changes
Used proper `userId` and `roomId` to get stored in a token.