### PR TITLE
Add "in_discord" Role to Users upon Discord Verification

### DIFF
--- a/controllers/users.js
+++ b/controllers/users.js
@@ -255,6 +255,12 @@ const updateSelf = async (req, res) => {
       }
       await userQuery.setIncompleteUserDetails(userId);
     }
+    if (req.body?.discordId) {
+      req.body.roles = {
+        ...req.userData.roles,
+        in_discord: true,
+      };
+    }
 
     const user = await userQuery.addOrUpdate(req.body, userId);
 


### PR DESCRIPTION
## Title: Add "in_discord" Role to Users upon Discord Verification

### Test Coverage stats
![image](https://github.com/Real-Dev-Squad/website-backend/assets/57758447/16ee6800-f601-40bc-91b8-6a781707989b)
Lines changed by me: 258-263

### Introduction
This pull request introduces a new feature to the website backend. It enables the automatic assignment of the "in_discord" role to users when they verify their Discord accounts. This addition eliminates the need for manual synchronization using the Discord Sync API. Furthermore, it sets the foundation for a future pull request that will include the "discord_joined_at" field in the user's data.

### Feature Changes
1. Automatic "in_discord" Role Assignment:
   - Implement functionality to assign the "in_discord" role to users upon successful verification of their Discord accounts.
   - Update the backend logic to handle the verification process and manage the user's role status accordingly.

### Future Enhancement
This pull request lays the groundwork for a future enhancement, which involves raising another pull request that will introduce the "discord_joined_at" field. This addition will provide additional information about when a user joined Discord, enhancing user management capabilities.

### Project
Website Backend

### Impact
The proposed changes will have the following impact:

- Improved user experience with seamless role assignment upon Discord verification.
- Simplified backend management, eliminating the need for manual synchronization through the Discord Sync API.
- Increased efficiency and accuracy in identifying users who have verified their Discord accounts.
- Preparation for the future introduction of the "discord_joined_at" field, enhancing user data with Discord join information.

### Request for Feedback
Reviewers are kindly requested to provide feedback on the proposed changes. Specifically, we would appreciate insights on the implementation of the automatic "in_discord" role assignment, as well as any suggestions for improving the process. Additionally, your feedback on the planned future enhancement involving the "discord_joined_at" field is welcome.

Thank you for your time and valuable feedback.
