### PR TITLE
Script to Add Unverified Role to Users Without Discord Link

### DIFF
--- a/controllers/discordactions.js
+++ b/controllers/discordactions.js
@@ -3,6 +3,8 @@ const admin = require("firebase-admin");
 const config = require("config");
 const jwt = require("jsonwebtoken");
 const discordRolesModel = require("../models/discordactions");
+const { addRoleToUser, getDiscordMembers } = require("../services/discordService");
+const { fetchAllUsers } = require("../models/users");
 
 /**
  * Creates a role
@@ -141,9 +143,36 @@ const updateDiscordImageForVerification = async (req, res) => {
   }
 };
 
+const markUnverified = async (req, res) => {
+  try {
+    const [usersInRdsDiscordServer, allRdsLoggedInUsers] = await Promise.all([getDiscordMembers(), fetchAllUsers()]);
+    const rdsUserMap = {};
+    const unverifiedRoleId = config.get("discordUnverifiedRoleId");
+    const usersToApplyUnverifiedRole = [];
+    const addRolePromises = [];
+    allRdsLoggedInUsers.forEach((user) => {
+      rdsUserMap[user.discordId] = true;
+    });
+    usersInRdsDiscordServer.forEach((user) => {
+      if (!rdsUserMap[user.user.id]) {
+        usersToApplyUnverifiedRole.push(user.user.id);
+      }
+    });
+    usersToApplyUnverifiedRole.forEach((id) => {
+      addRolePromises.push(addRoleToUser(id, unverifiedRoleId));
+    });
+    await Promise.all(addRolePromises);
+    return res.json({ message: "ROLES APPLIED SUCCESSFULLY" });
+  } catch (err) {
+    logger.error(err);
+    return res.json({ message: INTERNAL_SERVER_ERROR });
+  }
+};
+
 module.exports = {
   createGroupRole,
   getAllGroupRoles,
   addGroupRoleToMember,
   updateDiscordImageForVerification,
+  markUnverified,
 };

--- a/routes/discordactions.js
+++ b/routes/discordactions.js
@@ -5,6 +5,7 @@ const {
   getAllGroupRoles,
   addGroupRoleToMember,
   updateDiscordImageForVerification,
+  markUnverified,
 } = require("../controllers/discordactions");
 const { validateGroupRoleBody, validateMemberRoleBody } = require("../middlewares/validators/discordactions");
 const checkIsVerifiedDiscord = require("../middlewares/verifydiscord");
@@ -16,6 +17,7 @@ const router = express.Router();
 router.post("/groups", authenticate, checkIsVerifiedDiscord, validateGroupRoleBody, createGroupRole);
 router.get("/groups", authenticate, checkIsVerifiedDiscord, getAllGroupRoles);
 router.post("/roles", authenticate, checkIsVerifiedDiscord, validateMemberRoleBody, addGroupRoleToMember);
+router.post("/update/roles/unverified", authenticate, authorizeRoles([SUPERUSER]), markUnverified);
 router.patch(
   "/avatar/verify/:id",
   authenticate,

--- a/services/discordService.js
+++ b/services/discordService.js
@@ -52,7 +52,41 @@ const setInDiscordFalseScript = async () => {
   await Promise.all(updateUsersPromises);
 };
 
+const generateAuthTokenForCloudflare = async () => {
+  let authToken;
+  const expiry = config.get("rdsServerlessBot.ttl");
+  const privateKey = config.get("rdsServerlessBot.rdsServerLessPrivateKey");
+  try {
+    authToken = await jwt.sign({}, privateKey, {
+      algorithm: "RS256",
+      expiresIn: expiry,
+    });
+  } catch (err) {
+    logger.error("Error in generating auth token", err);
+    throw err;
+  }
+  return authToken;
+};
+
+const addRoleToUser = async (userid, roleid) => {
+  try {
+    const authToken = await generateAuthTokenForCloudflare();
+    const response = await (
+      await fetch(`${DISCORD_BASE_URL}/roles/add`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${authToken}` },
+        body: JSON.stringify({ userid, roleid }),
+      })
+    ).json();
+    return response;
+  } catch (err) {
+    logger.error("Some Error occured", err);
+    throw err;
+  }
+};
+
 module.exports = {
   getDiscordMembers,
   setInDiscordFalseScript,
+  addRoleToUser,
 };


### PR DESCRIPTION
## Pull Request Description: Script to Add Unverified Role to Users Without Discord Link

### Description
This pull request introduces a script that adds an "unverified" role to all users who haven't linked their Discord accounts with our backend. The purpose of this script is to streamline the verification process and ensure consistent user management. Additionally, a superuser-only API endpoint has been created to facilitate this action securely.

### Changes Made
- Developed a script that identifies users without a linked Discord account and assigns them the "unverified" role.
- Created a new superuser-only API endpoint specifically designed for executing this action securely.
- Tested the script and API endpoint extensively to verify their functionality and performance.

### Testing
The script and API endpoint have undergone comprehensive testing to ensure accurate identification of users without a linked Discord account and proper assignment of the "unverified" role. Testing includes various scenarios, such as users with and without existing roles, to ensure the script behaves as expected.

### Impact
Implementing this script and API endpoint offers the following benefits:
- Improved user management: Automatically assigning the "unverified" role simplifies the verification process for users who haven't linked their Discord accounts.
- Streamlined workflow: Superusers can execute this action securely through the dedicated API endpoint, reducing manual intervention.

Please review the changes made in this pull request and provide any feedback or suggestions for improvement.

Thank you.
