### PR TITLE
Remove user personal details filters data

### DIFF
--- a/controllers/users.js
+++ b/controllers/users.js
@@ -576,7 +576,7 @@ const filterUsers = async (req, res) => {
       return res.boom.badRequest("filter for item not provided");
     }
     const users = await userQuery.getUsersBasedOnFilter(req.query);
-    const cleanedUsers = users.map((user) => {
+    const sanitizedUsers = users.map((user) => {
       delete user.tokens;
       delete user.email;
       delete user.phone;
@@ -584,7 +584,7 @@ const filterUsers = async (req, res) => {
     });
     return res.json({
       message: users.length ? "Users found successfully!" : "No users found",
-      users: cleanedUsers,
+      users: sanitizedUsers,
       count: users.length,
     });
   } catch (error) {

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -576,10 +576,15 @@ const filterUsers = async (req, res) => {
       return res.boom.badRequest("filter for item not provided");
     }
     const users = await userQuery.getUsersBasedOnFilter(req.query);
-
+    const cleanedUsers = users.map((user) => {
+      delete user.tokens;
+      delete user.email;
+      delete user.phone;
+      return user;
+    });
     return res.json({
       message: users.length ? "Users found successfully!" : "No users found",
-      users,
+      users: cleanedUsers,
       count: users.length,
     });
   } catch (error) {

--- a/test/integration/usersFilter.test.js
+++ b/test/integration/usersFilter.test.js
@@ -292,5 +292,29 @@ describe("Filter Users", function () {
           return done();
         });
     });
+
+    it("Check personal details not present", function (done) {
+      chai
+        .request(app)
+        .get("/users/search")
+        .query({ state: ["OOO", "ACTIVE", "IDLE"] })
+        .set("cookie", `${cookieName}=${jwt}`)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+          expect(res).to.have.status(200);
+          expect(res.body).to.be.a("object");
+          expect(res.body.count).to.be.a("number");
+          expect(res.body.message).to.equal("Users found successfully!");
+          expect(res.body.users).to.be.a("array");
+          res.body.users.forEach((user) => {
+            expect(user).to.not.have.property("phone");
+            expect(user).to.not.have.property("email");
+            expect(user).to.not.have.property("tokens");
+          });
+          return done();
+        });
+    });
   });
 });


### PR DESCRIPTION
## Closes: #1192

API Link : https://api.realdevsquad.com/users/search?state=IDLE&state=ACTIVE&state=OOO

**Description:**
The current above API returns personal details like Phone , E-mail and GitHub Access tokens. In this PR we are removing user personal details from the response.

**Test Coverage**
![image](https://github.com/Real-Dev-Squad/website-backend/assets/70854507/b906a313-dfb5-4be5-b35c-609db36ef880)

**Screenshot**
Before
![image](https://github.com/Real-Dev-Squad/website-backend/assets/70854507/7529509e-72dc-4e12-9cda-e8cade663a20)

After
![image](https://github.com/Real-Dev-Squad/website-backend/assets/70854507/3b678cb3-0dc8-428a-8d1e-599a0856110f)

