### PR TITLE
feat: includes archived users

### DIFF
--- a/middlewares/validators/user.js
+++ b/middlewares/validators/user.js
@@ -102,6 +102,9 @@ async function getUsers(req, res, next) {
           "string.empty": "size must contain value in range 1-100",
           "string.pattern.base": "size must be in range 1-100",
         }),
+      q: joi.string().optional().messages({
+        "string.empty": "q must not be empty and should have both a key and a value",
+      }),
       page: joi
         .string()
         .optional()

--- a/models/users.js
+++ b/models/users.js
@@ -136,7 +136,7 @@ const getSuggestedUsers = async (skill) => {
 
 /**
  * Fetches the data about our users
- * @param query { search, next, prev, size, page }: Filter for users
+ * @param query { search, next, prev, size, page, include }: Filter for users
  * @return {Promise<userModel|Array>}
  */
 const fetchPaginatedUsers = async (query) => {
@@ -145,9 +145,15 @@ const fetchPaginatedUsers = async (query) => {
     // INFO: https://github.com/Real-Dev-Squad/website-backend/pull/873#discussion_r1064229932
     const size = parseInt(query.size) || 100;
     const doc = (query.next || query.prev) && (await userModel.doc(query.next || query.prev).get());
-
-    let dbQuery = userModel.where("roles.archived", "==", false).orderBy("username");
-
+    let dbQuery;
+    if (query.q) {
+      const [queryName, queryValue] = query.q.split(":");
+      if (queryName === "includes" && queryValue === "archived") {
+        dbQuery = userModel;
+      }
+    } else {
+      dbQuery = userModel.where("roles.archived", "==", false).orderBy("username");
+    }
     if (query.prev) {
       dbQuery = dbQuery.limitToLast(size);
     } else {

--- a/test/integration/users.test.js
+++ b/test/integration/users.test.js
@@ -176,6 +176,7 @@ describe("Users", function () {
         .query({
           size: 1,
           page: 0,
+          q: "includes:archived",
         })
         .end((err, res) => {
           if (err) {
@@ -201,6 +202,7 @@ describe("Users", function () {
         .query({
           size: -1,
           page: -1,
+          q: "",
         })
         .end((err, res) => {
           if (err) {


### PR DESCRIPTION
## Before Changes
- before in API `/users`  only return archived users

## New Addition
### feature:
- create query param to include archived users
- query template `/users?q=includes%3Aarchived`
- with query param `/users?size=10&page=0&q=includes%3Aarchived` includes both archived true and false.
