### PR TITLE
Remove the option of marking oneself as idle or active

### DIFF
--- a/middlewares/validators/userStatus.js
+++ b/middlewares/validators/userStatus.js
@@ -3,12 +3,21 @@ const { userState } = require("../../constants/userStatus");
 const threeDaysInMilliseconds = 172800000;
 
 const validateUserStatusData = async (todaysTime, req, res, next) => {
+  // userStatusFlag is the Feature flag for status update based on task status. This flag is temporary and will be removed once the feature becomes stable.
+  const { userStatusFlag } = req.query;
+  const isUserStatusEnabled = userStatusFlag === "true";
+  let validUserStates = [userState.OOO, userState.ONBOARDING, userState.IDLE, userState.ACTIVE];
+
+  if (isUserStatusEnabled) {
+    validUserStates = [userState.OOO, userState.ONBOARDING];
+  }
+
   const schema = Joi.object({
     currentStatus: Joi.object().keys({
       state: Joi.string()
         .trim()
-        .valid(userState.IDLE, userState.ACTIVE, userState.OOO, userState.ONBOARDING)
-        .error(new Error(`Invalid State. State must be either IDLE, ACTIVE, OOO, or ONBOARDING`)),
+        .valid(...validUserStates)
+        .error(new Error(`Invalid State. the acceptable states are ${validUserStates}`)),
       updatedAt: Joi.number().required(),
       from: Joi.number()
         .min(todaysTime)

--- a/test/integration/userStatus.test.js
+++ b/test/integration/userStatus.test.js
@@ -3,6 +3,7 @@ const { expect } = chai;
 const chaiHttp = require("chai-http");
 const sinon = require("sinon");
 
+const firestore = require("../../utils/firestore");
 const app = require("../../server");
 const authService = require("../../services/authService");
 const addUser = require("../utils/addUser");
@@ -142,18 +143,14 @@ describe("UserStatus", function () {
       const fromDate = updatedAtDate + 12 * 24 * 60 * 60 * 1000; // 24th Nov 2022
       const untilDate = updatedAtDate + 16 * 24 * 60 * 60 * 1000; // 28th Nov 2022
 
-      const response1 = await chai
-        .request(app)
-        .patch(`/users/status/self`)
-        .set("Cookie", `${cookieName}=${testUserJwt}`)
-        .send(generateUserStatusData("ACTIVE", updatedAtDate, updatedAtDate));
-      expect(response1).to.have.status(201);
-      expect(response1.body.data.currentStatus.state).to.equal("ACTIVE");
+      const statusData = generateUserStatusData("ACTIVE", updatedAtDate, updatedAtDate);
+      statusData.userId = testUserId;
+      await firestore.collection("usersStatus").doc("userStatus").set(statusData);
 
       // Marking OOO Status from 24th Nov 2022 to 28th Nov 2022
       const response2 = await chai
         .request(app)
-        .patch(`/users/status/self`)
+        .patch(`/users/status/self?userStatusFlag=true`)
         .set("Cookie", `${cookieName}=${testUserJwt}`)
         .send(generateUserStatusData("OOO", updatedAtDate, fromDate, untilDate, "Vacation Trip"));
       expect(response2).to.have.status(200);
@@ -211,18 +208,14 @@ describe("UserStatus", function () {
       const fromDate = updatedAtDate + 12 * 24 * 60 * 60 * 1000; // 24th Nov 2022
       const untilDate = updatedAtDate + 16 * 24 * 60 * 60 * 1000; // 28th Nov 2022
 
-      const response1 = await chai
-        .request(app)
-        .patch(`/users/status/self`)
-        .set("Cookie", `${cookieName}=${testUserJwt}`)
-        .send(generateUserStatusData("ACTIVE", updatedAtDate, updatedAtDate));
-      expect(response1).to.have.status(201);
-      expect(response1.body.data.currentStatus.state).to.equal("ACTIVE");
+      const statusData = generateUserStatusData("ACTIVE", updatedAtDate, updatedAtDate);
+      statusData.userId = testUserId;
+      await firestore.collection("usersStatus").doc("userStatus").set(statusData);
 
       // Marking OOO Status from 24th Nov 2022 to 28th Nov 2022
       const response2 = await chai
         .request(app)
-        .patch(`/users/status/self`)
+        .patch(`/users/status/self?userStatusFlag=true`)
         .set("Cookie", `${cookieName}=${testUserJwt}`)
         .send(generateUserStatusData("OOO", updatedAtDate, fromDate, untilDate, "Vacation Trip"));
       expect(response2).to.have.status(200);
@@ -251,18 +244,6 @@ describe("UserStatus", function () {
       expect(response4.body.data.currentStatus.state).to.equal("OOO");
       expect(response4.body.data).to.have.property("futureStatus");
       expect(response4.body.data.futureStatus.state).to.equal("ACTIVE");
-
-      // Marking Active From today
-      const response5 = await chai
-        .request(app)
-        .patch(`/users/status/self`)
-        .set("Cookie", `${cookieName}=${testUserJwt}`)
-        .send(generateUserStatusData("ACTIVE", Date.now(), Date.now()));
-      expect(response5).to.have.status(200);
-      expect(response5.body.message).to.equal("User Status updated successfully.");
-      expect(response5.body.data).to.have.own.property("currentStatus");
-      expect(response5.body.data.currentStatus.state).to.equal("ACTIVE");
-      expect(response5.body.data.futureStatus.state).to.equal(undefined);
     });
   });
 
@@ -287,7 +268,7 @@ describe("UserStatus", function () {
     it("Should store the User Status in the collection", function (done) {
       chai
         .request(app)
-        .patch(`/users/status/self`)
+        .patch(`/users/status/self?userStatusFlag=true`)
         .set("Cookie", `${cookieName}=${testUserJwt}`)
         .send(userStatusDataForOooState)
         .end((err, res) => {
@@ -305,7 +286,7 @@ describe("UserStatus", function () {
     it("Should store the User Status in the collection when requested by Super User", function (done) {
       chai
         .request(app)
-        .patch(`/users/status/${testUserId}`)
+        .patch(`/users/status/${testUserId}?userStatusFlag=true`)
         .set("Cookie", `${cookieName}=${superUserAuthToken}`)
         .send(userStatusDataForOooState)
         .end((err, res) => {
@@ -320,7 +301,9 @@ describe("UserStatus", function () {
         });
     });
 
-    it("Should update the User Status", function (done) {
+    // Skipping this as the users are not allowed to mark them as active or idle. Will remove the test while removing the feature flag.
+    // eslint-disable-next-line mocha/no-skipped-tests
+    it.skip("Should update the User Status", function (done) {
       chai
         .request(app)
         .patch(`/users/status/self`)
@@ -339,7 +322,7 @@ describe("UserStatus", function () {
     it("Should update the User Status without reason for short duration", function (done) {
       chai
         .request(app)
-        .patch(`/users/status/self`)
+        .patch(`/users/status/self?userStatusFlag=true`)
         .set("cookie", `${cookieName}=${jwt}`)
         .send(oooStatusDataForShortDuration)
         .end((err, res) => {
@@ -352,7 +335,9 @@ describe("UserStatus", function () {
         });
     });
 
-    it("Should update the User Status when requested by Super User", function (done) {
+    // Skipping this as the users are not allowed to mark them as active or idle. Will remove the test while removing the feature flag.
+    // eslint-disable-next-line mocha/no-skipped-tests
+    it.skip("Should update the User Status when requested by Super User", function (done) {
       chai
         .request(app)
         .patch(`/users/status/${userId}`)
@@ -371,7 +356,7 @@ describe("UserStatus", function () {
     it("Should return 401 for unauthorized request", function (done) {
       chai
         .request(app)
-        .patch(`/users/status/${testUserId}`)
+        .patch(`/users/status/${testUserId}?userStatusFlag=true`)
         .set("Cookie", `${cookieName}=""`)
         .send(userStatusDataForOooState)
         .end((err, res) => {
@@ -388,7 +373,7 @@ describe("UserStatus", function () {
     it("Should return 400 for incorrect state value", function (done) {
       chai
         .request(app)
-        .patch(`/users/status/self`)
+        .patch(`/users/status/self?userStatusFlag=true`)
         .set("cookie", `${cookieName}=${testUserJwt}`)
         .send(generateUserStatusData("IN_OFFICE", Date.now(), Date.now()))
         .end((err, res) => {
@@ -398,7 +383,7 @@ describe("UserStatus", function () {
           expect(res).to.have.status(400);
           expect(res.body).to.be.an("object");
           expect(res.body.error).to.equal(`Bad Request`);
-          expect(res.body.message).to.equal(`Invalid State. State must be either IDLE, ACTIVE, OOO, or ONBOARDING`);
+          expect(res.body.message).to.equal(`Invalid State. the acceptable states are OOO,ONBOARDING`);
           return done();
         });
     });
@@ -408,7 +393,7 @@ describe("UserStatus", function () {
       const untilDate = Date.now() + 4 * 24 * 60 * 60 * 1000;
       chai
         .request(app)
-        .patch(`/users/status/self`)
+        .patch(`/users/status/self?userStatusFlag=true`)
         .set("cookie", `${cookieName}=${testUserJwt}`)
         .send(generateUserStatusData("OOO", Date.now(), Date.now(), untilDate, ""))
         .end((err, res) => {
@@ -429,7 +414,7 @@ describe("UserStatus", function () {
       const fromDate = Date.now() - 4 * 24 * 60 * 60 * 1000;
       chai
         .request(app)
-        .patch(`/users/status/self`)
+        .patch(`/users/status/self?userStatusFlag=true`)
         .set("cookie", `${cookieName}=${testUserJwt}`)
         .send(generateUserStatusData("OOO", Date.now(), fromDate, "", ""))
         .end((err, res) => {
@@ -451,7 +436,7 @@ describe("UserStatus", function () {
       const untilDate = Date.now() + 5 * 24 * 60 * 60 * 1000;
       chai
         .request(app)
-        .patch(`/users/status/self`)
+        .patch(`/users/status/self?userStatusFlag=true`)
         .set("cookie", `${cookieName}=${testUserJwt}`)
         .send(generateUserStatusData("OOO", Date.now(), fromDate, untilDate, "Semester Exams"))
         .end((err, res) => {
@@ -468,21 +453,17 @@ describe("UserStatus", function () {
     });
 
     it("should replace old future OOO Status with new future OOO Status", async function () {
-      // creating Active Status from 12th Nov 2022
-      const response1 = await chai
-        .request(app)
-        .patch(`/users/status/self`)
-        .set("Cookie", `${cookieName}=${testUserJwt}`)
-        .send(generateUserStatusData("ACTIVE", Date.now(), Date.now()));
-      expect(response1).to.have.status(201);
-      expect(response1.body.data.currentStatus.state).to.equal("ACTIVE");
+      const updatedAtDate = Date.now();
+      const statusData = generateUserStatusData("ACTIVE", updatedAtDate, updatedAtDate);
+      statusData.userId = testUserId;
+      await firestore.collection("usersStatus").doc("userStatus").set(statusData);
 
       // Initially Marking OOO Status from 24th Nov 2022 to 28th Nov 2022
       let fromDate = new Date(2022, 10, 24).getTime();
       let untilDate = new Date(2022, 10, 28).getTime();
       const response2 = await chai
         .request(app)
-        .patch(`/users/status/self`)
+        .patch(`/users/status/self?userStatusFlag=true`)
         .set("Cookie", `${cookieName}=${testUserJwt}`)
         .send(generateUserStatusData("OOO", Date.now(), fromDate, untilDate, "Vacation Trip"));
       expect(response2).to.have.status(200);
@@ -497,7 +478,7 @@ describe("UserStatus", function () {
       untilDate = new Date(2022, 11, 5).getTime();
       const response3 = await chai
         .request(app)
-        .patch(`/users/status/self`)
+        .patch(`/users/status/self?userStatusFlag=true`)
         .set("Cookie", `${cookieName}=${testUserJwt}`)
         .send(generateUserStatusData("OOO", Date.now(), fromDate, untilDate, "New plan for vacation Trip"));
       expect(response3).to.have.status(200);
@@ -526,7 +507,7 @@ describe("UserStatus", function () {
       let untilDate = new Date(2022, 10, 28).getTime(); // 28th Nov 2022
       const response1 = await chai
         .request(app)
-        .patch(`/users/status/self`)
+        .patch(`/users/status/self?userStatusFlag=true`)
         .set("Cookie", `${cookieName}=${testUserJwt}`)
         .send(generateUserStatusData("OOO", Date.now(), fromDate, untilDate, "Vacation Trip"));
       expect(response1).to.have.status(201);
@@ -541,7 +522,7 @@ describe("UserStatus", function () {
       untilDate = new Date(2022, 10, 17).getTime(); // 17th Nov 2022
       const response2 = await chai
         .request(app)
-        .patch(`/users/status/self`)
+        .patch(`/users/status/self?userStatusFlag=true`)
         .set("Cookie", `${cookieName}=${testUserJwt}`)
         .send(generateUserStatusData("OOO", Date.now(), fromDate, untilDate, "Changed plan for vacation Trip"));
       expect(response2).to.have.status(200);


### PR DESCRIPTION
Parent Ticket Id - https://github.com/Real-Dev-Squad/website-backend/issues/1184

**Changes** :

- [ ] Add functionality to remove the option of marking oneself as idle or active in status.
- [ ] This was implemented with the feature flag `userStatusFlag` and the old tests were removed.
- [ ] This feature flag is temporary and will be removed once the feature becomes stable.