### PR TITLE
Auto script to detect idle users ids

### DIFF
--- a/controllers/userStatus.js
+++ b/controllers/userStatus.js
@@ -149,11 +149,11 @@ const updateAllUserStatus = async (req, res) => {
  * @param res {Object} - Express response object
  */
 
-const getUsersWithoutAssignedOrInProgressTasks = async (req, res) => {
+const getIdleUsers = async (req, res) => {
   try {
-    const data = await userStatusModel.getUsersWithoutAssignedOrInProgressTasks();
+    const data = await userStatusModel.getIdleUsers();
     return res.json({
-      message: "All Non IN_PROGRESS and Non ACTIVE task state users found successfully.",
+      message: "All idle users found successfully.",
       data,
     });
   } catch (error) {
@@ -166,7 +166,7 @@ const getUsersWithoutAssignedOrInProgressTasks = async (req, res) => {
 
 const getUserStatusControllers = async (req, res, next) => {
   if (Object.keys(req.query).includes("taskStatus")) {
-    await getUsersWithoutAssignedOrInProgressTasks(req, res, next);
+    await getIdleUsers(req, res, next);
   } else {
     await getAllUserStatus(req, res, next);
   }
@@ -178,6 +178,6 @@ module.exports = {
   getAllUserStatus,
   updateUserStatus,
   updateAllUserStatus,
-  getUsersWithoutAssignedOrInProgressTasks,
+  getIdleUsers,
   getUserStatusControllers,
 };

--- a/controllers/userStatus.js
+++ b/controllers/userStatus.js
@@ -143,4 +143,41 @@ const updateAllUserStatus = async (req, res) => {
   }
 };
 
-module.exports = { deleteUserStatus, getUserStatus, getAllUserStatus, updateUserStatus, updateAllUserStatus };
+/**
+ * Retrieve the idle users based on their task status - in progress , assigned
+ * @req {Object} - Express request object
+ * @res {Object} - Express response object
+ */
+
+const getUsersWithoutAssignedOrInProgressTasks = async (req, res) => {
+  try {
+    const data = await userStatusModel.getUsersWithoutAssignedOrInProgressTasks();
+    return res.json({
+      message: "All Non IN_PROGRESS and Non ACTIVE task state users found successfully.",
+      data,
+    });
+  } catch (error) {
+    logger.error(error.message);
+    return res.status(500).json({
+      message: "The server has encountered an unexpected error. Please contact the administrator for more information.",
+    });
+  }
+};
+
+const getUserStatusControllers = async (req, res, next) => {
+  if (Object.keys(req.query).includes("taskStatus")) {
+    await getUsersWithoutAssignedOrInProgressTasks(req, res, next);
+  } else {
+    await getAllUserStatus(req, res, next);
+  }
+};
+
+module.exports = {
+  deleteUserStatus,
+  getUserStatus,
+  getAllUserStatus,
+  updateUserStatus,
+  updateAllUserStatus,
+  getUsersWithoutAssignedOrInProgressTasks,
+  getUserStatusControllers,
+};

--- a/controllers/userStatus.js
+++ b/controllers/userStatus.js
@@ -144,7 +144,7 @@ const updateAllUserStatus = async (req, res) => {
 };
 
 /**
- * Retrieve the idle users based on their task status - in progress , assigned
+ * Retrieve idle users based on task status where the status is not assigned and in progress
  * @param req {Object} - Express request object
  * @param res {Object} - Express response object
  */

--- a/controllers/userStatus.js
+++ b/controllers/userStatus.js
@@ -145,8 +145,8 @@ const updateAllUserStatus = async (req, res) => {
 
 /**
  * Retrieve the idle users based on their task status - in progress , assigned
- * @req {Object} - Express request object
- * @res {Object} - Express response object
+ * @param req {Object} - Express request object
+ * @param res {Object} - Express response object
  */
 
 const getUsersWithoutAssignedOrInProgressTasks = async (req, res) => {

--- a/middlewares/validators/userStatus.js
+++ b/middlewares/validators/userStatus.js
@@ -72,6 +72,28 @@ const validateUserStatus = (req, res, next) => {
   validateUserStatusData(todaysTime, req, res, next);
 };
 
+const validateGetQueryParams = async (req, res, next) => {
+  const schema = Joi.object()
+    .keys({
+      taskStatus: Joi.string()
+        .trim()
+        .valid(userState.IDLE)
+        .error(new Error(`Invalid state value passed for taskStatus.`)),
+    })
+    .messages({
+      "object.unknown": "Invalid query param provided.",
+    });
+
+  try {
+    await schema.validateAsync(req.query);
+    next();
+  } catch (error) {
+    logger.error(`Error validating Query Params for GET ${error.message}`);
+    res.boom.badRequest(error);
+  }
+};
+
 module.exports = {
   validateUserStatus,
+  validateGetQueryParams,
 };

--- a/middlewares/validators/userStatus.js
+++ b/middlewares/validators/userStatus.js
@@ -79,6 +79,10 @@ const validateGetQueryParams = async (req, res, next) => {
         .trim()
         .valid(userState.IDLE)
         .error(new Error(`Invalid state value passed for taskStatus.`)),
+      state: Joi.string()
+        .trim()
+        .valid(userState.IDLE, userState.ACTIVE, userState.OOO, userState.ONBOARDING)
+        .error(new Error(`Invalid State. State must be either IDLE, ACTIVE, OOO, or ONBOARDING`)),
     })
     .messages({
       "object.unknown": "Invalid query param provided.",

--- a/models/userStatus.js
+++ b/models/userStatus.js
@@ -326,8 +326,8 @@ const updateStatusOnTaskCompletion = async (userId) => {
   }
 };
 
-const getUsersWithoutAssignedOrInProgressTasks = async () => {
-  const usersWithoutAssignedOrInProgressTasks = [];
+const getIdleUsers = async () => {
+  const idleUsers = [];
   const usersNotProcessed = [];
   let errorCount = 0;
   let discordActiveNonArchivedUsersQuerySnapshot;
@@ -352,7 +352,7 @@ const getUsersWithoutAssignedOrInProgressTasks = async () => {
             .where("status", "in", [TASK_STATUS.ASSIGNED, TASK_STATUS.IN_PROGRESS])
             .get();
           if (tasksQuerySnapshot.empty) {
-            usersWithoutAssignedOrInProgressTasks.push(assigneeId);
+            idleUsers.push(assigneeId);
           }
         } catch (error) {
           errorCount++;
@@ -365,8 +365,8 @@ const getUsersWithoutAssignedOrInProgressTasks = async () => {
 
   return {
     totalValidUsersCount,
-    usersWithoutAssignedOrInProgressTasksCount: usersWithoutAssignedOrInProgressTasks.length,
-    usersWithoutAssignedOrInProgressTasks,
+    idleUsersCount: idleUsers.length,
+    idleUsers,
     usersNotProcessedCount: errorCount,
     usersNotProcessed,
   };
@@ -381,5 +381,5 @@ module.exports = {
   updateUserStatusOnNewTaskAssignment,
   updateUserStatusOnTaskUpdate,
   updateStatusOnTaskCompletion,
-  getUsersWithoutAssignedOrInProgressTasks,
+  getIdleUsers,
 };

--- a/models/userStatus.js
+++ b/models/userStatus.js
@@ -12,6 +12,7 @@ const {
   checkIfUserHasLiveTasks,
   generateErrorResponse,
 } = require("../utils/userStatus");
+const { TASK_STATUS } = require("../constants/tasks");
 const userStatusModel = firestore.collection("usersStatus");
 const tasksModel = firestore.collection("tasks");
 const usersCollection = firestore.collection("users");
@@ -348,7 +349,7 @@ const getUsersWithoutAssignedOrInProgressTasks = async () => {
           const tasksQuerySnapshot = await firestore
             .collection("tasks")
             .where("assignee", "==", assigneeId)
-            .where("status", "in", ["ASSIGNED", "IN_PROGRESS"])
+            .where("status", "in", [TASK_STATUS.ASSIGNED, TASK_STATUS.IN_PROGRESS])
             .get();
           if (tasksQuerySnapshot.empty) {
             usersWithoutAssignedOrInProgressTasks.push(assigneeId);

--- a/routes/userStatus.js
+++ b/routes/userStatus.js
@@ -10,9 +10,9 @@ const router = express.Router();
 const authenticate = require("../middlewares/authenticate");
 const authorizeRoles = require("../middlewares/authorizeRoles");
 const { SUPERUSER } = require("../constants/roles");
-const { validateUserStatus } = require("../middlewares/validators/userStatus");
+const { validateUserStatus, validateGetQueryParams } = require("../middlewares/validators/userStatus");
 
-router.get("/", getAllUserStatus);
+router.get("/", validateGetQueryParams, getAllUserStatus);
 router.get("/self", authenticate, getUserStatus);
 router.get("/:userId", getUserStatus);
 router.patch("/self", authenticate, validateUserStatus, updateUserStatus);

--- a/routes/userStatus.js
+++ b/routes/userStatus.js
@@ -2,9 +2,9 @@ const express = require("express");
 const {
   deleteUserStatus,
   getUserStatus,
-  getAllUserStatus,
   updateUserStatus,
   updateAllUserStatus,
+  getUserStatusControllers,
 } = require("../controllers/userStatus");
 const router = express.Router();
 const authenticate = require("../middlewares/authenticate");
@@ -12,7 +12,7 @@ const authorizeRoles = require("../middlewares/authorizeRoles");
 const { SUPERUSER } = require("../constants/roles");
 const { validateUserStatus, validateGetQueryParams } = require("../middlewares/validators/userStatus");
 
-router.get("/", validateGetQueryParams, getAllUserStatus);
+router.get("/", validateGetQueryParams, getUserStatusControllers);
 router.get("/self", authenticate, getUserStatus);
 router.get("/:userId", getUserStatus);
 router.patch("/self", authenticate, validateUserStatus, updateUserStatus);

--- a/test/fixtures/user/user.js
+++ b/test/fixtures/user/user.js
@@ -167,6 +167,7 @@ module.exports = () => {
       roles: {
         member: true,
         archived: false,
+        in_discord: true,
       },
       picture: {
         publicId: "profile/mtS4DhUvNYsKqI7oCWVB/aenklfhtjldc5ytei3ar",
@@ -205,6 +206,7 @@ module.exports = () => {
       roles: {
         archived: false,
         member: true,
+        in_discord: true,
       },
       twitter_id: "RitvikJamwal4u",
       linkedin_id: "ritvik-jamwal4u",
@@ -225,6 +227,8 @@ module.exports = () => {
       },
       roles: {
         member: true,
+        archived: false,
+        in_discord: true,
       },
       picture: {
         publicId: "profile/mtS4DhUvNYsKqI7oCWVB/aenklfhtjldc5ytei3ar",

--- a/test/integration/taskBasedStatusUpdate.test.js
+++ b/test/integration/taskBasedStatusUpdate.test.js
@@ -330,17 +330,17 @@ describe("Task Based Status Updates", function () {
         .set("cookie", `${cookieName}=${superUserJwt}`);
 
       expect(response.status).to.equal(200);
-      expect(response.body.message).to.equal("All Non IN_PROGRESS and Non ACTIVE task state users found successfully.");
+      expect(response.body.message).to.equal("All idle users found successfully.");
       expect(response.body.data.totalValidUsersCount).to.equal(4);
-      expect(response.body.data.usersWithoutAssignedOrInProgressTasksCount).to.equal(2);
-      expect(response.body.data.usersWithoutAssignedOrInProgressTasks).to.have.members([userId3, superUserId]);
+      expect(response.body.data.idleUsersCount).to.equal(2);
+      expect(response.body.data.idleUsers).to.have.members([userId3, superUserId]);
       expect(response.body.data.usersNotProcessedCount).to.equal(0);
       expect(response.body.data.usersNotProcessed).to.deep.equal([]);
     });
 
     it("should throw an error when an error occurs", async function () {
       sinon
-        .stub(userStatusModel, "getUsersWithoutAssignedOrInProgressTasks")
+        .stub(userStatusModel, "getIdleUsers")
         .throws(
           new Error(
             "The server has encountered an unexpected error. Please contact the administrator for more information."

--- a/test/unit/middlewares/userStatusValidator.js
+++ b/test/unit/middlewares/userStatusValidator.js
@@ -1,0 +1,42 @@
+const Sinon = require("sinon");
+const { expect } = require("chai");
+const { validateGetQueryParams } = require("../../../middlewares/validators/userStatus");
+
+describe.only("Middleware | Validators | userStatus", function () {
+  describe("validateRequestQuery", function () {
+    it("lets the request pass to the next function for a valid query", async function () {
+      const res = {};
+      const req = {
+        query: {
+            state: "IDLE",
+        },
+      };
+      const nextSpy = Sinon.spy();
+      await validateGetQueryParams(req, res, nextSpy);
+      expect(nextSpy.calledOnce).to.be.equal(true);
+      
+      delete req.query.state
+      req.query.taskStatus = "IDLE";
+      await validateGetQueryParams(req, res, nextSpy);
+      expect(nextSpy.calledTwice).to.be.equal(true);
+    });
+
+    it("stops the propogation of the event to next function", async function () {
+      const res = {
+        boom: {
+          badRequest: () => {},
+        },
+      };
+      const nextSpy = Sinon.spy();
+      const req = {
+        query: {
+            taskStatus: "invalidKey",
+        },
+      };
+      await validateGetQueryParams(req, res, nextSpy).catch((err) => {
+        expect(err).to.be.an.instanceOf(Error);
+      });
+      expect(nextSpy.callCount).to.be.equal(0);
+    });
+  })
+});

--- a/test/unit/middlewares/userStatusValidator.js
+++ b/test/unit/middlewares/userStatusValidator.js
@@ -2,20 +2,20 @@ const Sinon = require("sinon");
 const { expect } = require("chai");
 const { validateGetQueryParams } = require("../../../middlewares/validators/userStatus");
 
-describe.only("Middleware | Validators | userStatus", function () {
+describe("Middleware | Validators | userStatus", function () {
   describe("validateRequestQuery", function () {
     it("lets the request pass to the next function for a valid query", async function () {
       const res = {};
       const req = {
         query: {
-            state: "IDLE",
+          state: "IDLE",
         },
       };
       const nextSpy = Sinon.spy();
       await validateGetQueryParams(req, res, nextSpy);
       expect(nextSpy.calledOnce).to.be.equal(true);
-      
-      delete req.query.state
+
+      delete req.query.state;
       req.query.taskStatus = "IDLE";
       await validateGetQueryParams(req, res, nextSpy);
       expect(nextSpy.calledTwice).to.be.equal(true);
@@ -30,7 +30,7 @@ describe.only("Middleware | Validators | userStatus", function () {
       const nextSpy = Sinon.spy();
       const req = {
         query: {
-            taskStatus: "invalidKey",
+          taskStatus: "invalidKey",
         },
       };
       await validateGetQueryParams(req, res, nextSpy).catch((err) => {
@@ -38,5 +38,5 @@ describe.only("Middleware | Validators | userStatus", function () {
       });
       expect(nextSpy.callCount).to.be.equal(0);
     });
-  })
+  });
 });

--- a/test/unit/models/taskBasedStatusUpdate.test.js
+++ b/test/unit/models/taskBasedStatusUpdate.test.js
@@ -8,7 +8,7 @@ const {
   updateStatusOnTaskCompletion,
   updateUserStatusOnNewTaskAssignment,
   updateUserStatusOnTaskUpdate,
-  getUsersWithoutAssignedOrInProgressTasks,
+  getIdleUsers,
 } = require("../../../models/userStatus");
 const cleanDb = require("../../utils/cleanDb");
 const addUser = require("../../utils/addUser");
@@ -224,7 +224,7 @@ describe("Update Status based on task update", function () {
     });
   });
 
-  describe("getUsersWithoutAssignedOrInProgressTasks", function () {
+  describe("getIdleUsers", function () {
     let userId1;
     let userId2;
     let userId3;
@@ -259,10 +259,10 @@ describe("Update Status based on task update", function () {
     });
 
     it("should return the correct results when there are no errors", async function () {
-      const result = await getUsersWithoutAssignedOrInProgressTasks();
+      const result = await getIdleUsers();
       expect(result.totalValidUsersCount).to.equal(3);
-      expect(result.usersWithoutAssignedOrInProgressTasksCount).to.equal(1);
-      expect(result.usersWithoutAssignedOrInProgressTasks).to.deep.equal([userId3]);
+      expect(result.idleUsersCount).to.equal(1);
+      expect(result.idleUsers).to.deep.equal([userId3]);
       expect(result.usersNotProcessedCount).to.equal(0);
       expect(result.usersNotProcessed).to.deep.equal([]);
     });
@@ -271,7 +271,7 @@ describe("Update Status based on task update", function () {
       const usersCollection = firestore.collection("users");
       sinon.stub(usersCollection, "where").returns(usersCollection);
       sinon.stub(usersCollection, "get").throws(new Error("unable to get users"));
-      await getUsersWithoutAssignedOrInProgressTasks().catch((err) => {
+      await getIdleUsers().catch((err) => {
         expect(err).to.be.an.instanceOf(Error);
         expect(err.message).to.be.equal("unable to get users");
       });

--- a/test/unit/models/taskBasedStatusUpdate.test.js
+++ b/test/unit/models/taskBasedStatusUpdate.test.js
@@ -1,6 +1,5 @@
 const chai = require("chai");
 const sinon = require("sinon");
-// const admin = require("firebase-admin");
 const { expect } = chai;
 const firestore = require("../../../utils/firestore");
 const userStatusModel = firestore.collection("usersStatus");
@@ -268,52 +267,14 @@ describe("Update Status based on task update", function () {
       expect(result.usersNotProcessed).to.deep.equal([]);
     });
 
-    it("should return the correct results when there are errors", async function () {
-      // const usersCollection = firestore.collection("users");
-      // ----------------------------------------------------------------------------------------
-      // sinon.stub(usersCollection, "get").throws(new Error("Unable to fetch users"));
-      // ----------------------------------------------------------------------------------------
-      // sinon.stub(usersCollection, "where").callsFake((query) => {
-      // console.log("Stubbed get method called");
-      //   if (query.where("roles.in_discord", "==", true) && query.where("roles.archived", "==", false)) {
-      //     throw new Error("Unable to fetch users");
-      //   } else {
-      //     return usersCollection.get();
-      //   }
-      // });
-      // ----------------------------------------------------------------------------------------
-      // sinon.stub(usersCollection, "get").callsFake(() => {
-      //   console.log("Stubbed get method called");
-      //   throw new Error("Unable to fetch users");
-      // });
-      // ----------------------------------------------------------------------------------------
-      // sinon.stub(usersCollection, "where").returns(usersCollection);
-      // sinon.stub(usersCollection, "get").throws(new Error("Unable to fetch users"));
-      // ----------------------------------------------------------------------------------------
-      // sinon.stub(usersCollection, "where").returnsThis();
-      // sinon.stub(usersCollection, "get").throws(new Error("Unable to fetch users"));
-      // ----------------------------------------------------------------------------------------
-      // sinon.stub(usersCollection, "where").callsFake((query) => {
-      //   console.log("Stubbed where method called with query:", query);
-      //   return usersCollection;
-      // });
-      // sinon.stub(usersCollection, "get").callsFake(() => {
-      //   console.log("Stubbed get method called");
-      //   throw new Error("Unable to fetch users");
-      // });
-      // ----------------------------------------------------------------------------------------
-      // const queryStub = sinon.stub().throws(new Error('Unable to fetch users'));
-      // sinon.stub(usersCollection, 'where').returns({ get: queryStub });
-      // ----------------------------------------------------------------------------------------
-      // Mocking the entire firestore to throw an error
-      // sinon.stub(admin, 'initializeApp').throws(new Error('Unable to initializeApp'));
-      // sinon.stub(admin, 'initializeApp').callsFake(() => {
-      //   console.log("Stubbed initializeApp");
-      //   throw new Error("Unable to initializeApp");
-      // });
-      // ----------------------------------------------------------------------------------------
-      // const result = await getUsersWithoutAssignedOrInProgressTasks();
-      // expect(result).to.deep.equal(expectedResult);
+    it("should throw an error if users query fail", async function () {
+      const usersCollection = firestore.collection("users");
+      sinon.stub(usersCollection, "where").returns(usersCollection);
+      sinon.stub(usersCollection, "get").throws(new Error("unable to get users"));
+      await getUsersWithoutAssignedOrInProgressTasks().catch((err) => {
+        expect(err).to.be.an.instanceOf(Error);
+        expect(err.message).to.be.equal("unable to get users");
+      });
     });
   });
 });


### PR DESCRIPTION
Closes the 1st task of the ticket https://github.com/Real-Dev-Squad/website-backend/issues/1248

- As of now users can change their status to idle active or OOO from my site. moving forward this will be decided from their task if they have a task assigned on their name or a task in progress they are active else they would be considered idle. Now the users have the flexibility to mark themselves as idle or active from my site on their own which will be removed. This script will Identify all the users who are idle based on their task status. If they have a task in assigned or in_progress they will be counted as active else they will be counted as idle and returned in the response of this script. This is a one time script going forward when a new task is assigned user will be marked active and once they mark it as complete it will be checked if they have another task in progress or assigned if yes they will remain active if not they will be marked idle.

Testing Stats

 Middlewares

![image](https://github.com/Real-Dev-Squad/website-backend/assets/97341921/b94c3b20-9130-4d38-a0f6-515a41acd8b8)

Models 

![image](https://github.com/Real-Dev-Squad/website-backend/assets/97341921/4a521545-06d0-4340-9634-82b76e24de88)

Controllers

![image](https://github.com/Real-Dev-Squad/website-backend/assets/97341921/ec8615ae-19f8-4d8d-bce7-d6fd006e3500)


