### PR TITLE
Remove orderBy from self tasks api

### DIFF
--- a/models/tasks.js
+++ b/models/tasks.js
@@ -356,7 +356,7 @@ const fetchSkillLevelTask = async (userId) => {
  */
 const fetchSelfTasks = async (username) => {
   return await fetchUserTasks(username, []);
-  // removed startedOn as now task is not have field startedOn
+Removed `startedOn` field since we are getting issues with some of the documents in the tasks collection as some of the documents dont have `startedOn` present. 
 };
 
 /**

--- a/models/tasks.js
+++ b/models/tasks.js
@@ -253,8 +253,7 @@ const fetchUserTasks = async (username, statuses = [], field, order) => {
           .where("participants", "array-contains", userId)
           .orderBy(field, order)
           .get();
-        featureTasksSnapshot = await tasksModel.where("assignee", "==", userId).get();
-        // removed orderBy(field, order) as now task is not have field startedOn
+        featureTasksSnapshot = await tasksModel.where("assignee", "==", userId).orderBy(field, order).get();
       } else {
         groupTasksSnapshot = await tasksModel.where("participants", "array-contains", userId).get();
         featureTasksSnapshot = await tasksModel.where("assignee", "==", userId).get();
@@ -356,7 +355,8 @@ const fetchSkillLevelTask = async (userId) => {
  * @returns {Promise<tasks>|Array}
  */
 const fetchSelfTasks = async (username) => {
-  return await fetchUserTasks(username, [], "startedOn", "desc");
+  return await fetchUserTasks(username, []);
+  // removed startedOn as now task is not have field startedOn
 };
 
 /**

--- a/models/tasks.js
+++ b/models/tasks.js
@@ -356,7 +356,7 @@ const fetchSkillLevelTask = async (userId) => {
  */
 const fetchSelfTasks = async (username) => {
   return await fetchUserTasks(username, []);
-Removed `startedOn` field since we are getting issues with some of the documents in the tasks collection as some of the documents dont have `startedOn` present. 
+  // Removed `startedOn` field since we are getting issues with some of the documents in the tasks collection as some of the documents dont have `startedOn` present.
 };
 
 /**

--- a/models/tasks.js
+++ b/models/tasks.js
@@ -253,7 +253,8 @@ const fetchUserTasks = async (username, statuses = [], field, order) => {
           .where("participants", "array-contains", userId)
           .orderBy(field, order)
           .get();
-        featureTasksSnapshot = await tasksModel.where("assignee", "==", userId).orderBy(field, order).get();
+        featureTasksSnapshot = await tasksModel.where("assignee", "==", userId).get();
+        // removed orderBy(field, order) as now task is not have field startedOn
       } else {
         groupTasksSnapshot = await tasksModel.where("participants", "array-contains", userId).get();
         featureTasksSnapshot = await tasksModel.where("assignee", "==", userId).get();


### PR DESCRIPTION
Closes #1254

## Overview

Currently, self API of tasks is failing because there is no field of startedOn in some tasks so for the temporary solution it is been removed for a permanent solution the issue is mentioned below.

![image](https://github.com/Real-Dev-Squad/website-backend/assets/111434418/acb16a02-0348-4428-813d-ebc8e96f5c57)

## Later work
- https://github.com/Real-Dev-Squad/website-backend/issues/1257
