### PR TITLE
Add middleware to invalidate cache

### DIFF
--- a/constants/cacheKeys.js
+++ b/constants/cacheKeys.js
@@ -1,3 +1,3 @@
-const ALL_TASKS = "__cache__ALL_TASKS";
+const ALL_TASKS = "cache:ALL-TASKS";
 
 module.exports = { ALL_TASKS };

--- a/constants/cacheKeys.js
+++ b/constants/cacheKeys.js
@@ -1,3 +1,3 @@
-const TASKS_ALL = "__cache__ALL_TASKS";
+const ALL_TASKS = "__cache__ALL_TASKS";
 
-module.exports = { TASKS_ALL };
+module.exports = { ALL_TASKS };

--- a/constants/cacheKeys.js
+++ b/constants/cacheKeys.js
@@ -1,0 +1,3 @@
+const TASKS_ALL = "__cache__GET/tasks";
+
+module.exports = { TASKS_ALL };

--- a/constants/cacheKeys.js
+++ b/constants/cacheKeys.js
@@ -1,3 +1,3 @@
-const TASKS_ALL = "__cache__GET/tasks";
+const TASKS_ALL = "__cache__ALL_TASKS";
 
 module.exports = { TASKS_ALL };

--- a/routes/taskRequests.js
+++ b/routes/taskRequests.js
@@ -4,10 +4,10 @@ const router = express.Router();
 const authenticate = require("../middlewares/authenticate");
 const authorizeRoles = require("../middlewares/authorizeRoles");
 const taskRequests = require("../controllers/tasksRequests");
-const { cache } = require("../utils/cache");
+const { cacheResponse } = require("../utils/cache");
 const { validateUser } = require("../middlewares/taskRequests");
 
-router.get("/", authenticate, authorizeRoles([SUPERUSER]), cache(), taskRequests.fetchTaskRequests);
+router.get("/", authenticate, authorizeRoles([SUPERUSER]), cacheResponse(), taskRequests.fetchTaskRequests);
 router.post("/addOrUpdate", authenticate, validateUser, taskRequests.addOrUpdate);
 router.patch("/approve", authenticate, authorizeRoles([SUPERUSER]), validateUser, taskRequests.approveTaskRequest);
 

--- a/routes/taskRequests.js
+++ b/routes/taskRequests.js
@@ -4,7 +4,7 @@ const router = express.Router();
 const authenticate = require("../middlewares/authenticate");
 const authorizeRoles = require("../middlewares/authorizeRoles");
 const taskRequests = require("../controllers/tasksRequests");
-const cache = require("../utils/cache");
+const { cache } = require("../utils/cache");
 const { validateUser } = require("../middlewares/taskRequests");
 
 router.get("/", authenticate, authorizeRoles([SUPERUSER]), cache(), taskRequests.fetchTaskRequests);

--- a/routes/tasks.js
+++ b/routes/tasks.js
@@ -6,17 +6,17 @@ const { createTask, updateTask, updateSelfTask, getTasksValidator } = require(".
 const authorizeRoles = require("../middlewares/authorizeRoles");
 const { APPOWNER, SUPERUSER } = require("../constants/roles");
 const assignTask = require("../middlewares/assignTask");
-const { cache, invalidateCache } = require("../utils/cache");
-const { TASKS_ALL } = require("../constants/cacheKeys");
+const { cacheResponse, invalidateCache } = require("../utils/cache");
+const { ALL_TASKS } = require("../constants/cacheKeys");
 
-router.get("/", getTasksValidator, cache({ invalidationKey: TASKS_ALL, expiry: 10 }), tasks.fetchTasks);
+router.get("/", getTasksValidator, cacheResponse({ invalidationKey: ALL_TASKS, expiry: 10 }), tasks.fetchTasks);
 router.get("/self", authenticate, tasks.getSelfTasks);
 router.get("/overdue", authenticate, authorizeRoles([SUPERUSER]), tasks.overdueTasks);
 router.post(
   "/",
   authenticate,
   authorizeRoles([APPOWNER, SUPERUSER]),
-  invalidateCache({ invalidationKeys: [TASKS_ALL] }),
+  invalidateCache({ invalidationKeys: [ALL_TASKS] }),
   createTask,
   tasks.addNewTask
 );
@@ -24,7 +24,7 @@ router.patch(
   "/:id",
   authenticate,
   authorizeRoles([APPOWNER, SUPERUSER]),
-  invalidateCache({ invalidationKeys: [TASKS_ALL] }),
+  invalidateCache({ invalidationKeys: [ALL_TASKS] }),
   updateTask,
   tasks.updateTask
 );
@@ -33,11 +33,11 @@ router.get("/:username", tasks.getUserTasks);
 router.patch(
   "/self/:id",
   authenticate,
-  invalidateCache({ invalidationKeys: [TASKS_ALL] }),
+  invalidateCache({ invalidationKeys: [ALL_TASKS] }),
   updateSelfTask,
   tasks.updateTaskStatus,
   assignTask
 );
-router.patch("/assign/self", authenticate, invalidateCache({ invalidationKeys: [TASKS_ALL] }), tasks.assignTask);
+router.patch("/assign/self", authenticate, invalidateCache({ invalidationKeys: [ALL_TASKS] }), tasks.assignTask);
 
 module.exports = router;

--- a/routes/tasks.js
+++ b/routes/tasks.js
@@ -9,14 +9,14 @@ const assignTask = require("../middlewares/assignTask");
 const { cache, invalidateCache } = require("../utils/cache");
 const { TASKS_ALL } = require("../constants/cacheKeys");
 
-router.get("/", getTasksValidator, cache(TASKS_ALL, 10), tasks.fetchTasks);
+router.get("/", getTasksValidator, cache({ invalidationKey: TASKS_ALL, expiry: 10 }), tasks.fetchTasks);
 router.get("/self", authenticate, tasks.getSelfTasks);
 router.get("/overdue", authenticate, authorizeRoles([SUPERUSER]), tasks.overdueTasks);
 router.post(
   "/",
   authenticate,
   authorizeRoles([APPOWNER, SUPERUSER]),
-  invalidateCache([TASKS_ALL]),
+  invalidateCache({ invalidationKeys: [TASKS_ALL] }),
   createTask,
   tasks.addNewTask
 );
@@ -24,7 +24,7 @@ router.patch(
   "/:id",
   authenticate,
   authorizeRoles([APPOWNER, SUPERUSER]),
-  invalidateCache([TASKS_ALL]),
+  invalidateCache({ invalidationKeys: [TASKS_ALL] }),
   updateTask,
   tasks.updateTask
 );
@@ -33,10 +33,11 @@ router.get("/:username", tasks.getUserTasks);
 router.patch(
   "/self/:id",
   authenticate,
-  invalidateCache([TASKS_ALL]),
+  invalidateCache({ invalidationKeys: [TASKS_ALL] }),
   updateSelfTask,
   tasks.updateTaskStatus,
   assignTask
 );
-router.patch("/assign/self", authenticate, invalidateCache([TASKS_ALL]), tasks.assignTask);
+router.patch("/assign/self", authenticate, invalidateCache({ invalidationKeys: [TASKS_ALL] }), tasks.assignTask);
+
 module.exports = router;

--- a/test/fixtures/cache/cache.js
+++ b/test/fixtures/cache/cache.js
@@ -1,0 +1,3 @@
+const dummyResponse = { body: "test" };
+
+module.exports = { dummyResponse };

--- a/test/unit/middlewares/cache.test.js
+++ b/test/unit/middlewares/cache.test.js
@@ -10,7 +10,7 @@ describe("Middleware | Utils | cache", function () {
   afterEach(function () {
     sinon.restore();
   });
-  it("should cache the response", async function () {
+  it("should cache the response", function () {
     const cacheTestKey = "__cache__1";
 
     const request = {
@@ -33,13 +33,13 @@ describe("Middleware | Utils | cache", function () {
     expect(nextSpy.callCount).to.equal(1);
     expect(response.send.callCount).to.equal(1);
 
-    await cacheMiddleware(request, response, nextSpy);
+    cacheMiddleware(request, response, nextSpy);
 
     expect(nextSpy.callCount).to.equal(1);
     expect(response.send.callCount).to.equal(2);
   });
 
-  it("should invalidate stale the response", async function () {
+  it("should invalidate stale the response", function () {
     const cacheTestKey = "__cache__2";
 
     const request = {

--- a/test/unit/middlewares/cache.test.js
+++ b/test/unit/middlewares/cache.test.js
@@ -1,0 +1,69 @@
+const sinon = require("sinon");
+const { expect } = require("chai");
+const { cache, invalidateCache } = require("../../../utils/cache");
+const { dummyResponse } = require("../../fixtures/cache/cache");
+
+const responseBody = JSON.stringify(dummyResponse);
+
+describe("Middleware | Utils | cache", function () {
+  it("should cache the response", async function () {
+    const cacheTestKey = "__cache__1";
+
+    const request = {};
+
+    const response = {
+      send: sinon.spy(),
+    };
+
+    const nextSpy = sinon.spy();
+
+    const cacheMiddleware = cache(cacheTestKey);
+
+    cacheMiddleware(request, response, nextSpy);
+
+    response.send(responseBody);
+
+    expect(nextSpy.callCount).to.equal(1);
+    expect(response.send.callCount).to.equal(1);
+
+    await cacheMiddleware(request, response, nextSpy);
+
+    expect(nextSpy.callCount).to.equal(1);
+    expect(response.send.callCount).to.equal(2);
+  });
+
+  it("should invalidate stale the response", async function () {
+    const cacheTestKey = "__cache__2";
+
+    const request = {};
+
+    const response = {
+      send: sinon.spy(),
+    };
+
+    const nextSpy = sinon.spy();
+
+    const cacheMiddlewareForCache = cache(cacheTestKey);
+
+    cacheMiddlewareForCache(request, response, nextSpy);
+
+    response.send(responseBody);
+
+    expect(nextSpy.callCount).to.equal(1);
+    expect(response.send.callCount).to.equal(1);
+
+    const cacheMiddlewareForInvalidation = invalidateCache([cacheTestKey]);
+
+    cacheMiddlewareForInvalidation(request, response, nextSpy);
+    response.send(responseBody);
+
+    expect(nextSpy.callCount).to.equal(2);
+    expect(response.send.callCount).to.equal(2);
+
+    cacheMiddlewareForCache(request, response, nextSpy);
+    response.send(responseBody);
+
+    expect(nextSpy.callCount).to.equal(3);
+    expect(response.send.callCount).to.equal(3);
+  });
+});

--- a/test/unit/middlewares/cache.test.js
+++ b/test/unit/middlewares/cache.test.js
@@ -14,11 +14,8 @@ describe("Middleware | Utils | cache", function () {
     const cacheTestKey = "__cache__1";
 
     const request = {
-      params: {},
-      query: {},
-      _parsedUrl: {
-        pathname: "/test",
-      },
+      method: "GET",
+      originalUrl: "/test1",
     };
 
     const response = {
@@ -46,11 +43,8 @@ describe("Middleware | Utils | cache", function () {
     const cacheTestKey = "__cache__2";
 
     const request = {
-      params: {},
-      query: {},
-      _parsedUrl: {
-        pathname: "/test2",
-      },
+      method: "GET",
+      originalUrl: "/test2",
     };
     const response = {
       send: sinon.spy(),

--- a/test/unit/middlewares/cache.test.js
+++ b/test/unit/middlewares/cache.test.js
@@ -1,6 +1,6 @@
 const sinon = require("sinon");
 const { expect } = require("chai");
-const { cache, invalidateCache } = require("../../../utils/cache");
+const { cacheResponse, invalidateCache } = require("../../../utils/cache");
 
 const { dummyResponse } = require("../../fixtures/cache/cache");
 
@@ -24,7 +24,7 @@ describe("Middleware | Utils | cache", function () {
 
     const nextSpy = sinon.spy();
 
-    const cacheMiddleware = cache({ invalidationKey: cacheTestKey });
+    const cacheMiddleware = cacheResponse({ invalidationKey: cacheTestKey });
 
     cacheMiddleware(request, response, nextSpy);
 
@@ -52,7 +52,7 @@ describe("Middleware | Utils | cache", function () {
 
     const nextSpy = sinon.spy();
 
-    const cacheMiddlewareForCache = cache({ invalidationKey: cacheTestKey });
+    const cacheMiddlewareForCache = cacheResponse({ invalidationKey: cacheTestKey });
 
     cacheMiddlewareForCache(request, response, nextSpy);
 

--- a/test/unit/middlewares/cache.test.js
+++ b/test/unit/middlewares/cache.test.js
@@ -1,15 +1,25 @@
 const sinon = require("sinon");
 const { expect } = require("chai");
 const { cache, invalidateCache } = require("../../../utils/cache");
+
 const { dummyResponse } = require("../../fixtures/cache/cache");
 
 const responseBody = JSON.stringify(dummyResponse);
 
 describe("Middleware | Utils | cache", function () {
+  afterEach(function () {
+    sinon.restore();
+  });
   it("should cache the response", async function () {
     const cacheTestKey = "__cache__1";
 
-    const request = {};
+    const request = {
+      params: {},
+      query: {},
+      _parsedUrl: {
+        pathname: "/test",
+      },
+    };
 
     const response = {
       send: sinon.spy(),
@@ -17,7 +27,7 @@ describe("Middleware | Utils | cache", function () {
 
     const nextSpy = sinon.spy();
 
-    const cacheMiddleware = cache(cacheTestKey);
+    const cacheMiddleware = cache({ invalidationKey: cacheTestKey });
 
     cacheMiddleware(request, response, nextSpy);
 
@@ -35,15 +45,20 @@ describe("Middleware | Utils | cache", function () {
   it("should invalidate stale the response", async function () {
     const cacheTestKey = "__cache__2";
 
-    const request = {};
-
+    const request = {
+      params: {},
+      query: {},
+      _parsedUrl: {
+        pathname: "/test2",
+      },
+    };
     const response = {
       send: sinon.spy(),
     };
 
     const nextSpy = sinon.spy();
 
-    const cacheMiddlewareForCache = cache(cacheTestKey);
+    const cacheMiddlewareForCache = cache({ invalidationKey: cacheTestKey });
 
     cacheMiddlewareForCache(request, response, nextSpy);
 
@@ -52,7 +67,7 @@ describe("Middleware | Utils | cache", function () {
     expect(nextSpy.callCount).to.equal(1);
     expect(response.send.callCount).to.equal(1);
 
-    const cacheMiddlewareForInvalidation = invalidateCache([cacheTestKey]);
+    const cacheMiddlewareForInvalidation = invalidateCache({ invalidationKeys: [cacheTestKey] });
 
     cacheMiddlewareForInvalidation(request, response, nextSpy);
     response.send(responseBody);

--- a/test/unit/utils/cache.test.js
+++ b/test/unit/utils/cache.test.js
@@ -43,7 +43,7 @@ describe("cachedKeysStore", function () {
 
       const result = keyStore.getCachedKeys(modelKey);
       expect(result).to.be.an("array");
-      //   expect(result).to.be.empty;
+      expect(result).to.deep.equal([]);
     });
   });
 
@@ -56,6 +56,7 @@ describe("cachedKeysStore", function () {
 
       const result = keyStore.getCachedKeys(modelKey);
       expect(result).to.be.an("array");
+      expect(result).to.deep.equal([]);
     });
 
     it("should not remove other cached keys for the same model key", function () {

--- a/test/unit/utils/cache.test.js
+++ b/test/unit/utils/cache.test.js
@@ -1,0 +1,72 @@
+const { expect } = require("chai");
+const { cachedKeysStore } = require("../../../utils/cache");
+
+describe("cachedKeysStore", function () {
+  let keyStore;
+  const modelKey = "modelKey";
+  beforeEach(function () {
+    keyStore = cachedKeysStore();
+  });
+
+  describe("getCachedKeys", function () {
+    it("should return an array of cached keys for a model key", function () {
+      const cachedKeys = ["key1", "key2", "key3"];
+      keyStore.addCachedKey(modelKey, "key1");
+      keyStore.addCachedKey(modelKey, "key2");
+      keyStore.addCachedKey(modelKey, "key3");
+
+      const result = keyStore.getCachedKeys(modelKey);
+
+      expect(result).to.be.an("array");
+      expect(result).to.be.deep.equal(cachedKeys);
+    });
+  });
+
+  describe("addCachedKey", function () {
+    it("should add a cached key to the key store", function () {
+      const cachedKey = "key1";
+
+      keyStore.addCachedKey(modelKey, cachedKey);
+
+      const result = keyStore.getCachedKeys(modelKey);
+      expect(result).to.have.members([cachedKey]);
+    });
+  });
+
+  describe("removeModelKey", function () {
+    it("should remove the model key and its associated cached keys from the key store", function () {
+      keyStore.addCachedKey(modelKey, "key1");
+      keyStore.addCachedKey(modelKey, "key2");
+      keyStore.addCachedKey(modelKey, "key3");
+
+      keyStore.removeModelKey(modelKey);
+
+      const result = keyStore.getCachedKeys(modelKey);
+      expect(result).to.be.an("array");
+      //   expect(result).to.be.empty;
+    });
+  });
+
+  describe("removeCachedKey", function () {
+    it("should remove a cached key from the key store for a given model key", function () {
+      const cachedKey = "key1";
+      keyStore.addCachedKey(modelKey, cachedKey);
+
+      keyStore.removeCachedKey(modelKey, cachedKey);
+
+      const result = keyStore.getCachedKeys(modelKey);
+      expect(result).to.be.an("array");
+    });
+
+    it("should not remove other cached keys for the same model key", function () {
+      keyStore.addCachedKey(modelKey, "key1");
+      keyStore.addCachedKey(modelKey, "key2");
+      keyStore.addCachedKey(modelKey, "key3");
+
+      keyStore.removeCachedKey(modelKey, "key2");
+
+      const result = keyStore.getCachedKeys(modelKey);
+      expect(result).to.have.members(["key1", "key3"]);
+    });
+  });
+});

--- a/test/unit/utils/cache.test.js
+++ b/test/unit/utils/cache.test.js
@@ -10,14 +10,14 @@ describe("cachedKeysStore", function () {
 
   describe("getCachedKeys", function () {
     it("should return an array of cached keys for a model key", function () {
-      const cachedKeys = ["key1", "key2", "key3"];
+      const cachedKeys = new Set(["key1", "key2", "key3"]);
       keyStore.addCachedKey(modelKey, "key1");
       keyStore.addCachedKey(modelKey, "key2");
       keyStore.addCachedKey(modelKey, "key3");
 
       const result = keyStore.getCachedKeys(modelKey);
 
-      expect(result).to.be.an("array");
+      expect(result).to.be.an("set");
       expect(result).to.be.deep.equal(cachedKeys);
     });
   });
@@ -29,7 +29,7 @@ describe("cachedKeysStore", function () {
       keyStore.addCachedKey(modelKey, cachedKey);
 
       const result = keyStore.getCachedKeys(modelKey);
-      expect(result).to.have.members([cachedKey]);
+      expect(result).to.deep.equal(new Set([cachedKey]));
     });
   });
 
@@ -42,8 +42,8 @@ describe("cachedKeysStore", function () {
       keyStore.removeModelKey(modelKey);
 
       const result = keyStore.getCachedKeys(modelKey);
-      expect(result).to.be.an("array");
-      expect(result).to.deep.equal([]);
+      expect(result).to.be.an("set");
+      expect(result).to.deep.equal(new Set());
     });
   });
 
@@ -55,8 +55,8 @@ describe("cachedKeysStore", function () {
       keyStore.removeCachedKey(modelKey, cachedKey);
 
       const result = keyStore.getCachedKeys(modelKey);
-      expect(result).to.be.an("array");
-      expect(result).to.deep.equal([]);
+      expect(result).to.be.an("set");
+      expect(result).to.deep.equal(new Set());
     });
 
     it("should not remove other cached keys for the same model key", function () {
@@ -67,7 +67,7 @@ describe("cachedKeysStore", function () {
       keyStore.removeCachedKey(modelKey, "key2");
 
       const result = keyStore.getCachedKeys(modelKey);
-      expect(result).to.have.members(["key1", "key3"]);
+      expect(result).to.deep.equal(new Set(["key1", "key3"]));
     });
   });
 });

--- a/utils/cache.js
+++ b/utils/cache.js
@@ -178,16 +178,18 @@ const generateCacheKey = (request) => {
 const invalidateCache = (options = {}) => {
   const keys = options.invalidationKeys;
 
+  if (!Array.isArray(keys)) {
+    throw new Error("Invalidation keys must be an array");
+  }
+
   return async (req, res, next) => {
     try {
-      if (Array.isArray(keys)) {
-        for (const key of keys) {
-          const cachedKeysList = cachedKeys.getCachedKeys(key);
-          for (const ck of cachedKeysList) {
-            pool.evict(ck);
-          }
-          cachedKeys.removeModelKey(key);
+      for (const key of keys) {
+        const cachedKeysList = cachedKeys.getCachedKeys(key);
+        for (const ck of cachedKeysList) {
+          pool.evict(ck);
         }
+        cachedKeys.removeModelKey(key);
       }
     } catch (err) {
       logger.error(`Error while removing cached response ${err}`);

--- a/utils/cache.js
+++ b/utils/cache.js
@@ -189,7 +189,7 @@ const cacheResponse = (options = {}) => {
  * @returns {string} cache key.
  */
 const generateCacheKey = (request) => {
-  return "__cache__" + request.method + request.originalUrl;
+  return "cache:" + request.method + ":" + request.originalUrl;
 };
 
 /**
@@ -209,8 +209,8 @@ const invalidateCache = (options = {}) => {
     try {
       for (const key of keys) {
         const cachedKeysSet = cachedKeys.getCachedKeys(key);
-        for (const ck of cachedKeysSet) {
-          pool.evict(ck);
+        for (const cachedKey of cachedKeysSet) {
+          pool.evict(cachedKey);
         }
         cachedKeys.removeModelKey(key);
       }

--- a/utils/cache.js
+++ b/utils/cache.js
@@ -72,8 +72,8 @@ const cachePool = (opt = { maximumSize: CACHE_SIZE_MB }) => {
   return { get, set, evict, hits, cacheStore };
 };
 /**
- * A MultiMap implementation where each key maps to set of unique values
- *
+ * A MultiMap implementation where each key maps to set of unique values.
+ * It internally uses Map to store keys and values and to save multiple values it uses Set. Map<string,Set<string>>
  */
 const cachedKeysStore = () => {
   const keyStore = new Map();

--- a/utils/cache.js
+++ b/utils/cache.js
@@ -84,10 +84,10 @@ const cachedKeysStore = () => {
    * @returns {Set} set of values
    */
   const getCachedKeys = (modelKey) => {
-    if (keyStore.has(modelKey)) {
-      return keyStore.get(modelKey);
+    if (!keyStore.has(modelKey)) {
+      return new Set();
     }
-    return new Set();
+    return keyStore.get(modelKey);
   };
 
   /**

--- a/utils/cache.js
+++ b/utils/cache.js
@@ -126,7 +126,6 @@ const cache = (options = {}) => {
   return async (req, res, next) => {
     try {
       const key = generateCacheKey(req);
-
       const cacheData = pool.get(key);
       if (cacheData) {
         res.send(cacheData);
@@ -167,14 +166,7 @@ const cache = (options = {}) => {
  * @returns {string} cache key.
  */
 const generateCacheKey = (request) => {
-  return (
-    "__cache__" +
-    request._parsedUrl.pathname +
-    "_p_" +
-    JSON.stringify(request.params) +
-    "_q_" +
-    JSON.stringify(request.query)
-  );
+  return "__cache__" + request.method + request.originalUrl;
 };
 
 /**


### PR DESCRIPTION
closes Issue: 

-  #1278 

Description:

1. Add a new data store to save all the keys generated for a particular cached API endpoint under a common key

>     eg: /tasks?page=2&size=9 / AND /tasks?page=10&size=10 will be saved as a set under a common key '__cache__ALL_TASKS'.


2. Add a middleware to evict cache data based on given common keys. 

>     eg: /tasks?page=2&size=9 / AND /tasks?page=10&size=10 cached 

3. Use the said middleware for when there's a write on tasks model
4. Increase expiry time of fetch all tasks api to 10mins.



Test coverage:
<img width="824" alt="Screenshot 2023-07-16 at 6 48 12 PM" src="https://github.com/Real-Dev-Squad/website-backend/assets/98796547/2175f833-e008-42a5-849c-104e06d84ace">

