### PR TITLE
Update Batch scripts Tests to handle active users

### DIFF
--- a/test/integration/taskBasedStatusUpdate.test.js
+++ b/test/integration/taskBasedStatusUpdate.test.js
@@ -287,64 +287,113 @@ describe("Task Based Status Updates", function () {
   });
 
   describe("PATCH Integration tests for Changing the status to IDLE based on users list passed", function () {
-    let superUserId;
-    let superUserJwt;
+    let userId0;
     let userId1;
     let userId2;
     let userId3;
     let userId4;
     let userId5;
+    let userId6;
+    let userId7;
+    let userId8;
+    let userId9;
+    let superUserJwt;
     let listUsers;
     const reqBody = {};
 
     beforeEach(async function () {
-      superUserId = await addUser(userData[4]);
-      superUserJwt = authService.generateAuthToken({ userId: superUserId });
-
-      userId1 = await addUser(userData[6]);
-      userId2 = await addUser(userData[8]);
-      userId3 = await addUser(userData[9]);
-      userId4 = await addUser(userData[0]);
-      userId5 = await addUser(userData[1]);
-      listUsers = [userId1, userId2, userId3, userId4, userId5];
+      userId0 = await addUser(userData[0]);
+      userId1 = await addUser(userData[1]);
+      userId2 = await addUser(userData[2]);
+      userId3 = await addUser(userData[3]);
+      userId4 = await addUser(userData[4]);
+      userId5 = await addUser(userData[5]);
+      userId6 = await addUser(userData[6]);
+      userId7 = await addUser(userData[7]);
+      userId8 = await addUser(userData[8]);
+      userId9 = await addUser(userData[9]);
+      superUserJwt = authService.generateAuthToken({ userId: userId4 });
+      listUsers = [
+        { userId: userId0, expectedState: "IDLE" },
+        { userId: userId1, expectedState: "IDLE" },
+        { userId: userId2, expectedState: "IDLE" },
+        { userId: userId3, expectedState: "IDLE" },
+        { userId: userId4, expectedState: "IDLE" },
+        { userId: userId5, expectedState: "ACTIVE" },
+        { userId: userId6, expectedState: "ACTIVE" },
+        { userId: userId7, expectedState: "ACTIVE" },
+        { userId: userId8, expectedState: "ACTIVE" },
+        { userId: userId9, expectedState: "ACTIVE" },
+      ];
       reqBody.users = listUsers;
-      await userStatusModel.doc("userStatus001").set(generateStatusDataForState(userId1, userState.ACTIVE));
-      await userStatusModel.doc("userStatus002").set(generateStatusDataForState(userId2, userState.OOO));
-      await userStatusModel.doc("userStatus003").set(generateStatusDataForState(userId3, userState.IDLE));
-      await userStatusModel.doc("userStatus004").set(generateStatusDataForState(userId4, userState.ONBOARDING));
+      await userStatusModel.doc("userStatus000").set(generateStatusDataForState(userId0, userState.ACTIVE));
+      await userStatusModel.doc("userStatus001").set(generateStatusDataForState(userId1, userState.OOO));
+      await userStatusModel.doc("userStatus002").set(generateStatusDataForState(userId2, userState.IDLE));
+      await userStatusModel.doc("userStatus003").set(generateStatusDataForState(userId3, userState.ONBOARDING));
+      await userStatusModel.doc("userStatus005").set(generateStatusDataForState(userId5, userState.ACTIVE));
+      await userStatusModel.doc("userStatus006").set(generateStatusDataForState(userId6, userState.OOO));
+      await userStatusModel.doc("userStatus007").set(generateStatusDataForState(userId7, userState.IDLE));
+      await userStatusModel.doc("userStatus008").set(generateStatusDataForState(userId8, userState.ONBOARDING));
     });
 
     afterEach(async function () {
       await cleanDb();
     });
 
-    it("should return the correct results when there are no errors", async function () {
+    // eslint-disable-next-line mocha/no-skipped-tests
+    it.skip("should return the correct results when there are no errors", async function () {
       const res = await chai
         .request(app)
         .patch(`/users/status/batch`)
         .set("cookie", `${cookieName}=${superUserJwt}`)
         .send(reqBody);
       expect(res.status).to.equal(200);
-      const response = res.body;
-      expect(response.data).to.have.property("totalUsers");
-      expect(response.data).to.have.property("usersWithStatusUpdated");
-      expect(response.data).to.have.property("usersOnboardingOrAlreadyIdle");
-      expect(response.data.totalUsers).to.equal(5);
-      expect(response.data.usersWithStatusUpdated).to.deep.equal(3);
-      expect(response.data.usersOnboardingOrAlreadyIdle).to.equal(2);
+      const response = res.body.data;
+      expect(response).to.have.all.keys(
+        "totalUsers",
+        "totalUnprocessedUsers",
+        "totalOnboardingUsersAltered",
+        "totalOnboardingUsersUnAltered",
+        "totalActiveUsersAltered",
+        "totalActiveUsersUnAltered",
+        "totalIdleUsersAltered",
+        "totalIdleUsersUnAltered"
+      );
+      expect(response.totalUsers).to.equal(10);
+      expect(response.totalUnprocessedUsers).to.equal(0);
+      expect(response.totalOnboardingUsersAltered).to.equal(1);
+      expect(response.totalOnboardingUsersUnAltered).to.equal(1);
+      expect(response.totalActiveUsersAltered).to.equal(3);
+      expect(response.totalActiveUsersUnAltered).to.equal(1);
+      expect(response.totalIdleUsersAltered).to.equal(3);
+      expect(response.totalIdleUsersUnAltered).to.equal(1);
+
+      const userStatus000Data = (await userStatusModel.doc("userStatus000").get()).data();
+      expect(userStatus000Data.currentStatus.state).to.equal(userState.IDLE);
       const userStatus001Data = (await userStatusModel.doc("userStatus001").get()).data();
-      expect(userStatus001Data.currentStatus.state).to.equal(userState.IDLE);
+      expect(userStatus001Data.currentStatus.state).to.equal(userState.OOO);
+      expect(userStatus001Data.futureStatus.state).to.equal(userState.IDLE);
       const userStatus002Data = (await userStatusModel.doc("userStatus002").get()).data();
-      expect(userStatus002Data.currentStatus.state).to.equal(userState.OOO);
-      expect(userStatus002Data.futureStatus.state).to.equal(userState.IDLE);
+      expect(userStatus002Data.currentStatus.state).to.equal(userState.IDLE);
       const userStatus003Data = (await userStatusModel.doc("userStatus003").get()).data();
-      expect(userStatus003Data.currentStatus.state).to.equal(userState.IDLE);
-      const userStatus004Data = (await userStatusModel.doc("userStatus004").get()).data();
-      expect(userStatus004Data.currentStatus.state).to.equal(userState.ONBOARDING);
-      const userStatus005SnapShot = await userStatusModel.where("userId", "==", userId5).limit(1).get();
-      const [userStatus005Doc] = userStatus005SnapShot.docs;
-      const userStatus005Data = userStatus005Doc.data();
-      expect(userStatus005Data.currentStatus.state).to.equal(userState.IDLE);
+      expect(userStatus003Data.currentStatus.state).to.equal(userState.ONBOARDING);
+      const userStatus004SnapShot = await userStatusModel.where("userId", "==", userId4).limit(1).get();
+      const [userStatus004Doc] = userStatus004SnapShot.docs;
+      const userStatus004Data = userStatus004Doc.data();
+      expect(userStatus004Data.currentStatus.state).to.equal(userState.IDLE);
+      const userStatus005Data = (await userStatusModel.doc("userStatus005").get()).data();
+      expect(userStatus005Data.currentStatus.state).to.equal(userState.ACTIVE);
+      const userStatus006Data = (await userStatusModel.doc("userStatus006").get()).data();
+      expect(userStatus006Data.currentStatus.state).to.equal(userState.OOO);
+      expect(userStatus006Data.futureStatus.state).to.equal(userState.ACTIVE);
+      const userStatus007Data = (await userStatusModel.doc("userStatus007").get()).data();
+      expect(userStatus007Data.currentStatus.state).to.equal(userState.ACTIVE);
+      const userStatus008Data = (await userStatusModel.doc("userStatus008").get()).data();
+      expect(userStatus008Data.currentStatus.state).to.equal(userState.ACTIVE);
+      const userStatus009SnapShot = await userStatusModel.where("userId", "==", userId9).limit(1).get();
+      const [userStatus009Doc] = userStatus009SnapShot.docs;
+      const userStatus009Data = userStatus009Doc.data();
+      expect(userStatus009Data.currentStatus.state).to.equal(userState.ACTIVE);
     });
 
     it("should throw an error if users firestore batch operations fail", async function () {
@@ -400,23 +449,31 @@ describe("Task Based Status Updates", function () {
     afterEach(async function () {
       await cleanDb();
     });
-
-    it("should get the users who without Assigned Or InProgress Tasks", async function () {
+    // eslint-disable-next-line mocha/no-skipped-tests
+    it.skip("should get the users who without Assigned Or InProgress Tasks", async function () {
       const response = await chai
         .request(app)
-        .get(`/users/status?taskStatus=IDLE`)
+        .get(`/users/status?batch=true`)
         .set("cookie", `${cookieName}=${superUserJwt}`);
-
       expect(response.status).to.equal(200);
       expect(response.body.message).to.equal("All idle users found successfully.");
-      expect(response.body.data.totalValidUsersCount).to.equal(4);
-      expect(response.body.data.idleUsersCount).to.equal(2);
-      expect(response.body.data.idleUsers).to.have.members([userId3, superUserId]);
-      expect(response.body.data.usersNotProcessedCount).to.equal(0);
-      expect(response.body.data.usersNotProcessed).to.deep.equal([]);
+      expect(response.body.data.totalUsers).to.equal(4);
+      expect(response.body.data.totalIdleUsers).to.equal(2);
+      expect(response.body.data.totalActiveUsers).to.equal(2);
+      expect(response.body.data.totalUnprocessedUsers).to.equal(0);
+      expect(response.body.data.unprocessedUsers).to.deep.equal([]);
+      expect(response.body.data)
+        .to.have.deep.property("users")
+        .that.has.deep.members([
+          { userId: userId1, expectedState: "ACTIVE" },
+          { userId: userId2, expectedState: "ACTIVE" },
+          { userId: userId3, expectedState: "IDLE" },
+          { userId: superUserId, expectedState: "IDLE" },
+        ]);
     });
 
-    it("should throw an error when an error occurs", async function () {
+    // eslint-disable-next-line mocha/no-skipped-tests
+    it.skip("should throw an error when an error occurs", async function () {
       sinon
         .stub(userStatusModelFunction, "getIdleUsers")
         .throws(
@@ -426,7 +483,7 @@ describe("Task Based Status Updates", function () {
         );
       const response = await chai
         .request(app)
-        .get(`/users/status?taskStatus=IDLE`)
+        .get(`/users/status?batch=true`)
         .set("cookie", `${cookieName}=${superUserJwt}`);
       expect(response.status).to.equal(500);
       expect(response.body.message).to.equal(

--- a/test/integration/taskBasedStatusUpdate.test.js
+++ b/test/integration/taskBasedStatusUpdate.test.js
@@ -396,7 +396,8 @@ describe("Task Based Status Updates", function () {
       expect(userStatus009Data.currentStatus.state).to.equal(userState.ACTIVE);
     });
 
-    it("should throw an error if users firestore batch operations fail", async function () {
+    // eslint-disable-next-line mocha/no-skipped-tests
+    it.skip("should throw an error if users firestore batch operations fail", async function () {
       sinon.stub(firestore, "batch").throws(new Error("something went wrong"));
 
       const res = await chai

--- a/test/unit/middlewares/userStatusValidator.js
+++ b/test/unit/middlewares/userStatusValidator.js
@@ -4,7 +4,8 @@ const { validateGetQueryParams } = require("../../../middlewares/validators/user
 
 describe("Middleware | Validators | userStatus", function () {
   describe("validateRequestQuery", function () {
-    it("lets the request pass to the next function for a valid query", async function () {
+    // eslint-disable-next-line mocha/no-skipped-tests
+    it.skip("lets the request pass to the next function for a valid query", async function () {
       const res = {};
       const req = {
         query: {
@@ -16,7 +17,7 @@ describe("Middleware | Validators | userStatus", function () {
       expect(nextSpy.calledOnce).to.be.equal(true);
 
       delete req.query.state;
-      req.query.taskStatus = "IDLE";
+      req.query.taskStatus = true;
       await validateGetQueryParams(req, res, nextSpy);
       expect(nextSpy.calledTwice).to.be.equal(true);
     });

--- a/test/unit/models/taskBasedStatusUpdate.test.js
+++ b/test/unit/models/taskBasedStatusUpdate.test.js
@@ -226,25 +226,50 @@ describe("Update Status based on task update", function () {
   });
 
   describe("Test the Model Function for Changing the status to IDLE based on users list passed", function () {
+    let userId0;
     let userId1;
     let userId2;
     let userId3;
     let userId4;
     let userId5;
+    let userId6;
+    let userId7;
+    let userId8;
+    let userId9;
     let listUsers;
 
     beforeEach(async function () {
       const userArr = userData();
-      userId1 = await addUser(userArr[6]);
-      userId2 = await addUser(userArr[8]);
-      userId3 = await addUser(userArr[9]);
-      userId4 = await addUser(userArr[0]);
-      userId5 = await addUser(userArr[1]);
-      listUsers = [userId1, userId2, userId3, userId4, userId5];
-      await userStatusModel.doc("userStatus001").set(generateStatusDataForState(userId1, userState.ACTIVE));
-      await userStatusModel.doc("userStatus002").set(generateStatusDataForState(userId2, userState.OOO));
-      await userStatusModel.doc("userStatus003").set(generateStatusDataForState(userId3, userState.IDLE));
-      await userStatusModel.doc("userStatus004").set(generateStatusDataForState(userId4, userState.ONBOARDING));
+      userId0 = await addUser(userArr[0]);
+      userId1 = await addUser(userArr[1]);
+      userId2 = await addUser(userArr[2]);
+      userId3 = await addUser(userArr[3]);
+      userId4 = await addUser(userArr[4]);
+      userId5 = await addUser(userArr[5]);
+      userId6 = await addUser(userArr[6]);
+      userId7 = await addUser(userArr[7]);
+      userId8 = await addUser(userArr[8]);
+      userId9 = await addUser(userArr[9]);
+      await userStatusModel.doc("userStatus000").set(generateStatusDataForState(userId0, userState.ACTIVE));
+      await userStatusModel.doc("userStatus001").set(generateStatusDataForState(userId1, userState.OOO));
+      await userStatusModel.doc("userStatus002").set(generateStatusDataForState(userId2, userState.IDLE));
+      await userStatusModel.doc("userStatus003").set(generateStatusDataForState(userId3, userState.ONBOARDING));
+      await userStatusModel.doc("userStatus005").set(generateStatusDataForState(userId5, userState.ACTIVE));
+      await userStatusModel.doc("userStatus006").set(generateStatusDataForState(userId6, userState.OOO));
+      await userStatusModel.doc("userStatus007").set(generateStatusDataForState(userId7, userState.IDLE));
+      await userStatusModel.doc("userStatus008").set(generateStatusDataForState(userId8, userState.ONBOARDING));
+      listUsers = [
+        { userId: userId0, expectedState: "IDLE" },
+        { userId: userId1, expectedState: "IDLE" },
+        { userId: userId2, expectedState: "IDLE" },
+        { userId: userId3, expectedState: "IDLE" },
+        { userId: userId4, expectedState: "IDLE" },
+        { userId: userId5, expectedState: "ACTIVE" },
+        { userId: userId6, expectedState: "ACTIVE" },
+        { userId: userId7, expectedState: "ACTIVE" },
+        { userId: userId8, expectedState: "ACTIVE" },
+        { userId: userId9, expectedState: "ACTIVE" },
+      ];
     });
 
     afterEach(async function () {
@@ -252,27 +277,53 @@ describe("Update Status based on task update", function () {
       sinon.restore();
     });
 
-    it("should return the correct results when there are no errors", async function () {
+    // eslint-disable-next-line mocha/no-skipped-tests
+    it.skip("should return the correct results when there are no errors", async function () {
       const result = await massUpdateIdleUsers(listUsers);
-      expect(result).to.have.property("totalUsers");
-      expect(result).to.have.property("usersWithStatusUpdated");
-      expect(result).to.have.property("usersOnboardingOrAlreadyIdle");
-      expect(result.totalUsers).to.equal(5);
-      expect(result.usersWithStatusUpdated).to.deep.equal(3);
-      expect(result.usersOnboardingOrAlreadyIdle).to.equal(2);
+      expect(result).to.have.all.keys(
+        "totalUsers",
+        "totalUnprocessedUsers",
+        "totalOnboardingUsersAltered",
+        "totalOnboardingUsersUnAltered",
+        "totalActiveUsersAltered",
+        "totalActiveUsersUnAltered",
+        "totalIdleUsersAltered",
+        "totalIdleUsersUnAltered"
+      );
+      expect(result.totalUsers).to.equal(10);
+      expect(result.totalUnprocessedUsers).to.equal(0);
+      expect(result.totalOnboardingUsersAltered).to.equal(1);
+      expect(result.totalOnboardingUsersUnAltered).to.equal(1);
+      expect(result.totalActiveUsersAltered).to.equal(3);
+      expect(result.totalActiveUsersUnAltered).to.equal(1);
+      expect(result.totalIdleUsersAltered).to.equal(3);
+      expect(result.totalIdleUsersUnAltered).to.equal(1);
+      const userStatus000Data = (await userStatusModel.doc("userStatus000").get()).data();
+      expect(userStatus000Data.currentStatus.state).to.equal(userState.IDLE);
       const userStatus001Data = (await userStatusModel.doc("userStatus001").get()).data();
-      expect(userStatus001Data.currentStatus.state).to.equal(userState.IDLE);
+      expect(userStatus001Data.currentStatus.state).to.equal(userState.OOO);
+      expect(userStatus001Data.futureStatus.state).to.equal(userState.IDLE);
       const userStatus002Data = (await userStatusModel.doc("userStatus002").get()).data();
-      expect(userStatus002Data.currentStatus.state).to.equal(userState.OOO);
-      expect(userStatus002Data.futureStatus.state).to.equal(userState.IDLE);
+      expect(userStatus002Data.currentStatus.state).to.equal(userState.IDLE);
       const userStatus003Data = (await userStatusModel.doc("userStatus003").get()).data();
-      expect(userStatus003Data.currentStatus.state).to.equal(userState.IDLE);
-      const userStatus004Data = (await userStatusModel.doc("userStatus004").get()).data();
-      expect(userStatus004Data.currentStatus.state).to.equal(userState.ONBOARDING);
-      const userStatus005SnapShot = await userStatusModel.where("userId", "==", userId5).limit(1).get();
-      const [userStatus005Doc] = userStatus005SnapShot.docs;
-      const userStatus005Data = userStatus005Doc.data();
-      expect(userStatus005Data.currentStatus.state).to.equal(userState.IDLE);
+      expect(userStatus003Data.currentStatus.state).to.equal(userState.ONBOARDING);
+      const userStatus004SnapShot = await userStatusModel.where("userId", "==", userId4).limit(1).get();
+      const [userStatus004Doc] = userStatus004SnapShot.docs;
+      const userStatus004Data = userStatus004Doc.data();
+      expect(userStatus004Data.currentStatus.state).to.equal(userState.IDLE);
+      const userStatus005Data = (await userStatusModel.doc("userStatus005").get()).data();
+      expect(userStatus005Data.currentStatus.state).to.equal(userState.ACTIVE);
+      const userStatus006Data = (await userStatusModel.doc("userStatus006").get()).data();
+      expect(userStatus006Data.currentStatus.state).to.equal(userState.OOO);
+      expect(userStatus006Data.futureStatus.state).to.equal(userState.ACTIVE);
+      const userStatus007Data = (await userStatusModel.doc("userStatus007").get()).data();
+      expect(userStatus007Data.currentStatus.state).to.equal(userState.ACTIVE);
+      const userStatus008Data = (await userStatusModel.doc("userStatus008").get()).data();
+      expect(userStatus008Data.currentStatus.state).to.equal(userState.ACTIVE);
+      const userStatus009SnapShot = await userStatusModel.where("userId", "==", userId9).limit(1).get();
+      const [userStatus009Doc] = userStatus009SnapShot.docs;
+      const userStatus009Data = userStatus009Doc.data();
+      expect(userStatus009Data.currentStatus.state).to.equal(userState.ACTIVE);
     });
 
     it("should throw an error if users firestore batch operations fail", async function () {
@@ -319,13 +370,23 @@ describe("Update Status based on task update", function () {
       await cleanDb();
     });
 
-    it("should return the correct results when there are no errors", async function () {
+    // eslint-disable-next-line mocha/no-skipped-tests
+    it.skip("should return the correct results when there are no errors", async function () {
       const result = await getIdleUsers();
-      expect(result.totalValidUsersCount).to.equal(3);
-      expect(result.idleUsersCount).to.equal(1);
-      expect(result.idleUsers).to.deep.equal([userId3]);
-      expect(result.usersNotProcessedCount).to.equal(0);
-      expect(result.usersNotProcessed).to.deep.equal([]);
+      expect(result).to.deep.include({
+        totalUsers: 3,
+        totalIdleUsers: 1,
+        totalActiveUsers: 2,
+        totalUnprocessedUsers: 0,
+        unprocessedUsers: [],
+      });
+      expect(result)
+        .to.have.deep.property("users")
+        .that.has.deep.members([
+          { userId: userId1, expectedState: "ACTIVE" },
+          { userId: userId3, expectedState: "IDLE" },
+          { userId: userId2, expectedState: "ACTIVE" },
+        ]);
     });
 
     it("should throw an error if users query fail", async function () {

--- a/test/unit/utils/userStatusValidator.test.js
+++ b/test/unit/utils/userStatusValidator.test.js
@@ -4,11 +4,21 @@ const { validateMassUpdate } = require("../../../middlewares/validators/userStat
 
 describe("Middleware | Validators | massUpdateUserStatus", function () {
   describe("validateMassUpdate", function () {
-    it("lets the request pass to the next function for a valid query", async function () {
+    // eslint-disable-next-line mocha/no-skipped-tests
+    it.skip("lets the request pass to the next function for a valid query", async function () {
       const res = {};
       const req = {
         body: {
-          users: ["W861F6GY6leVijLrNb9B", "4kAkRv9TBlOfR6WEUhoQ"],
+          users: [
+            {
+              userId: "4kAkRv9TBlOfR6WEUhoQ",
+              expectedState: "IDLE",
+            },
+            {
+              userId: "SooJK37gzjIZfFNH0tlL",
+              expectedState: "ACTIVE",
+            },
+          ],
         },
       };
       const nextSpy = Sinon.spy();


### PR DESCRIPTION
Issue ticket - https://github.com/Real-Dev-Squad/website-backend/issues/1295

The updates in this PR modify the tests to handle batch updates of both idle and active users. Currently, we execute a batch update script that identifies idle users and marks them as idle, which adds them to the pool of idle users. Now, we also want to remove users from the idle list if they are active. Therefore, in addition to identifying new idle users, this PR ensures that active users are correctly removed from the idle state. The changes made here are limited to updating the test cases. The subsequent PR will include the actual code changes, and the tests that are currently skipped will be uncommented in that PR.