### PR TITLE
Include all tasks state such as NEEDS_REVIEW , IN_REVIEW etc. for Marking Users Idle/ Active

### DIFF
--- a/controllers/tasks.js
+++ b/controllers/tasks.js
@@ -342,7 +342,7 @@ const updateTaskStatus = async (req, res, next) => {
       }
     }
 
-    if (isUserStatusEnabled && req.body.status === TASK_STATUS.COMPLETED && req.body.percentCompleted === 100) {
+    if (isUserStatusEnabled && req.body.status) {
       userStatusUpdate = await updateStatusOnTaskCompletion(userId);
     }
     return res.json({

--- a/test/integration/taskBasedStatusUpdate.test.js
+++ b/test/integration/taskBasedStatusUpdate.test.js
@@ -83,9 +83,38 @@ describe("Task Based Status Updates", function () {
         expect(res.body.userStatus.data.currentStatus).to.equal(userState.IDLE);
       });
 
-      it("Should not change the ACTIVE state to IDLE if no other task is assigned to the user.", async function () {
+      it("Should change the ACTIVE state to IDLE if no other task is assigned to the user.", async function () {
         const statusData = generateStatusDataForState(userId, userState.ACTIVE);
         await firestore.collection("usersStatus").doc("userStatus").set(statusData);
+        const res = await chai
+          .request(app)
+          .patch(`/tasks/self/taskid123?userStatusFlag=true`)
+          .set("cookie", `${cookieName}=${userJwt}`)
+          .send(reqBody);
+        expect(res.body.userStatus.status).to.equal("success");
+        expect(res.body.userStatus.message).to.equal("The status has been updated to IDLE");
+        expect(res.body.userStatus.data.previousStatus).to.equal(userState.ACTIVE);
+        expect(res.body.userStatus.data.currentStatus).to.equal(userState.IDLE);
+      });
+
+      it("Should not change the IDLE state if no other task is assigned to the user. & current task status is updated (excluding completed, e.g., in progress).", async function () {
+        const statusData = generateStatusDataForState(userId, userState.IDLE);
+        await firestore.collection("usersStatus").doc("userStatus").set(statusData);
+        reqBody.status = "NEEDS_REVIEW";
+        const res = await chai
+          .request(app)
+          .patch(`/tasks/self/taskid123?userStatusFlag=true`)
+          .set("cookie", `${cookieName}=${userJwt}`)
+          .send(reqBody);
+        expect(res.body.userStatus.status).to.equal("success");
+        expect(res.body.userStatus.message).to.equal("The status is already IDLE");
+        expect(res.body.userStatus.data.currentStatus).to.equal(userState.IDLE);
+      });
+
+      it("Should change the ACTIVE state to IDLE if no other task is assigned to the user. & current task status is updated (excluding completed, e.g., in progress).", async function () {
+        const statusData = generateStatusDataForState(userId, userState.ACTIVE);
+        await firestore.collection("usersStatus").doc("userStatus").set(statusData);
+        reqBody.status = "NEEDS_REVIEW";
         const res = await chai
           .request(app)
           .patch(`/tasks/self/taskid123?userStatusFlag=true`)
@@ -148,9 +177,38 @@ describe("Task Based Status Updates", function () {
         expect(res.body.userStatus.data.currentStatus).to.equal(userState.ACTIVE);
       });
 
-      it("Should change to ACTIVE state if the user is not ACTIVE.", async function () {
+      it("Should change to ACTIVE state if the user is not ACTIVE. ", async function () {
         const statusData = generateStatusDataForState(userId, userState.IDLE);
         await firestore.collection("usersStatus").doc("userStatus").set(statusData);
+        const res = await chai
+          .request(app)
+          .patch(`/tasks/self/taskid123?userStatusFlag=true`)
+          .set("cookie", `${cookieName}=${userJwt}`)
+          .send(reqBody);
+        expect(res.body.userStatus.status).to.equal("success");
+        expect(res.body.userStatus.message).to.equal("The status has been updated to ACTIVE");
+        expect(res.body.userStatus.data.previousStatus).to.equal(userState.IDLE);
+        expect(res.body.userStatus.data.currentStatus).to.equal(userState.ACTIVE);
+      });
+
+      it("Should not change the ACTIVE state if the user is already ACTIVE. & current task status is updated (excluding completed, e.g., in progress).", async function () {
+        const statusData = generateStatusDataForState(userId, userState.ACTIVE);
+        await firestore.collection("usersStatus").doc("userStatus").set(statusData);
+        reqBody.status = "NEEDS_REVIEW";
+        const res = await chai
+          .request(app)
+          .patch(`/tasks/self/taskid123?userStatusFlag=true`)
+          .set("cookie", `${cookieName}=${userJwt}`)
+          .send(reqBody);
+        expect(res.body.userStatus.status).to.equal("success");
+        expect(res.body.userStatus.message).to.equal("The status is already ACTIVE");
+        expect(res.body.userStatus.data.currentStatus).to.equal(userState.ACTIVE);
+      });
+
+      it("Should change to ACTIVE state if the user is not ACTIVE. & current task status is updated (excluding completed, e.g., in progress).", async function () {
+        const statusData = generateStatusDataForState(userId, userState.IDLE);
+        await firestore.collection("usersStatus").doc("userStatus").set(statusData);
+        reqBody.status = "NEEDS_REVIEW";
         const res = await chai
           .request(app)
           .patch(`/tasks/self/taskid123?userStatusFlag=true`)


### PR DESCRIPTION
Closes 
- #1310

We currently update user status only for tasks when they are marked as completed. However, we also need to update user status for other statuses like NEEDS_REVIEW,  IN_REVIEW etc. to mark users as idle/active.

This feature is hidden behind a feature flag.

Testing Stats: 

Controllers 

![image](https://github.com/Real-Dev-Squad/website-backend/assets/97341921/522b457f-ba49-4942-bf59-a3aa1ad67c70)
