### PR TITLE
Cache new response if successful 

### DIFF
--- a/test/unit/middlewares/cache.test.js
+++ b/test/unit/middlewares/cache.test.js
@@ -19,6 +19,7 @@ describe("Middleware | Utils | cache", function () {
     };
 
     const response = {
+      statusCode: 200,
       send: sinon.spy(),
     };
 
@@ -39,7 +40,7 @@ describe("Middleware | Utils | cache", function () {
     expect(response.send.callCount).to.equal(2);
   });
 
-  it("should invalidate stale the response", function () {
+  it("should invalidate stale response", function () {
     const cacheTestKey = "__cache__2";
 
     const request = {
@@ -47,6 +48,8 @@ describe("Middleware | Utils | cache", function () {
       originalUrl: "/test2",
     };
     const response = {
+      on: sinon.spy(),
+      statusCode: 200,
       send: sinon.spy(),
     };
 
@@ -66,6 +69,9 @@ describe("Middleware | Utils | cache", function () {
     cacheMiddlewareForInvalidation(request, response, nextSpy);
     response.send(responseBody);
 
+    response.on.withArgs("finish").yield();
+
+    expect(response.on.callCount).to.equal(1);
     expect(nextSpy.callCount).to.equal(2);
     expect(response.send.callCount).to.equal(2);
 
@@ -73,6 +79,81 @@ describe("Middleware | Utils | cache", function () {
     response.send(responseBody);
 
     expect(nextSpy.callCount).to.equal(3);
+    expect(response.send.callCount).to.equal(3);
+  });
+
+  it("should not cache the response", function () {
+    const cacheTestKey = "__cache__3";
+    const request = {
+      method: "GET",
+      originalUrl: "/test3",
+    };
+
+    const response = {
+      statusCode: 400,
+      send: sinon.spy(),
+    };
+
+    const nextSpy = sinon.spy();
+
+    const cacheMiddleware = cacheResponse({ invalidationKey: cacheTestKey });
+
+    cacheMiddleware(request, response, nextSpy);
+
+    response.send(responseBody);
+
+    expect(nextSpy.callCount).to.equal(1);
+    expect(response.send.callCount).to.equal(1);
+
+    cacheMiddleware(request, response, nextSpy);
+    response.send(responseBody);
+
+    expect(nextSpy.callCount).to.equal(2);
+
+    expect(response.send.callCount).to.equal(2);
+  });
+
+  it("should not invalidate stale the response if theres an error", function () {
+    const cacheTestKey = "__cache__4";
+
+    const request = {
+      method: "GET",
+      originalUrl: "/test4",
+    };
+    const response = {
+      on: sinon.spy(),
+      statusCode: 200,
+      send: sinon.spy(),
+    };
+
+    const nextSpy = sinon.spy();
+
+    const cacheMiddlewareForCache = cacheResponse({ invalidationKey: cacheTestKey });
+
+    cacheMiddlewareForCache(request, response, nextSpy);
+
+    response.send(responseBody);
+
+    expect(nextSpy.callCount).to.equal(1);
+    expect(response.send.callCount).to.equal(1);
+
+    response.statusCode = 400;
+
+    const cacheMiddlewareForInvalidation = invalidateCache({ invalidationKeys: [cacheTestKey] });
+
+    cacheMiddlewareForInvalidation(request, response, nextSpy);
+    response.send(responseBody);
+
+    response.on.withArgs("finish").yield();
+
+    expect(response.on.callCount).to.equal(1);
+    expect(nextSpy.callCount).to.equal(2);
+    expect(response.send.callCount).to.equal(2);
+
+    response.statusCode = 200;
+    cacheMiddlewareForCache(request, response, nextSpy);
+
+    expect(nextSpy.callCount).to.equal(2);
     expect(response.send.callCount).to.equal(3);
   });
 });


### PR DESCRIPTION
Fixes: #1305

Description: 
For caching: 
1. This PR adds a check to verify if the controller layer sets the status code in the range 2xx before caching the response.

For Invalidation: 
1. Currently we were invalidating the cache before passing the control to controller function. 
2. This PR makes necessary changes to make the invalidation after the controller function is executed. It also makes sure the call was successful by checking the status code. 

Test coverage: 
<img width="921" alt="Screenshot 2023-07-24 at 9 33 09 PM" src="https://github.com/Real-Dev-Squad/website-backend/assets/98796547/938577c9-dff9-4541-af11-8019aa1702b7">
