### PR TITLE
FIX : remove accessToken parameter

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -17,7 +17,7 @@ const githubAuth = (req, res, next) => {
   let authRedirectionUrl = req.query.state ?? rdsUiUrl;
 
   try {
-    return passport.authenticate("github", { session: false }, async (err, accessToken, user) => {
+    return passport.authenticate("github", { session: false }, async (err, user) => {
       if (err) {
         logger.error(err);
         return res.boom.unauthorized("User cannot be authenticated");


### PR DESCRIPTION
Fix for  issue URI mismatch

https://bf0e-2409-40e5-99-ecf1-df7f-fa9e-6c30-1019.ngrok-free.app/auth/github/callback?error=redirect_uri_mismatch&error_description=The+redirect_uri+MUST+match+the+registered+callback+URL+for+this+application.&error_uri=https%3A%2F%2Fdocs.github.com%2Fapps%2Fmanaging-oauth-apps%2Ftroubleshooting-authorization-request-errors%2F%23redirect-uri-mismatch