### PR TITLE
FEATURE: change `in_discord` role based on condition

### DIFF
--- a/controllers/external-accounts.js
+++ b/controllers/external-accounts.js
@@ -62,6 +62,21 @@ const syncExternalAccountData = async (req, res) => {
       };
     });
 
+    rdsUserData.forEach((rdsUser) => {
+      if (
+        rdsUser.roles?.in_discord === true &&
+        !discordUserData.some((discordUser) => discordUser.user.id === rdsUser.discordId)
+      ) {
+        const userData = {
+          roles: {
+            ...rdsUser.roles,
+            in_discord: false,
+          },
+        };
+        updateUserDataPromises.push(addOrUpdate(userData, rdsUser.id));
+      }
+    });
+
     discordUserData.forEach((discordUser) => {
       const mappedRdsUser = rdsUserDataMap[discordUser.user.id];
       if (mappedRdsUser) {

--- a/controllers/external-accounts.js
+++ b/controllers/external-accounts.js
@@ -66,25 +66,25 @@ const syncExternalAccountData = async (req, res) => {
     for (const rdsUser of rdsUserData) {
       const discordUser = discordUserData.find((discordUser) => discordUser.user.id === rdsUser.discordId);
 
+      let userData = {};
       if (rdsUser.roles?.in_discord === true && !discordUser) {
-        const userData = {
+        userData = {
           roles: {
             ...rdsUser.roles,
             in_discord: false,
           },
         };
         userUpdatedWithInDiscordFalse.push(rdsUser);
-        updateUserDataPromises.push(addOrUpdate(userData, rdsUser.id));
       } else if (discordUser) {
-        const userData = {
+        userData = {
           discordJoinedAt: discordUser.joined_at,
           roles: {
             ...rdsUser.roles,
             in_discord: true,
           },
         };
-        updateUserDataPromises.push(addOrUpdate(userData, rdsUser.id));
       }
+      updateUserDataPromises.push(addOrUpdate(rdsUser.id, userData));
     }
 
     await Promise.all(updateUserDataPromises);

--- a/controllers/external-accounts.js
+++ b/controllers/external-accounts.js
@@ -67,7 +67,7 @@ const syncExternalAccountData = async (req, res) => {
       const discordUser = discordUserData.find((discordUser) => discordUser.user.id === rdsUser.discordId);
 
       let userData = {};
-      if (rdsUser.roles?.in_discord === true && !discordUser) {
+      if (rdsUser.roles?.in_discord && !discordUser) {
         userData = {
           roles: {
             ...rdsUser.roles,

--- a/controllers/external-accounts.js
+++ b/controllers/external-accounts.js
@@ -54,6 +54,7 @@ const syncExternalAccountData = async (req, res) => {
     const [discordUserData, rdsUserData] = await Promise.all([getDiscordMembers(), getDiscordUsers()]);
     const rdsUserDataMap = {};
     const updateUserDataPromises = [];
+    const userUpdatedWithInDiscordFalse = [];
 
     rdsUserData.forEach((rdsUser) => {
       rdsUserDataMap[rdsUser.discordId] = {
@@ -73,6 +74,7 @@ const syncExternalAccountData = async (req, res) => {
             in_discord: false,
           },
         };
+        userUpdatedWithInDiscordFalse.push(rdsUser);
         updateUserDataPromises.push(addOrUpdate(userData, rdsUser.id));
       }
     });
@@ -96,6 +98,7 @@ const syncExternalAccountData = async (req, res) => {
     return res.json({
       rdsUsers: rdsUserData.length,
       discordUsers: discordUserData.length,
+      userUpdatedWithInDiscordFalse: userUpdatedWithInDiscordFalse.length,
       message: "Data Sync Complete",
     });
   } catch (err) {

--- a/controllers/external-accounts.js
+++ b/controllers/external-accounts.js
@@ -84,7 +84,7 @@ const syncExternalAccountData = async (req, res) => {
           },
         };
       }
-      updateUserDataPromises.push(addOrUpdate(rdsUser.id, userData));
+      updateUserDataPromises.push(addOrUpdate(userData, rdsUser.id));
     }
 
     await Promise.all(updateUserDataPromises);

--- a/models/users.js
+++ b/models/users.js
@@ -552,7 +552,7 @@ const getDiscordUsers = async () => {
     const users = [];
     usersRef.forEach((user) => {
       const userData = user.data();
-      if (userData?.discordId && userData.roles?.in_discord === false)
+      if (userData?.discordId)
         users.push({
           id: user.id,
           ...userData,

--- a/test/integration/external-accounts.test.js
+++ b/test/integration/external-accounts.test.js
@@ -264,6 +264,7 @@ describe("External Accounts", function () {
           expect(res.body).to.deep.equal({
             rdsUsers: 3,
             discordUsers: 2,
+            userUpdatedWithInDiscordFalse: 1,
             message: "Data Sync Complete",
           });
           return done();

--- a/test/integration/external-accounts.test.js
+++ b/test/integration/external-accounts.test.js
@@ -262,7 +262,7 @@ describe("External Accounts", function () {
           }
           expect(res).to.have.status(200);
           expect(res.body).to.deep.equal({
-            rdsUsers: 2,
+            rdsUsers: 3,
             discordUsers: 2,
             message: "Data Sync Complete",
           });


### PR DESCRIPTION
### Closes: #1292
**Description:**
This pull request addresses the issue of synchronizing the "in_discord" role for users in our system based on their presence in the Discord server. The changes introduced in this pull request will enable us to update the "in_discord" role for each user, ensuring accurate representation of their Discord status within our platform.

**Test Coverage:**
| File name | Lines | Branches | Functions | Statements | Excluded lines |
| --------------------- | ------- | -------- | --------- | ---------- | ------------------------------------------- |
| /models/users.js | 66.02% | 69.23% | 62.74% | 65.42% | ...,526-540,563-564,584-585,614-615,621-622 |
| /controllers/external-accounts.js | 75.51% | 68.75% | 85.71% | 75.51% | 8-24,42-43 |
