### PR TITLE
Script to Update 'archived' Role When 'in_discord' is True

### DIFF
--- a/models/users.js
+++ b/models/users.js
@@ -622,6 +622,25 @@ const removeGitHubToken = async (users) => {
     throw err;
   }
 };
+
+const getUsersByRole = async (role) => {
+  try {
+    const usersRef = await userModel.where(`roles.${role}`, "==", true).get();
+    const users = [];
+    usersRef.docs.forEach((user) => {
+      const userData = user.data();
+      users.push({
+        id: user.id,
+        ...userData,
+      });
+    });
+    return users;
+  } catch (err) {
+    logger.error(`Fetching users with role: ${role} exitted with an error: ${err}`);
+    throw err;
+  }
+};
+
 module.exports = {
   addOrUpdate,
   fetchPaginatedUsers,
@@ -644,4 +663,5 @@ module.exports = {
   fetchAllUsers,
   fetchUsersWithToken,
   removeGitHubToken,
+  getUsersByRole,
 };

--- a/test/fixtures/discordResponse/discord-response.js
+++ b/test/fixtures/discordResponse/discord-response.js
@@ -74,6 +74,19 @@ const usersFromRds = [
       archived: false,
     },
   },
+  {
+    username: "",
+    first_name: "",
+    last_name: "",
+    github_id: "",
+    github_display_name: "",
+    incompleteUserDetails: false,
+    discordId: "12345678909867666",
+    roles: {
+      in_discord: true,
+      archived: true,
+    },
+  },
 ];
 
 module.exports = {

--- a/test/integration/external-accounts.test.js
+++ b/test/integration/external-accounts.test.js
@@ -237,6 +237,7 @@ describe("External Accounts", function () {
       superUserJwt = authService.generateAuthToken({ userId });
       await userModel.add(usersFromRds[0]);
       await userModel.add(usersFromRds[1]);
+      await userModel.add(usersFromRds[2]);
       fetchStub = Sinon.stub(global, "fetch");
     });
 
@@ -265,6 +266,7 @@ describe("External Accounts", function () {
             rdsUsers: 3,
             discordUsers: 2,
             userUpdatedWithInDiscordFalse: 1,
+            usersMarkedUnArchived: 1,
             message: "Data Sync Complete",
           });
           return done();

--- a/test/unit/models/users.test.js
+++ b/test/unit/models/users.test.js
@@ -257,4 +257,26 @@ describe("users", function () {
       }
     });
   });
+
+  describe("get users by roles", function () {
+    beforeEach(async function () {
+      const addUsersPromises = [];
+      userDataArray.forEach((user) => {
+        addUsersPromises.push(userModel.add(user));
+      });
+      await Promise.all(addUsersPromises);
+    });
+    it("returns users with member role", async function () {
+      const members = await users.getUsersByRole("member");
+      expect(members.length).to.be.equal(6);
+      members.forEach((member) => {
+        expect(member.roles.member).to.be.equal(true);
+      });
+    });
+    it("throws an error", async function () {
+      await users.getUsersByRole(32389434).catch((err) => {
+        expect(err).to.be.instanceOf(Error);
+      });
+    });
+  });
 });


### PR DESCRIPTION
# Script to Update 'archived' Role When 'in_discord' is True

closes: #1233 

### Expected Behavior
When the 'in_discord' flag is set to true for a user, their 'archived' role should be updated to true as well.

### Current Behavior
Currently, there is no automated process to update the 'archived' role when the 'in_discord' flag is set to true for a user. The 'archived' role remains unaffected even if 'in_discord' is true.

## Proposed Solution
Create a script that runs periodically and checks the 'in_discord' flag for each user. If the 'in_discord' flag is true for a user, the script should update their 'archived' role to true.

## Script Implementation
The script should be written in a programming language with access to the necessary database or user management system. The script should perform the following steps:

1. Connect to the user database or user management system.
2. Retrieve a list of all users.
3. For each user in the list, check if the 'in_discord' flag is true.
4. If the 'in_discord' flag is true for a user, update their 'archived' role to true.
5. Log the changes made to the 'archived' role for auditing purposes.
6. Handle any errors or exceptions gracefully to ensure the script's reliability.

## Test coverage:
### Controllers
![image](https://github.com/Real-Dev-Squad/website-backend/assets/57758447/0492616a-2acd-4216-aa93-f147b5bdaa29)

### Models
![image](https://github.com/Real-Dev-Squad/website-backend/assets/57758447/221b45c0-1384-4bdb-82f0-89ac03f79a7b)
