### PR TITLE
Adds Metrics for Users Status Update Route

### DIFF
--- a/controllers/userStatus.js
+++ b/controllers/userStatus.js
@@ -135,9 +135,10 @@ const updateUserStatus = async (req, res) => {
  */
 const updateAllUserStatus = async (req, res) => {
   try {
-    await userStatusModel.updateAllUserStatus();
+    const data = await userStatusModel.updateAllUserStatus();
     return res.status(200).json({
       message: "All User Status updated successfully.",
+      data,
     });
   } catch (err) {
     logger.error(`Error while updating the User Data: ${err}`);

--- a/models/userStatus.js
+++ b/models/userStatus.js
@@ -157,8 +157,16 @@ const updateUserStatus = async (userId, newStatusData) => {
  */
 
 const updateAllUserStatus = async () => {
+  const summary = {
+    usersCount: 0,
+    oooUsersAltered: 0,
+    oooUsersUnaltered: 0,
+    nonOooUsersAltered: 0,
+    nonOooUsersUnaltered: 0,
+  };
   try {
     const userStatusDocs = await userStatusModel.where("futureStatus.state", "in", ["ACTIVE", "IDLE", "OOO"]).get();
+    summary.usersCount = userStatusDocs._size;
     const batch = firestore.batch();
     const today = new Date().getTime();
     userStatusDocs.forEach(async (document) => {
@@ -170,15 +178,23 @@ const updateAllUserStatus = async () => {
       const { state: futureState } = futureStatus;
       if (futureState === "ACTIVE" || futureState === "IDLE") {
         if (today >= futureStatus.from) {
+          // OOO period is over and we need to update their current status
           newStatusData.currentStatus = { ...futureStatus, until: "", updatedAt: today };
-          newStatusData.futureStatus = {};
+          delete newStatusData.futureStatus;
           toUpdate = !toUpdate;
+          summary.oooUsersAltered++;
+        } else {
+          summary.oooUsersUnaltered++;
         }
       } else {
+        // futureState is OOO
         if (today > futureStatus.until) {
-          newStatusData.futureStatus = {};
+          // the OOO period is over
+          delete newStatusData.futureStatus;
           toUpdate = !toUpdate;
+          summary.nonOooUsersAltered++;
         } else if (today <= doc.futureStatus.until && today >= doc.futureStatus.from) {
+          // the current date i.e today lies in between the from and until so we need to swap the status
           let newCurrentStatus = {};
           let newFutureStatus = {};
           newCurrentStatus = { ...futureStatus, updatedAt: today };
@@ -188,6 +204,9 @@ const updateAllUserStatus = async () => {
           newStatusData.currentStatus = newCurrentStatus;
           newStatusData.futureStatus = newFutureStatus;
           toUpdate = !toUpdate;
+          summary.nonOooUsersAltered++;
+        } else {
+          summary.nonOooUsersUnaltered++;
         }
       }
       if (toUpdate) {
@@ -200,13 +219,12 @@ const updateAllUserStatus = async () => {
       );
     }
     await batch.commit();
-    return { status: 204, message: "User Status updated Successfully." };
+    return summary;
   } catch (error) {
     logger.error(`error in updating User Status Documents ${error}`);
     return { status: 500, message: "User Status couldn't be updated Successfully." };
   }
 };
-
 /**
  * Updates the user status based on a new task assignment.
  * @param {string} userId - The ID of the user.

--- a/test/integration/userStatus.test.js
+++ b/test/integration/userStatus.test.js
@@ -175,6 +175,13 @@ describe("UserStatus", function () {
         .send();
       expect(response3).to.have.status(200);
       expect(response3.body.message).to.equal("All User Status updated successfully.");
+      expect(response3.body.data).to.deep.equal({
+        usersCount: 1,
+        oooUsersAltered: 0,
+        oooUsersUnaltered: 0,
+        nonOooUsersAltered: 1,
+        nonOooUsersUnaltered: 0,
+      });
 
       // Checking the current status
       const response4 = await chai.request(app).get(`/users/status/self`).set("Cookie", `${cookieName}=${testUserJwt}`);
@@ -195,6 +202,13 @@ describe("UserStatus", function () {
         .send();
       expect(response5).to.have.status(200);
       expect(response5.body.message).to.equal("All User Status updated successfully.");
+      expect(response5.body.data).to.deep.equal({
+        usersCount: 1,
+        oooUsersAltered: 1,
+        oooUsersUnaltered: 0,
+        nonOooUsersAltered: 0,
+        nonOooUsersUnaltered: 0,
+      });
 
       const response6 = await chai.request(app).get(`/users/status/self`).set("Cookie", `${cookieName}=${testUserJwt}`);
       expect(response6).to.have.status(200);
@@ -236,6 +250,13 @@ describe("UserStatus", function () {
         .send();
       expect(response3).to.have.status(200);
       expect(response3.body.message).to.equal("All User Status updated successfully.");
+      expect(response3.body.data).to.deep.equal({
+        usersCount: 1,
+        oooUsersAltered: 0,
+        oooUsersUnaltered: 0,
+        nonOooUsersAltered: 1,
+        nonOooUsersUnaltered: 0,
+      });
 
       // Checking the current status
       const response4 = await chai.request(app).get(`/users/status/self`).set("Cookie", `${cookieName}=${testUserJwt}`);


### PR DESCRIPTION
Closes 
- #1291

### Description
The Current Route on Status Update doesn't gives any metrics. We would like to see the metrics so that the super user is aware of the no of users updated and modified. 
The current PR updates the model function to send the necessary details in the response.

Proof on Local 

**Before** 

![image](https://github.com/Real-Dev-Squad/website-backend/assets/97341921/71039a4e-2a5e-4666-9584-b7f642b1fff2)

**After**

![image](https://github.com/Real-Dev-Squad/website-backend/assets/97341921/4b2d9e10-f016-4dc9-9677-8bceb63280de)
 
Testing Stats:

Models 

![image](https://github.com/Real-Dev-Squad/website-backend/assets/97341921/e7fd01b2-68ae-4133-98ef-8a643d22c9ba)

Controllers 

![image](https://github.com/Real-Dev-Squad/website-backend/assets/97341921/c3458f98-87f5-4b5a-b49e-67e7fbdae4e3)
