### PR TITLE
Remove userStatus feature flag

### DIFF
--- a/controllers/tasks.js
+++ b/controllers/tasks.js
@@ -20,9 +20,6 @@ const dataAccess = require("../services/dataAccessLayer");
  */
 const addNewTask = async (req, res) => {
   try {
-    // userStatusFlag is the Feature flag for status update based on task status. This flag is temporary and will be removed once the feature becomes stable.
-    const { userStatusFlag } = req.query;
-    const isUserStatusEnabled = userStatusFlag === "true";
     const { id: createdBy } = req.userData;
     const dependsOn = req.body.dependsOn;
     let userStatusUpdate;
@@ -37,7 +34,7 @@ const addNewTask = async (req, res) => {
       dependsOn,
     };
     const taskDependency = dependsOn && (await dependencyModel.addDependency(data));
-    if (isUserStatusEnabled && req.body.assignee) {
+    if (req.body.assignee) {
       userStatusUpdate = await updateUserStatusOnTaskUpdate(req.body.assignee);
     }
     return res.json({
@@ -241,9 +238,6 @@ const getTask = async (req, res) => {
  */
 const updateTask = async (req, res) => {
   try {
-    // userStatusFlag is the Feature flag for status update based on task status. This flag is temporary and will be removed once the feature becomes stable.
-    const { userStatusFlag } = req.query;
-    const isUserStatusEnabled = userStatusFlag === "true";
     const task = await tasks.fetchTask(req.params.id);
     if (!task.taskData) {
       return res.boom.notFound("Task not found");
@@ -255,7 +249,7 @@ const updateTask = async (req, res) => {
       }
     }
     await tasks.updateTask(req.body, req.params.id);
-    if (isUserStatusEnabled && req.body.assignee) {
+    if (req.body.assignee) {
       await updateUserStatusOnTaskUpdate(req.body.assignee);
     }
 
@@ -278,9 +272,6 @@ const updateTask = async (req, res) => {
  */
 const updateTaskStatus = async (req, res, next) => {
   try {
-    // userStatusFlag is the Feature flag for status update based on task status. This flag is temporary and will be removed once the feature becomes stable.
-    const { userStatusFlag } = req.query;
-    const isUserStatusEnabled = userStatusFlag === "true";
     let userStatusUpdate;
     const taskId = req.params.id;
     const { dev } = req.query;
@@ -341,7 +332,7 @@ const updateTaskStatus = async (req, res, next) => {
       }
     }
 
-    if (isUserStatusEnabled && req.body.status) {
+    if (req.body.status) {
       userStatusUpdate = await updateStatusOnTaskCompletion(userId);
     }
     return res.json({

--- a/middlewares/validators/userStatus.js
+++ b/middlewares/validators/userStatus.js
@@ -3,14 +3,7 @@ const { userState, CANCEL_OOO } = require("../../constants/userStatus");
 const threeDaysInMilliseconds = 172800000;
 
 const validateUserStatusData = async (todaysTime, req, res, next) => {
-  // userStatusFlag is the Feature flag for status update based on task status. This flag is temporary and will be removed once the feature becomes stable.
-  const { userStatusFlag } = req.query;
-  const isUserStatusEnabled = userStatusFlag === "true";
-  let validUserStates = [userState.OOO, userState.ONBOARDING, userState.IDLE, userState.ACTIVE];
-
-  if (isUserStatusEnabled) {
-    validUserStates = [userState.OOO, userState.ONBOARDING];
-  }
+  const validUserStates = [userState.OOO, userState.ONBOARDING];
 
   const statusSchema = Joi.object({
     currentStatus: Joi.object().keys({

--- a/test/integration/taskBasedStatusUpdate.test.js
+++ b/test/integration/taskBasedStatusUpdate.test.js
@@ -44,7 +44,7 @@ describe("Task Based Status Updates", function () {
       it("Should Create a new user status Document with status IDLE if the status document doesn't exist & the user is IDLE.", async function () {
         const res = await chai
           .request(app)
-          .patch(`/tasks/self/taskid123?userStatusFlag=true`)
+          .patch(`/tasks/self/taskid123`)
           .set("cookie", `${cookieName}=${userJwt}`)
           .send(reqBody);
         expect(res.body.userStatus.status).to.equal("success");
@@ -59,7 +59,7 @@ describe("Task Based Status Updates", function () {
         await firestore.collection("usersStatus").doc("userStatus").set(statusData);
         const res = await chai
           .request(app)
-          .patch(`/tasks/self/taskid123?userStatusFlag=true`)
+          .patch(`/tasks/self/taskid123`)
           .set("cookie", `${cookieName}=${userJwt}`)
           .send(reqBody);
         expect(res.body.userStatus.status).to.equal("success");
@@ -75,7 +75,7 @@ describe("Task Based Status Updates", function () {
         await firestore.collection("usersStatus").doc("userStatus").set(statusData);
         const res = await chai
           .request(app)
-          .patch(`/tasks/self/taskid123?userStatusFlag=true`)
+          .patch(`/tasks/self/taskid123`)
           .set("cookie", `${cookieName}=${userJwt}`)
           .send(reqBody);
         expect(res.body.userStatus.status).to.equal("success");
@@ -88,7 +88,7 @@ describe("Task Based Status Updates", function () {
         await firestore.collection("usersStatus").doc("userStatus").set(statusData);
         const res = await chai
           .request(app)
-          .patch(`/tasks/self/taskid123?userStatusFlag=true`)
+          .patch(`/tasks/self/taskid123`)
           .set("cookie", `${cookieName}=${userJwt}`)
           .send(reqBody);
         expect(res.body.userStatus.status).to.equal("success");
@@ -103,7 +103,7 @@ describe("Task Based Status Updates", function () {
         reqBody.status = "NEEDS_REVIEW";
         const res = await chai
           .request(app)
-          .patch(`/tasks/self/taskid123?userStatusFlag=true`)
+          .patch(`/tasks/self/taskid123`)
           .set("cookie", `${cookieName}=${userJwt}`)
           .send(reqBody);
         expect(res.body.userStatus.status).to.equal("success");
@@ -117,7 +117,7 @@ describe("Task Based Status Updates", function () {
         reqBody.status = "NEEDS_REVIEW";
         const res = await chai
           .request(app)
-          .patch(`/tasks/self/taskid123?userStatusFlag=true`)
+          .patch(`/tasks/self/taskid123`)
           .set("cookie", `${cookieName}=${userJwt}`)
           .send(reqBody);
         expect(res.body.userStatus.status).to.equal("success");
@@ -138,7 +138,7 @@ describe("Task Based Status Updates", function () {
       it("Should Create a new user status Document with status ACTIVE if the status document doesn't exist & the user is ACTIVE.", async function () {
         const res = await chai
           .request(app)
-          .patch(`/tasks/self/taskid123?userStatusFlag=true`)
+          .patch(`/tasks/self/taskid123`)
           .set("cookie", `${cookieName}=${userJwt}`)
           .send(reqBody);
         expect(res.body.userStatus.status).to.equal("success");
@@ -153,7 +153,7 @@ describe("Task Based Status Updates", function () {
         await firestore.collection("usersStatus").doc("userStatus").set(statusData);
         const res = await chai
           .request(app)
-          .patch(`/tasks/self/taskid123?userStatusFlag=true`)
+          .patch(`/tasks/self/taskid123`)
           .set("cookie", `${cookieName}=${userJwt}`)
           .send(reqBody);
         expect(res.body.userStatus.status).to.equal("success");
@@ -169,7 +169,7 @@ describe("Task Based Status Updates", function () {
         await firestore.collection("usersStatus").doc("userStatus").set(statusData);
         const res = await chai
           .request(app)
-          .patch(`/tasks/self/taskid123?userStatusFlag=true`)
+          .patch(`/tasks/self/taskid123`)
           .set("cookie", `${cookieName}=${userJwt}`)
           .send(reqBody);
         expect(res.body.userStatus.status).to.equal("success");
@@ -182,7 +182,7 @@ describe("Task Based Status Updates", function () {
         await firestore.collection("usersStatus").doc("userStatus").set(statusData);
         const res = await chai
           .request(app)
-          .patch(`/tasks/self/taskid123?userStatusFlag=true`)
+          .patch(`/tasks/self/taskid123`)
           .set("cookie", `${cookieName}=${userJwt}`)
           .send(reqBody);
         expect(res.body.userStatus.status).to.equal("success");
@@ -197,7 +197,7 @@ describe("Task Based Status Updates", function () {
         reqBody.status = "NEEDS_REVIEW";
         const res = await chai
           .request(app)
-          .patch(`/tasks/self/taskid123?userStatusFlag=true`)
+          .patch(`/tasks/self/taskid123`)
           .set("cookie", `${cookieName}=${userJwt}`)
           .send(reqBody);
         expect(res.body.userStatus.status).to.equal("success");
@@ -211,7 +211,7 @@ describe("Task Based Status Updates", function () {
         reqBody.status = "NEEDS_REVIEW";
         const res = await chai
           .request(app)
-          .patch(`/tasks/self/taskid123?userStatusFlag=true`)
+          .patch(`/tasks/self/taskid123`)
           .set("cookie", `${cookieName}=${userJwt}`)
           .send(reqBody);
         expect(res.body.userStatus.status).to.equal("success");
@@ -253,11 +253,7 @@ describe("Task Based Status Updates", function () {
     });
 
     it("Should Create a new user status Document with status ACTIVE if the status document doesn't exist.", async function () {
-      const res = await chai
-        .request(app)
-        .post(`/tasks?userStatusFlag=true`)
-        .set("cookie", `${cookieName}=${superUserJwt}`)
-        .send(reqBody);
+      const res = await chai.request(app).post(`/tasks`).set("cookie", `${cookieName}=${superUserJwt}`).send(reqBody);
       expect(res.status).to.equal(200);
       expect(res.body.userStatus.status).to.equal("success");
       expect(res.body.userStatus.message).to.equal(
@@ -269,11 +265,7 @@ describe("Task Based Status Updates", function () {
     it("Should change the Future Status to ACTIVE if the user is currently OOO .", async function () {
       const statusData = await generateStatusDataForState(userId, userState.OOO);
       await firestore.collection("usersStatus").doc("userStatus").set(statusData);
-      const res = await chai
-        .request(app)
-        .post(`/tasks?userStatusFlag=true`)
-        .set("cookie", `${cookieName}=${superUserJwt}`)
-        .send(reqBody);
+      const res = await chai.request(app).post(`/tasks`).set("cookie", `${cookieName}=${superUserJwt}`).send(reqBody);
       expect(res.status).to.equal(200);
       expect(res.body.userStatus.status).to.equal("success");
       expect(res.body.userStatus.message).to.equal(
@@ -286,11 +278,7 @@ describe("Task Based Status Updates", function () {
     it("Should not change the ACTIVE state if the user is already ACTIVE.", async function () {
       const statusData = await generateStatusDataForState(userId, userState.ACTIVE);
       await firestore.collection("usersStatus").doc("userStatus").set(statusData);
-      const res = await chai
-        .request(app)
-        .post(`/tasks?userStatusFlag=true`)
-        .set("cookie", `${cookieName}=${superUserJwt}`)
-        .send(reqBody);
+      const res = await chai.request(app).post(`/tasks`).set("cookie", `${cookieName}=${superUserJwt}`).send(reqBody);
       expect(res.status).to.equal(200);
       expect(res.body.userStatus.status).to.equal("success");
       expect(res.body.userStatus.message).to.equal("The status is already ACTIVE");
@@ -300,11 +288,7 @@ describe("Task Based Status Updates", function () {
     it("Should change the status to ACTIVE if the status is not ACTIVE i.e IDLE.", async function () {
       const statusData = await generateStatusDataForState(userId, userState.IDLE);
       await firestore.collection("usersStatus").doc("userStatus").set(statusData);
-      const res = await chai
-        .request(app)
-        .post(`/tasks?userStatusFlag=true`)
-        .set("cookie", `${cookieName}=${superUserJwt}`)
-        .send(reqBody);
+      const res = await chai.request(app).post(`/tasks`).set("cookie", `${cookieName}=${superUserJwt}`).send(reqBody);
       expect(res.status).to.equal(200);
       expect(res.body.userStatus.status).to.equal("success");
       expect(res.body.userStatus.message).to.equal("The status has been updated to ACTIVE");
@@ -315,11 +299,7 @@ describe("Task Based Status Updates", function () {
     it("Should throw an error to if an invalid state is set in the Status.", async function () {
       const statusData = await generateStatusDataForState(userId, "InvalidState");
       await firestore.collection("usersStatus").doc("userStatus").set(statusData);
-      const res = await chai
-        .request(app)
-        .post(`/tasks?userStatusFlag=true`)
-        .set("cookie", `${cookieName}=${superUserJwt}`)
-        .send(reqBody);
+      const res = await chai.request(app).post(`/tasks`).set("cookie", `${cookieName}=${superUserJwt}`).send(reqBody);
       expect(res.status).to.equal(200);
       expect(res.body.userStatus.status).to.equal(500);
       expect(res.body.userStatus.error).to.equal("Internal Server Error");
@@ -330,11 +310,7 @@ describe("Task Based Status Updates", function () {
 
     it("Should give NotFound message if the userName is invalid.", async function () {
       reqBody.assignee = "funkeyMonkey123";
-      const res = await chai
-        .request(app)
-        .post(`/tasks?userStatusFlag=true`)
-        .set("cookie", `${cookieName}=${superUserJwt}`)
-        .send(reqBody);
+      const res = await chai.request(app).post(`/tasks`).set("cookie", `${cookieName}=${superUserJwt}`).send(reqBody);
       expect(res.status).to.equal(200);
       expect(res.body.userStatus.status).to.equal(404);
       expect(res.body.userStatus.error).to.equal("Not Found");

--- a/test/integration/taskBasedStatusUpdate.test.js
+++ b/test/integration/taskBasedStatusUpdate.test.js
@@ -541,7 +541,7 @@ describe("Task Based Status Updates", function () {
       reqBody.assignee = user2Name;
       const res = await chai
         .request(app)
-        .patch(`/tasks/taskid123?userStatusFlag=true`)
+        .patch(`/tasks/taskid123`)
         .set("cookie", `${cookieName}=${superUserJwt}`)
         .send(reqBody);
       expect(res.status).to.equal(204);
@@ -559,7 +559,7 @@ describe("Task Based Status Updates", function () {
       reqBody.assignee = user2Name;
       const res = await chai
         .request(app)
-        .patch(`/tasks/taskid123?userStatusFlag=true`)
+        .patch(`/tasks/taskid123`)
         .set("cookie", `${cookieName}=${superUserJwt}`)
         .send(reqBody);
       expect(res.status).to.equal(204);

--- a/test/integration/userStatus.test.js
+++ b/test/integration/userStatus.test.js
@@ -152,7 +152,7 @@ describe("UserStatus", function () {
       // Marking OOO Status from 24th Nov 2022 to 28th Nov 2022
       const response2 = await chai
         .request(app)
-        .patch(`/users/status/self?userStatusFlag=true`)
+        .patch(`/users/status/self`)
         .set("Cookie", `${cookieName}=${testUserJwt}`)
         .send(generateUserStatusData("OOO", updatedAtDate, fromDate, untilDate, "Vacation Trip"));
       expect(response2).to.have.status(200);
@@ -231,7 +231,7 @@ describe("UserStatus", function () {
       // Marking OOO Status from 24th Nov 2022 to 28th Nov 2022
       const response2 = await chai
         .request(app)
-        .patch(`/users/status/self?userStatusFlag=true`)
+        .patch(`/users/status/self`)
         .set("Cookie", `${cookieName}=${testUserJwt}`)
         .send(generateUserStatusData("OOO", updatedAtDate, fromDate, untilDate, "Vacation Trip"));
       expect(response2).to.have.status(200);
@@ -291,7 +291,7 @@ describe("UserStatus", function () {
     it("Should store the User Status in the collection", function (done) {
       chai
         .request(app)
-        .patch(`/users/status/self?userStatusFlag=true`)
+        .patch(`/users/status/self`)
         .set("Cookie", `${cookieName}=${testUserJwt}`)
         .send(userStatusDataForOooState)
         .end((err, res) => {
@@ -309,7 +309,7 @@ describe("UserStatus", function () {
     it("Should store the User Status in the collection when requested by Super User", function (done) {
       chai
         .request(app)
-        .patch(`/users/status/${testUserId}?userStatusFlag=true`)
+        .patch(`/users/status/${testUserId}`)
         .set("Cookie", `${cookieName}=${superUserAuthToken}`)
         .send(userStatusDataForOooState)
         .end((err, res) => {
@@ -345,7 +345,7 @@ describe("UserStatus", function () {
     it("Should update the User Status without reason for short duration", function (done) {
       chai
         .request(app)
-        .patch(`/users/status/self?userStatusFlag=true`)
+        .patch(`/users/status/self`)
         .set("cookie", `${cookieName}=${jwt}`)
         .send(oooStatusDataForShortDuration)
         .end((err, res) => {
@@ -379,7 +379,7 @@ describe("UserStatus", function () {
     it("Should return 401 for unauthorized request", function (done) {
       chai
         .request(app)
-        .patch(`/users/status/${testUserId}?userStatusFlag=true`)
+        .patch(`/users/status/${testUserId}`)
         .set("Cookie", `${cookieName}=""`)
         .send(userStatusDataForOooState)
         .end((err, res) => {
@@ -396,7 +396,7 @@ describe("UserStatus", function () {
     it("Should return 400 for incorrect state value", function (done) {
       chai
         .request(app)
-        .patch(`/users/status/self?userStatusFlag=true`)
+        .patch(`/users/status/self`)
         .set("cookie", `${cookieName}=${testUserJwt}`)
         .send(generateUserStatusData("IN_OFFICE", Date.now(), Date.now()))
         .end((err, res) => {
@@ -416,7 +416,7 @@ describe("UserStatus", function () {
       const untilDate = Date.now() + 4 * 24 * 60 * 60 * 1000;
       chai
         .request(app)
-        .patch(`/users/status/self?userStatusFlag=true`)
+        .patch(`/users/status/self`)
         .set("cookie", `${cookieName}=${testUserJwt}`)
         .send(generateUserStatusData("OOO", Date.now(), Date.now(), untilDate, ""))
         .end((err, res) => {
@@ -437,7 +437,7 @@ describe("UserStatus", function () {
       const fromDate = Date.now() - 4 * 24 * 60 * 60 * 1000;
       chai
         .request(app)
-        .patch(`/users/status/self?userStatusFlag=true`)
+        .patch(`/users/status/self`)
         .set("cookie", `${cookieName}=${testUserJwt}`)
         .send(generateUserStatusData("OOO", Date.now(), fromDate, "", ""))
         .end((err, res) => {
@@ -459,7 +459,7 @@ describe("UserStatus", function () {
       const untilDate = Date.now() + 5 * 24 * 60 * 60 * 1000;
       chai
         .request(app)
-        .patch(`/users/status/self?userStatusFlag=true`)
+        .patch(`/users/status/self`)
         .set("cookie", `${cookieName}=${testUserJwt}`)
         .send(generateUserStatusData("OOO", Date.now(), fromDate, untilDate, "Semester Exams"))
         .end((err, res) => {
@@ -486,7 +486,7 @@ describe("UserStatus", function () {
       let untilDate = new Date(2022, 10, 28).getTime();
       const response2 = await chai
         .request(app)
-        .patch(`/users/status/self?userStatusFlag=true`)
+        .patch(`/users/status/self`)
         .set("Cookie", `${cookieName}=${testUserJwt}`)
         .send(generateUserStatusData("OOO", Date.now(), fromDate, untilDate, "Vacation Trip"));
       expect(response2).to.have.status(200);
@@ -501,7 +501,7 @@ describe("UserStatus", function () {
       untilDate = new Date(2022, 11, 5).getTime();
       const response3 = await chai
         .request(app)
-        .patch(`/users/status/self?userStatusFlag=true`)
+        .patch(`/users/status/self`)
         .set("Cookie", `${cookieName}=${testUserJwt}`)
         .send(generateUserStatusData("OOO", Date.now(), fromDate, untilDate, "New plan for vacation Trip"));
       expect(response3).to.have.status(200);
@@ -530,7 +530,7 @@ describe("UserStatus", function () {
       let untilDate = new Date(2022, 10, 28).getTime(); // 28th Nov 2022
       const response1 = await chai
         .request(app)
-        .patch(`/users/status/self?userStatusFlag=true`)
+        .patch(`/users/status/self`)
         .set("Cookie", `${cookieName}=${testUserJwt}`)
         .send(generateUserStatusData("OOO", Date.now(), fromDate, untilDate, "Vacation Trip"));
       expect(response1).to.have.status(201);
@@ -545,7 +545,7 @@ describe("UserStatus", function () {
       untilDate = new Date(2022, 10, 17).getTime(); // 17th Nov 2022
       const response2 = await chai
         .request(app)
-        .patch(`/users/status/self?userStatusFlag=true`)
+        .patch(`/users/status/self`)
         .set("Cookie", `${cookieName}=${testUserJwt}`)
         .send(generateUserStatusData("OOO", Date.now(), fromDate, untilDate, "Changed plan for vacation Trip"));
       expect(response2).to.have.status(200);

--- a/test/unit/middlewares/userStatusValidator.test.js
+++ b/test/unit/middlewares/userStatusValidator.test.js
@@ -16,7 +16,6 @@ describe("Validation Tests for Cancel OOO", function () {
   });
   it("should validate for a valid request", async function () {
     req = {
-      query: { userStatusFlag: false },
       body: {
         cancelOoo: true,
       },


### PR DESCRIPTION
Issue Ticket Number:-
- #1224 

Backend changes
- [x] Yes
- [ ] No

Frontend Changes
- [ ] Yes
- [x] No

Database changes
- [] Yes 
- [x] No

Breaking changes (If your feature is breaking/missing something please mention pending tickets)
- [ ] Yes
- [x] No

Deployment notes
None

Description:
This pull request (PR) aims to removes the userStatus flag, which is currently in use to track user status based on task. The feature is now stable and has been in prod since more than 3 weeks and as confirmed with Ankush we can remove this feature flag.

Testing Stats:

Controllers:

![image](https://github.com/Real-Dev-Squad/website-backend/assets/97341921/6e238cfc-af89-4aba-a0d9-50865d3ddaee)

Validator 

![image](https://github.com/Real-Dev-Squad/website-backend/assets/97341921/12cae07d-b57b-473c-97b6-6e6bd7e70001)

![image](https://github.com/Real-Dev-Squad/website-backend/assets/97341921/098f3d78-b0d8-4533-9f81-906947f92b2b)


