### PR TITLE
return taskId for existing github issues

### DIFF
--- a/controllers/issues.js
+++ b/controllers/issues.js
@@ -25,6 +25,7 @@ const getIssues = async (req, res) => {
       const taskData = await tasks.fetchTaskByIssueId(issue.id);
       if (taskData) {
         issue.taskExists = true;
+        issue.taskId = taskData.id;
       }
 
       return issue;


### PR DESCRIPTION
> [!NOTE]
The issues feature has no test at all thus I have asked for an exemption of test for this line change. (Reason: This feature is required at the earliest)

This PR will add a field of task id for the GitHub issue if the issue is already converted to task.