### PR TITLE
include OOO completed users in status update

### DIFF
--- a/models/userStatus.js
+++ b/models/userStatus.js
@@ -11,6 +11,7 @@ const {
   checkIfUserHasLiveTasks,
   generateErrorResponse,
   generateNewStatus,
+  getNextDayTimeStamp,
 } = require("../utils/userStatus");
 const { TASK_STATUS } = require("../constants/tasks");
 const userStatusModel = firestore.collection("usersStatus");
@@ -371,7 +372,7 @@ const batchUpdateUsersStatus = async (users) => {
     const statusToUpdate = {
       state,
       message: "",
-      from: currentTimeStamp,
+      from: new Date().setUTCHours(0, 0, 0, 0),
       until: "",
       updatedAt: currentTimeStamp,
     };
@@ -391,8 +392,7 @@ const batchUpdateUsersStatus = async (users) => {
       if (currentState === state) {
         currentState === userState.ACTIVE ? summary.activeUsersUnaltered++ : summary.idleUsersUnaltered++;
         continue;
-      }
-      if (currentState === userState.ONBOARDING) {
+      } else if (currentState === userState.ONBOARDING) {
         const docRef = userStatusModel.doc(id);
         if (state === userState.ACTIVE) {
           const updatedStatusData = {
@@ -403,20 +403,35 @@ const batchUpdateUsersStatus = async (users) => {
         } else {
           summary.onboardingUsersUnaltered++;
         }
-      } else {
-        state === userState.ACTIVE ? summary.activeUsersAltered++ : summary.idleUsersAltered++;
+      } else if (currentState === userState.OOO) {
         const docRef = userStatusModel.doc(id);
-        const updatedStatusData =
-          currentState === userState.OOO
-            ? {
-                futureStatus: {
-                  ...statusToUpdate,
-                  from: until,
-                },
-              }
-            : {
-                currentStatus: statusToUpdate,
-              };
+        state === userState.ACTIVE ? summary.activeUsersAltered++ : summary.idleUsersAltered++;
+
+        const currentDate = new Date();
+        const untilDate = new Date(until);
+
+        const timeDifferenceMilliseconds = currentDate.setUTCHours(0, 0, 0, 0) - untilDate.setUTCHours(0, 0, 0, 0);
+        const timeDifferenceDays = Math.floor(timeDifferenceMilliseconds / (24 * 60 * 60 * 1000));
+
+        if (timeDifferenceDays >= 1) {
+          batch.update(docRef, {
+            currentStatus: statusToUpdate,
+          });
+        } else {
+          const getNextDayAfterUntil = getNextDayTimeStamp(until);
+          batch.update(docRef, {
+            futureStatus: {
+              ...statusToUpdate,
+              from: getNextDayAfterUntil,
+            },
+          });
+        }
+      } else {
+        const docRef = userStatusModel.doc(id);
+        state === userState.ACTIVE ? summary.activeUsersAltered++ : summary.idleUsersAltered++;
+        const updatedStatusData = {
+          currentStatus: statusToUpdate,
+        };
         batch.update(docRef, updatedStatusData);
       }
     }

--- a/test/unit/models/taskBasedStatusUpdate.test.js
+++ b/test/unit/models/taskBasedStatusUpdate.test.js
@@ -226,7 +226,8 @@ describe("Update Status based on task update", function () {
   });
 
   describe("Test the Model Function for Changing the status to IDLE based on users list passed", function () {
-    let [userId0, userId1, userId2, userId3, userId4, userId5, userId6, userId7, userId8, userId9] = [];
+    let [userId0, userId1, userId2, userId3, userId4, userId5, userId6, userId7, userId8, userId9, userId10, userId11] =
+      [];
     let listUsers;
 
     beforeEach(async function () {
@@ -241,6 +242,8 @@ describe("Update Status based on task update", function () {
       userId7 = await addUser(userArr[7]);
       userId8 = await addUser(userArr[8]);
       userId9 = await addUser(userArr[9]);
+      userId10 = await addUser(userArr[10]);
+      userId11 = await addUser(userArr[11]);
       await userStatusModel.doc("userStatus000").set(generateStatusDataForState(userId0, userState.ACTIVE));
       await userStatusModel.doc("userStatus001").set(generateStatusDataForState(userId1, userState.OOO));
       await userStatusModel.doc("userStatus002").set(generateStatusDataForState(userId2, userState.IDLE));
@@ -249,6 +252,16 @@ describe("Update Status based on task update", function () {
       await userStatusModel.doc("userStatus006").set(generateStatusDataForState(userId6, userState.OOO));
       await userStatusModel.doc("userStatus007").set(generateStatusDataForState(userId7, userState.IDLE));
       await userStatusModel.doc("userStatus008").set(generateStatusDataForState(userId8, userState.ONBOARDING));
+
+      const oooStateCompletedStatus = generateStatusDataForState(userId10, userState.OOO);
+      oooStateCompletedStatus.currentStatus.from =
+        oooStateCompletedStatus.currentStatus.from - 20 * 24 * 60 * 60 * 1000;
+      oooStateCompletedStatus.currentStatus.until =
+        oooStateCompletedStatus.currentStatus.until - 10 * 24 * 60 * 60 * 1000;
+      await userStatusModel.doc("userStatus010").set(oooStateCompletedStatus);
+      oooStateCompletedStatus.userId = userId11;
+      await userStatusModel.doc("userStatus011").set(oooStateCompletedStatus);
+
       listUsers = [
         { userId: userId0, state: "IDLE" },
         { userId: userId1, state: "IDLE" },
@@ -260,6 +273,8 @@ describe("Update Status based on task update", function () {
         { userId: userId7, state: "ACTIVE" },
         { userId: userId8, state: "ACTIVE" },
         { userId: userId9, state: "ACTIVE" },
+        { userId: userId10, state: "ACTIVE" },
+        { userId: userId11, state: "IDLE" },
       ];
     });
 
@@ -280,13 +295,13 @@ describe("Update Status based on task update", function () {
         "idleUsersAltered",
         "idleUsersUnaltered"
       );
-      expect(result.usersCount).to.equal(10);
+      expect(result.usersCount).to.equal(12);
       expect(result.unprocessedUsers).to.equal(0);
       expect(result.onboardingUsersAltered).to.equal(1);
       expect(result.onboardingUsersUnaltered).to.equal(1);
-      expect(result.activeUsersAltered).to.equal(3);
+      expect(result.activeUsersAltered).to.equal(4);
       expect(result.activeUsersUnaltered).to.equal(1);
-      expect(result.idleUsersAltered).to.equal(3);
+      expect(result.idleUsersAltered).to.equal(4);
       expect(result.idleUsersUnaltered).to.equal(1);
       const userStatus000Data = (await userStatusModel.doc("userStatus000").get()).data();
       expect(userStatus000Data.currentStatus.state).to.equal(userState.IDLE);
@@ -314,6 +329,10 @@ describe("Update Status based on task update", function () {
       const [userStatus009Doc] = userStatus009SnapShot.docs;
       const userStatus009Data = userStatus009Doc.data();
       expect(userStatus009Data.currentStatus.state).to.equal(userState.ACTIVE);
+      const userStatus010Data = (await userStatusModel.doc("userStatus010").get()).data();
+      expect(userStatus010Data.currentStatus.state).to.equal(userState.ACTIVE);
+      const userStatus011Data = (await userStatusModel.doc("userStatus011").get()).data();
+      expect(userStatus011Data.currentStatus.state).to.equal(userState.IDLE);
     });
 
     it("should throw an error if users firestore batch operations fail", async function () {

--- a/test/unit/utils/taskBasedStatusUpdates.test.js
+++ b/test/unit/utils/taskBasedStatusUpdates.test.js
@@ -11,6 +11,7 @@ const {
   createUserStatusWithState,
   updateCurrentStatusToState,
   updateFutureStatusToState,
+  getNextDayTimeStamp,
 } = require("../../../utils/userStatus");
 
 describe("Task Based User Status Update Util Functions", function () {
@@ -282,6 +283,15 @@ describe("Task Based User Status Update Util Functions", function () {
         expect(error).to.be.an.instanceof(Error);
         expect(error.message).to.equal("error updating the future status.");
       }
+    });
+  });
+
+  describe("getNextDayTimeStamp", function () {
+    it("should return the correct timestamp for the next day", function () {
+      const inputTimestamp = new Date("2023-08-07T12:00:00Z").getTime();
+      const expectedTimestamp = new Date("2023-08-08T00:00:00Z").getTime();
+      const result = getNextDayTimeStamp(inputTimestamp);
+      expect(result).to.equal(expectedTimestamp);
     });
   });
 });

--- a/utils/userStatus.js
+++ b/utils/userStatus.js
@@ -294,6 +294,14 @@ const generateErrorResponse = (message) => {
   };
 };
 
+const getNextDayTimeStamp = (timeStamp) => {
+  const currentDateTime = new Date(timeStamp);
+  const nextDateDateTime = new Date(currentDateTime);
+  nextDateDateTime.setDate(currentDateTime.getDate() + 1);
+  nextDateDateTime.setUTCHours(0, 0, 0, 0);
+  return nextDateDateTime.getTime();
+};
+
 module.exports = {
   getUserIdBasedOnRoute,
   getTomorrowTimeStamp,
@@ -307,4 +315,5 @@ module.exports = {
   checkIfUserHasLiveTasks,
   generateErrorResponse,
   generateNewStatus,
+  getNextDayTimeStamp,
 };


### PR DESCRIPTION
Issue Ticket Number:-
- #1381 

Backend changes
- [x] Yes
- [ ] No

Frontend Changes
- [ ] Yes
- [x] No

Database changes
- [ ] Yes 
- [x] No

Breaking changes (If your feature is breaking/missing something please mention pending tickets)
- [ ] Yes
- [x] No

### Deployment notes
None

### Description
Presently, if a user designates themselves as "Out of Office" (OOO) starting from today, they are unable to transition back to an "Idle" or "Active" status once the OOO period concludes. In the past, users had the ability to manually set themselves as "Active" or "Idle" directly on the site. However, due to the transition towards a task-based status update we now run a script periodically we need to check if OOO period is over then we need to change their status accordingly.

### Testing Stats:

Model file : models/userStatus.js

![image](https://github.com/Real-Dev-Squad/website-backend/assets/97341921/bd547647-7c03-4368-aced-04f349907c1b)

utils file : utils/userStatus.js

![image](https://github.com/Real-Dev-Squad/website-backend/assets/97341921/fc80e581-6b44-4e6d-a4bd-e45415e1c8e5)



