### PR TITLE
Add isMember Field to API Response for Group Membership

### DIFF
--- a/controllers/discordactions.js
+++ b/controllers/discordactions.js
@@ -78,7 +78,7 @@ const getAllGroupRoles = async (req, res) => {
     }
     return res.json({
       message: "Roles fetched successfully!",
-      groups: groups,
+      groups,
     });
   } catch (err) {
     logger.error(`Error while getting roles: ${err}`);

--- a/controllers/discordactions.js
+++ b/controllers/discordactions.js
@@ -66,11 +66,19 @@ const createGroupRole = async (req, res) => {
 const getAllGroupRoles = async (req, res) => {
   try {
     const { groups } = await discordRolesModel.getAllGroupRoles();
-    const discordId = req.userData?.discordId;
-    const groupsWithMembershipInfo = await discordRolesModel.enrichGroupDataWithMembershipInfo(discordId, groups);
+    const dev = req.query.dev;
+    if (dev) {
+      // Placing the new changes under the feature flag.
+      const discordId = req.userData?.discordId;
+      const groupsWithMembershipInfo = await discordRolesModel.enrichGroupDataWithMembershipInfo(discordId, groups);
+      return res.json({
+        message: "Roles fetched successfully!",
+        groups: groupsWithMembershipInfo,
+      });
+    }
     return res.json({
       message: "Roles fetched successfully!",
-      groups: groupsWithMembershipInfo,
+      groups: groups,
     });
   } catch (err) {
     logger.error(`Error while getting roles: ${err}`);

--- a/controllers/discordactions.js
+++ b/controllers/discordactions.js
@@ -3,7 +3,6 @@ const admin = require("firebase-admin");
 const config = require("config");
 const jwt = require("jsonwebtoken");
 const discordRolesModel = require("../models/discordactions");
-const { retrieveUsers } = require("../services/dataAccessLayer");
 
 /**
  * Creates a role
@@ -67,25 +66,11 @@ const createGroupRole = async (req, res) => {
 const getAllGroupRoles = async (req, res) => {
   try {
     const { groups } = await discordRolesModel.getAllGroupRoles();
-    const groupsWithMemberCount = await discordRolesModel.getNumberOfMemberForGroups(groups);
-    const groupCreatorIds = groupsWithMemberCount.reduce((ids, group) => {
-      ids.add(group.createdBy);
-      return ids;
-    }, new Set());
-    const groupCreatorsDetails = await retrieveUsers({ userIds: Array.from(groupCreatorIds) });
-    const groupsWithUserDetails = groupsWithMemberCount.map((group) => {
-      const groupCreator = groupCreatorsDetails[group.createdBy];
-      return {
-        ...group,
-        firstName: groupCreator.first_name,
-        lastName: groupCreator.last_name,
-        image: groupCreator.picture?.url,
-      };
-    });
-
+    const discordId = req.userData?.discordId;
+    const groupsWithMembershipInfo = await discordRolesModel.enrichGroupDataWithMembershipInfo(discordId, groups);
     return res.json({
       message: "Roles fetched successfully!",
-      groups: groupsWithUserDetails,
+      groups: groupsWithMembershipInfo,
     });
   } catch (err) {
     logger.error(`Error while getting roles: ${err}`);

--- a/controllers/discordactions.js
+++ b/controllers/discordactions.js
@@ -66,7 +66,7 @@ const createGroupRole = async (req, res) => {
 const getAllGroupRoles = async (req, res) => {
   try {
     const { groups } = await discordRolesModel.getAllGroupRoles();
-    const dev = req.query.dev;
+    const dev = req.query.dev === "true";
     if (dev) {
       // Placing the new changes under the feature flag.
       const discordId = req.userData?.discordId;

--- a/models/discordactions.js
+++ b/models/discordactions.js
@@ -3,8 +3,9 @@ const firestore = require("../utils/firestore");
 const discordRoleModel = firestore.collection("discord-roles");
 const memberRoleModel = firestore.collection("member-group-roles");
 const admin = require("firebase-admin");
-const { findMemberGroupIds } = require("../utils/helper");
+const { findSubscribedGroupIds } = require("../utils/helper");
 const { retrieveUsers } = require("../services/dataAccessLayer");
+const { BATCH_SIZE_IN_CLAUSE } = require("../constants/firebase");
 const photoVerificationModel = firestore.collection("photo-verification");
 
 /**
@@ -137,21 +138,17 @@ const enrichGroupDataWithMembershipInfo = async (discordId, groups = []) => {
     }, new Set());
 
     const groupCreatorsDetails = await retrieveUsers({ userIds: Array.from(groupCreatorIds) });
-
     const roleIds = groups.map((group) => group.roleid);
-    const snapshots = await memberRoleModel.where("roleid", "in", roleIds).get();
+    const groupsToUserMappings = await fetchGroupToUserMapping(roleIds);
+    const roleIdToCountMap = {};
 
-    const groupsToMemberMaps = [];
-    const roleCount = {};
-    snapshots.forEach((doc) => {
-      const groupToMemberMapping = doc.data();
-      if (groupToMemberMapping) {
-        groupsToMemberMaps.push(groupToMemberMapping);
-        roleCount[groupToMemberMapping.roleid] = (roleCount[groupToMemberMapping.roleid] ?? 0) + 1;
-      }
+    groupsToUserMappings.forEach((groupToUserMapping) => {
+      // Count how many times roleId comes up in the array.
+      // This says how many users we have for a given roleId
+      roleIdToCountMap[groupToUserMapping.roleid] = (roleIdToCountMap[groupToUserMapping.roleid] ?? 0) + 1;
     });
 
-    const userGroupMembershipsIds = findMemberGroupIds(discordId, groupsToMemberMaps);
+    const subscribedGroupIds = findSubscribedGroupIds(discordId, groupsToUserMappings);
 
     return groups.map((group) => {
       const groupCreator = groupCreatorsDetails[group.createdBy];
@@ -160,12 +157,43 @@ const enrichGroupDataWithMembershipInfo = async (discordId, groups = []) => {
         firstName: groupCreator?.first_name,
         lastName: groupCreator?.last_name,
         image: groupCreator?.picture?.url,
-        memberCount: roleCount[group.roleid] || 0,
-        isMember: userGroupMembershipsIds.has(group.roleid),
+        memberCount: roleIdToCountMap[group.roleid] || 0, // Number of users joined this group
+        isMember: subscribedGroupIds.has(group.roleid), // Is current loggedIn user is a member of this group
       };
     });
   } catch (err) {
     logger.error("Error while enriching group data with membership info", err);
+    throw err;
+  }
+};
+
+/**
+ *
+ * @param {Array<string>} roleIds Array of roleIds whose user mapping needs to fetched
+ * @returns Array of roleId to userId mapping
+ *
+ * Breaking the roleIds array into chunks of 30 or less due to firebase limitation
+ */
+const fetchGroupToUserMapping = async (roleIds) => {
+  try {
+    const roleIdChunks = [];
+
+    for (let i = 0; i < roleIds.length; i += BATCH_SIZE_IN_CLAUSE) {
+      roleIdChunks.push(roleIds.slice(i, i + BATCH_SIZE_IN_CLAUSE));
+    }
+
+    const promises = roleIdChunks.map(async (roleIdChunk) => {
+      const querySnapshot = await memberRoleModel.where("roleid", "in", roleIdChunk).get();
+      return querySnapshot.docs.map((doc) => doc.data());
+    });
+
+    const snapshots = await Promise.all(promises);
+
+    const groupToUserMappingArray = snapshots.flat();
+
+    return groupToUserMappingArray;
+  } catch (err) {
+    logger.error("Error while fetching group to user mapping", err);
     throw err;
   }
 };
@@ -177,4 +205,5 @@ module.exports = {
   isGroupRoleExists,
   updateDiscordImageForVerification,
   enrichGroupDataWithMembershipInfo,
+  fetchGroupToUserMapping,
 };

--- a/models/discordactions.js
+++ b/models/discordactions.js
@@ -130,7 +130,9 @@ const enrichGroupDataWithMembershipInfo = async (discordId, groups = []) => {
     }
 
     const groupCreatorIds = groups.reduce((ids, group) => {
-      ids.add(group.createdBy);
+      if (group.createdBy) {
+        ids.add(group.createdBy);
+      }
       return ids;
     }, new Set());
 
@@ -143,8 +145,10 @@ const enrichGroupDataWithMembershipInfo = async (discordId, groups = []) => {
     const roleCount = {};
     snapshots.forEach((doc) => {
       const groupToMemberMapping = doc.data();
-      groupsToMemberMaps.push(groupToMemberMapping);
-      roleCount[groupToMemberMapping.roleid] = (roleCount[groupToMemberMapping.roleid] ?? 0) + 1;
+      if (groupToMemberMapping) {
+        groupsToMemberMaps.push(groupToMemberMapping);
+        roleCount[groupToMemberMapping.roleid] = (roleCount[groupToMemberMapping.roleid] ?? 0) + 1;
+      }
     });
 
     const userGroupMembershipsIds = findMemberGroupIds(discordId, groupsToMemberMaps);
@@ -153,9 +157,9 @@ const enrichGroupDataWithMembershipInfo = async (discordId, groups = []) => {
       const groupCreator = groupCreatorsDetails[group.createdBy];
       return {
         ...group,
-        firstName: groupCreator.first_name,
-        lastName: groupCreator.last_name,
-        image: groupCreator.picture?.url,
+        firstName: groupCreator?.first_name,
+        lastName: groupCreator?.last_name,
+        image: groupCreator?.picture?.url,
         memberCount: roleCount[group.roleid] || 0,
         isMember: userGroupMembershipsIds.has(group.roleid),
       };

--- a/scripts/tests/testUnit.sh
+++ b/scripts/tests/testUnit.sh
@@ -8,4 +8,4 @@ json=$(node -e "console.log(require('config').get('firestore'))")
 project_id=$(echo $json | grep -o '"project_id":[^,}]*' | cut -d':' -f2 | tr -d '"' | tr -d '[:space:]')
 
 echo 'Start firestore emulator and run unit tests:'
-firebase emulators:exec 'nyc --x=controllers --x=test --x=docs  --recursive --x=mockdata --x=dist mocha --timeout 10000 test/unit/**' --project=$project_id
+firebase emulators:exec 'nyc --x=controllers --x=test --x=docs  --recursive --x=mockdata --x=dist mocha test/unit/**' --project=$project_id

--- a/scripts/tests/testUnit.sh
+++ b/scripts/tests/testUnit.sh
@@ -8,4 +8,4 @@ json=$(node -e "console.log(require('config').get('firestore'))")
 project_id=$(echo $json | grep -o '"project_id":[^,}]*' | cut -d':' -f2 | tr -d '"' | tr -d '[:space:]')
 
 echo 'Start firestore emulator and run unit tests:'
-firebase emulators:exec 'nyc --x=controllers --x=test --x=docs  --recursive --x=mockdata --x=dist mocha test/unit/**' --project=$project_id
+firebase emulators:exec 'nyc --x=controllers --x=test --x=docs  --recursive --x=mockdata --x=dist mocha --timeout 10000 test/unit/**' --project=$project_id

--- a/services/dataAccessLayer.js
+++ b/services/dataAccessLayer.js
@@ -32,7 +32,7 @@ const retrieveUsers = async ({
     return result;
   } else if (userIds) {
     if (userIds.length === 0) {
-      return [];
+      return {};
     }
     const userDetails = await userQuery.fetchUserByIds(userIds);
     Object.keys(userDetails).forEach((userId) => {

--- a/services/dataAccessLayer.js
+++ b/services/dataAccessLayer.js
@@ -10,7 +10,7 @@ const retrieveUsers = async ({
   userdata,
   level = ACCESS_LEVEL.PUBLIC,
   role = null,
-  userIds = [],
+  userIds = null,
 }) => {
   if (id || username) {
     let result;
@@ -30,7 +30,10 @@ const retrieveUsers = async ({
       result.push(user);
     });
     return result;
-  } else if (userIds.length > 0) {
+  } else if (userIds) {
+    if (userIds.length === 0) {
+      return [];
+    }
     const userDetails = await userQuery.fetchUserByIds(userIds);
     Object.keys(userDetails).forEach((userId) => {
       removeSensitiveInfo(userDetails[userId]);

--- a/test/fixtures/user/user.js
+++ b/test/fixtures/user/user.js
@@ -43,6 +43,7 @@ module.exports = () => {
     {
       username: "nikhil",
       first_name: "Nikhil",
+      discordId: "1234567890",
       last_name: "Bhandarkar",
       yoe: 0,
       img: "./img.png",

--- a/test/integration/discordactions.test.js
+++ b/test/integration/discordactions.test.js
@@ -124,10 +124,31 @@ describe("Discord actions", function () {
       await cleanDb();
     });
 
-    it("should successfully return all groups detail", function (done) {
+    it("should successfully return old groups detail", function (done) {
       chai
         .request(app)
         .get(`/discord-actions/groups`)
+        .set("cookie", `${cookieName}=${superUserAuthToken}`)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          expect(res).to.have.status(200);
+          expect(res.body).to.be.an("object");
+          // Verify presence of specific properties in each group
+          const expectedProps = ["roleid", "rolename", "memberCount", "firstName", "lastName", "image", "isMember"];
+          res.body.groups.forEach((group) => {
+            expect(group).not.to.include.all.keys(expectedProps);
+          });
+          expect(res.body.message).to.equal("Roles fetched successfully!");
+          return done();
+        });
+    });
+    it("should successfully return new groups detail when flag is set", function (done) {
+      chai
+        .request(app)
+        .get(`/discord-actions/groups?dev=true`)
         .set("cookie", `${cookieName}=${superUserAuthToken}`)
         .end((err, res) => {
           if (err) {

--- a/test/integration/discordactions.test.js
+++ b/test/integration/discordactions.test.js
@@ -92,24 +92,30 @@ describe("Discord actions", function () {
   });
 
   describe("GET /discord-actions/groups", function () {
+    let newGroupData;
+    let allIds = [];
     before(async function () {
-      let allIds = [];
-
       const addUsersPromises = userData.map((user) => userModel.add({ ...user }));
       const responses = await Promise.all(addUsersPromises);
       allIds = responses.map((response) => response.id);
+      newGroupData = groupData.map((group, index) => {
+        return {
+          ...group,
+          createdBy: allIds[Math.min(index, allIds.length - 1)],
+        };
+      });
 
       const addRolesPromises = [
-        discordRoleModel.add({ roleid: groupData[0].roleid, rolename: groupData[0].rolename, createdBy: allIds[1] }),
-        discordRoleModel.add({ roleid: groupData[1].roleid, rolename: groupData[1].rolename, createdBy: allIds[0] }),
+        discordRoleModel.add(newGroupData[0]),
+        discordRoleModel.add(newGroupData[1]),
+        discordRoleModel.add(newGroupData[2]),
       ];
       await Promise.all(addRolesPromises);
 
       const addGroupRolesPromises = [
-        addGroupRoleToMember({ roleid: groupData[0].roleid, userid: allIds[0] }),
-        addGroupRoleToMember({ roleid: groupData[0].roleid, userid: allIds[1] }),
-        addGroupRoleToMember({ roleid: groupData[0].roleid, userid: allIds[1] }),
-        addGroupRoleToMember({ roleid: groupData[1].roleid, userid: allIds[0] }),
+        addGroupRoleToMember({ roleid: newGroupData[0].roleid, userid: userData[0].discordId }),
+        addGroupRoleToMember({ roleid: newGroupData[0].roleid, userid: userData[1].discordId }),
+        addGroupRoleToMember({ roleid: newGroupData[1].roleid, userid: userData[0].discordId }),
       ];
       await Promise.all(addGroupRolesPromises);
     });
@@ -131,7 +137,7 @@ describe("Discord actions", function () {
           expect(res).to.have.status(200);
           expect(res.body).to.be.an("object");
           // Verify presence of specific properties in each group
-          const expectedProps = ["roleid", "rolename", "memberCount", "firstName", "lastName", "image"];
+          const expectedProps = ["roleid", "rolename", "memberCount", "firstName", "lastName", "image", "isMember"];
           res.body.groups.forEach((group) => {
             expect(group).to.include.all.keys(expectedProps);
           });

--- a/test/unit/services/dataAccessLayer.test.js
+++ b/test/unit/services/dataAccessLayer.test.js
@@ -137,6 +137,11 @@ describe("Data Access Layer", function () {
         });
       });
     });
+
+    it("should return empty object if array with no userIds are provided", async function () {
+      const result = await retrieveUsers({ userIds: [] });
+      expect(result).to.deep.equal({});
+    });
   });
 
   describe("retrieveFilteredUsers", function () {

--- a/test/unit/utils/helper.test.js
+++ b/test/unit/utils/helper.test.js
@@ -1,5 +1,10 @@
 const chai = require("chai");
-const { getDateTimeRangeForPRs, getQualifiers, getPaginatedLink } = require("../../../utils/helper");
+const {
+  getDateTimeRangeForPRs,
+  getQualifiers,
+  getPaginatedLink,
+  findMemberGroupIds,
+} = require("../../../utils/helper");
 const { TASK_STATUS, TASK_SIZE } = require("../../../constants/tasks");
 const { expect } = chai;
 
@@ -91,6 +96,16 @@ describe("helper", function () {
       expect(result).to.contain(`dev=${dev}`);
       expect(result).to.contain(`${cursorKey}=${docId}`);
       expect(result).to.not.contain(`next=${nextId}`);
+    });
+  });
+
+  describe("findMemberGroupIds", function () {
+    it("should return set of member groupIds", function () {
+      const memberGroupIds = findMemberGroupIds("1234", [
+        { userid: "1234", roleid: "1" },
+        { userid: "12345", roleid: "3" },
+      ]);
+      expect(memberGroupIds).to.deep.equal(new Set(["1"]));
     });
   });
 });

--- a/test/unit/utils/helper.test.js
+++ b/test/unit/utils/helper.test.js
@@ -3,7 +3,7 @@ const {
   getDateTimeRangeForPRs,
   getQualifiers,
   getPaginatedLink,
-  findMemberGroupIds,
+  findSubscribedGroupIds,
 } = require("../../../utils/helper");
 const { TASK_STATUS, TASK_SIZE } = require("../../../constants/tasks");
 const { expect } = chai;
@@ -99,9 +99,9 @@ describe("helper", function () {
     });
   });
 
-  describe("findMemberGroupIds", function () {
+  describe("findSubscribedGroupIds", function () {
     it("should return set of member groupIds", function () {
-      const memberGroupIds = findMemberGroupIds("1234", [
+      const memberGroupIds = findSubscribedGroupIds("1234", [
         { userid: "1234", roleid: "1" },
         { userid: "12345", roleid: "3" },
       ]);

--- a/utils/helper.js
+++ b/utils/helper.js
@@ -68,23 +68,29 @@ const getPaginatedLink = ({
 };
 
 /**
- * Finds and returns a Set of group IDs for which a given Discord ID is a member.
+ * Finds and returns the set of subscribed group IDs for a given Discord user ID based on group-to-user mappings.
  *
- * @param {string} discordId - The Discord ID of the user.
- * @param {Array<object>} groupToMemberMappings - Array of group-to-member mappings.
- * @returns {Set<string>} - A Set of group IDs.
+ * @param {string} discordId - The Discord user ID for which to find subscribed group IDs.
+ * @param {Array} groupToUserMappings - An array of group-to-user mappings containing user and role information.
+ * @returns {Set} - A Set containing the group IDs to which the user is subscribed.
  */
-function findMemberGroupIds(discordId, groupToMemberMappings = []) {
-  return groupToMemberMappings.reduce((memberGroupIds, group) => {
+function findSubscribedGroupIds(discordId, groupToUserMappings = []) {
+  // Initialize a Set to store the subscribed group IDs
+  const subscribedGroupIds = new Set();
+
+  // Iterate through groupToUserMappings to find subscribed group IDs
+  groupToUserMappings.forEach((group) => {
     if (group.userid === discordId) {
-      memberGroupIds.add(group.roleid);
+      subscribedGroupIds.add(group.roleid);
     }
-    return memberGroupIds;
-  }, new Set());
+  });
+
+  return subscribedGroupIds;
 }
+
 module.exports = {
   getQualifiers,
   getDateTimeRangeForPRs,
   getPaginatedLink,
-  findMemberGroupIds,
+  findSubscribedGroupIds,
 };

--- a/utils/helper.js
+++ b/utils/helper.js
@@ -67,8 +67,24 @@ const getPaginatedLink = ({
   return paginatedLink;
 };
 
+/**
+ * Finds and returns a Set of group IDs for which a given Discord ID is a member.
+ *
+ * @param {string} discordId - The Discord ID of the user.
+ * @param {Array<object>} groupToMemberMappings - Array of group-to-member mappings.
+ * @returns {Set<string>} - A Set of group IDs.
+ */
+function findMemberGroupIds(discordId, groupToMemberMappings = []) {
+  return groupToMemberMappings.reduce((memberGroupIds, group) => {
+    if (group.userid === discordId) {
+      memberGroupIds.add(group.roleid);
+    }
+    return memberGroupIds;
+  }, new Set());
+}
 module.exports = {
   getQualifiers,
   getDateTimeRangeForPRs,
   getPaginatedLink,
+  findMemberGroupIds,
 };


### PR DESCRIPTION
### Description
This pull request addresses the need to include the `isMember` field in the API response for the `GET discord-actions/groups` endpoint. This field is necessary to provide information about whether the current user is a specific group member. This information is crucial for displaying the appropriate content on the group's page, specifically the right panel that lists all the groups the current member is a part of.

This PR also does refactoring and moves additional features under a feature flag.

Fixes: #1388 

### Before
```
{
  "message": "Roles fetched successfully!",
  "groups": [
    {
      "id": "mExFFXEJo2YL8XBbdYJ1",
      "date": {
        "_seconds": 1689838197,
        "_nanoseconds": 139000000
      },
      "rolename": "group-developers",
      "roleid": "1131488158979194902",
      "createdBy": "eCITJh08tFpYvq4SDa1d",
      "count": 1,
      "firstName": "Test",
      "lastName": "User1",
      "image": "https://images.unsplash.com/photo-1633332755192-727a05c4013d?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Mnx8dXNlcnxlbnwwfHwwfHx8MA%3D%3D&auto=format&fit=crop&w=500&q=60"
    }
  ]
}
```

### After
##### Without flag
```
{
  "message": "Roles fetched successfully!",
  "groups": [
    {
      "id": "mExFFXEJo2YL8XBbdYJ1",
      "date": {
        "_seconds": 1689838197,
        "_nanoseconds": 139000000
      },
      "rolename": "group-developers",
      "roleid": "1131488158979194902",
      "createdBy": "eCITJh08tFpYvq4SDa1d",
    }
  ]
}
```

##### With flag
```
{
  "message": "Roles fetched successfully!",
  "groups": [
    {
      "id": "mExFFXEJo2YL8XBbdYJ1",
      "date": {
        "_seconds": 1689838197,
        "_nanoseconds": 139000000
      },
      "rolename": "group-developers",
      "roleid": "1131488158979194902",
      "createdBy": "eCITJh08tFpYvq4SDa1d",
      "count": 1,
      "firstName": "Test",
      "lastName": "User1",
      "isMember": true,
      "image": "https://images.unsplash.com/photo-1633332755192-727a05c4013d?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Mnx8dXNlcnxlbnwwfHwwfHx8MA%3D%3D&auto=format&fit=crop&w=500&q=60"
    }
  ]
}
```

### Tests

##### Before

| File                               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line                   |
| ---------------------------------- | ------- | -------- | ------- | ------- | -------------------------------- |
| models/ discordactions.js                     |   82.71 |     92.3 |   94.44 |   81.69 | 19-20,42-43,57-59,63-64,88-89,142-143 | 
|  dataAccessLayer.js                    |     100 |    96.66 |     100 |     100 | 95 |
| helper.js                             |     100 |    82.35 |     100 |     100 | 50-51,62    |
| controllers/discordactions.js                     |      50 |     37.5 |      50 |      50 | 18-57,91-92,103-138




##### After
| File                               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line                   |
| ---------------------------------- | ------- | -------- | ------- | ------- | -------------------------------- |
| models/discordactions.js                     |   84.61 |       80 |   94.73 |   84.14 | 21-22,44-45,59-61,65-66,90-91,168-169 | 
| services/dataAccessLayer.js                    |     100 |    96.87 |     100 |     100 | 98 |
| utils/helper.js                    | 100     | 80       | 100     | 100     | 50-51,62-77                      |
| controllers/discordactions.js                     |   46.55 |       50 |      40 |   46.29 | 17-56,84-85,96-131 |






