### PR TITLE
Refactor: keeping body optional in archiving details in the archiving process

### DIFF
--- a/controllers/members.js
+++ b/controllers/members.js
@@ -87,18 +87,13 @@ const archiveMembers = async (req, res) => {
     const superUserId = req.userData.id;
     const { reason } = req.body;
     const roles = req?.userData?.roles;
-    const isReasonNullOrUndefined = !reason;
-    const isReasonEmptyOrWhitespace = /^\s*$/.test(reason);
-    if (isReasonNullOrUndefined || isReasonEmptyOrWhitespace) {
-      return res.boom.badRequest("Reason is required");
-    }
     if (user?.userExists) {
       const successObject = await members.addArchiveRoleToMembers(user.user.id);
       if (successObject.isArchived) {
         return res.boom.badRequest("User is already archived");
       }
       const body = {
-        reason: reason,
+        reason: reason || "",
         archived_user: {
           user_id: user.user.id,
           username: user.user.username,

--- a/test/integration/members.test.js
+++ b/test/integration/members.test.js
@@ -307,24 +307,6 @@ describe("Members", function () {
           return done();
         });
     });
-    it("Should return 400 if body is empty", function (done) {
-      chai
-        .request(app)
-        .patch(`/members/archiveMembers/${userToBeArchived.username}`)
-        .set("cookie", `${cookieName}=${jwt}`)
-        .send({})
-        .end((err, res) => {
-          if (err) {
-            return done(err);
-          }
-
-          expect(res).to.have.status(400);
-          expect(res.body).to.be.a("object");
-          expect(res.body.message).to.equal("Reason is required");
-
-          return done();
-        });
-    });
     it("Should archive the user", function (done) {
       addUser(userToBeArchived).then(() => {
         chai


### PR DESCRIPTION
**Why do we need to keep the body (reason) optional to the issue/ ticket #1214 ?**

- If we don't keep the body optional, the current archiving process will break because we don't have to Input field in the front-end for the body `reason`,

In the future scope, we will make the body(reason) a required field.

This PR aims to make the 
body an optional field to not break the current working process in prod, and the body (reason) can be passed optional, and yet the authorized users can fetch the logs of `archived-details`.

**Test case coverage and result:**

![Screenshot 2023-08-14 043647](https://github.com/Real-Dev-Squad/website-backend/assets/75125943/1080248d-cfa2-45e4-b2e8-dc3f16afa518)
![Screenshot 2023-08-12 004131](https://github.com/Real-Dev-Squad/website-backend/assets/75125943/7b3b2068-9d52-45f1-8ffb-34c3f00f2cbb)
![Screenshot 2023-08-12 004109](https://github.com/Real-Dev-Squad/website-backend/assets/75125943/9d215e5f-c95b-4a69-ad03-1d86ebf13f20)
![Screenshot 2023-08-14 042811](https://github.com/Real-Dev-Squad/website-backend/assets/75125943/f25a5075-eac3-4081-9fe8-f8e80cd376c4)
