### PR TITLE
[Live-Site] feat: create generate event code API

### DIFF
--- a/constants/events.js
+++ b/constants/events.js
@@ -9,4 +9,11 @@ const UNWANTED_PROPERTIES_FROM_100MS = [
   "customer",
 ];
 
-module.exports = { API_100MS_BASE_URL, GET_ALL_EVENTS_LIMIT_MIN, UNWANTED_PROPERTIES_FROM_100MS };
+const ROLES = {
+  HOST: "host",
+  MODERATOR: "moderator",
+  MAVEN: "maven",
+  GUEST: "guest",
+};
+
+module.exports = { API_100MS_BASE_URL, GET_ALL_EVENTS_LIMIT_MIN, UNWANTED_PROPERTIES_FROM_100MS, ROLES };

--- a/controllers/events.js
+++ b/controllers/events.js
@@ -279,7 +279,7 @@ const generateEventCode = async (req, res) => {
       code: eventCode,
       role,
     });
-    return res.status(201).json(eventCodeObjectFromDB);
+    return res.status(201).json({ message: "Event code created succesfully!", eventCodeObjectFromDB });
   } catch (error) {
     logger.error({ error });
     return res.status(500).json({

--- a/controllers/events.js
+++ b/controllers/events.js
@@ -273,13 +273,13 @@ const generateEventCode = async (req, res) => {
   }
 
   try {
-    const eventCodeObjectFromDB = await eventQuery.createEventCode({
+    const allEventCodeObjectFromDB = await eventQuery.createEventCode({
       id: eventCodeUuid,
       event_id: id,
       code: eventCode,
       role,
     });
-    return res.status(201).json({ message: "Event code created succesfully!", eventCodeObjectFromDB });
+    return res.status(201).json({ message: "Event code created succesfully!", data: [...allEventCodeObjectFromDB] });
   } catch (error) {
     logger.error({ error });
     return res.status(500).json({

--- a/middlewares/validators/events.js
+++ b/middlewares/validators/events.js
@@ -144,6 +144,27 @@ const kickoutPeer = async (req, res, next) => {
   }
 };
 
+const generateEventCode = async (req, res, next) => {
+  const { id } = req.params;
+  const { eventCode, role } = req.body;
+
+  const schema = joi.object({
+    id: joi.string().required(),
+    eventCode: joi.string().required(),
+    role: joi.string().required(),
+  });
+
+  const validationOptions = { abortEarly: false };
+
+  try {
+    await schema.validateAsync({ id, eventCode, role }, validationOptions);
+    next();
+  } catch (error) {
+    logger.error(`We encountered some error while generating event code: ${error}`);
+    res.boom.badRequest(error.details[0].message);
+  }
+};
+
 module.exports = {
   createEvent,
   getAllEvents,
@@ -153,4 +174,5 @@ module.exports = {
   endActiveEvent,
   addPeerToEvent,
   kickoutPeer,
+  generateEventCode,
 };

--- a/models/events.js
+++ b/models/events.js
@@ -198,7 +198,7 @@ const createEventCode = async (eventCodeData) => {
 
     if (!data) throw new Error();
 
-    if (previouslyPresentEventCodes?.length > 0) {
+    if (previouslyPresentEventCodes?.length) {
       await eventRef.update({
         event_codes: {
           by_role: {
@@ -232,7 +232,7 @@ const createEventCode = async (eventCodeData) => {
 
     return allEventCodesForMavens;
   } catch (error) {
-    logger.error("Error in adding data", error);
+    logger.error("Error in creating event code", error);
     throw error;
   }
 };

--- a/models/events.js
+++ b/models/events.js
@@ -192,20 +192,29 @@ const createEventCode = async (eventCodeData) => {
     const docSnapshot = await docRef.get();
     const data = docSnapshot.data();
 
-    if (data) {
+    const previouslyPresentEventCodes = eventSnapshotData?.event_codes?.byRole?.mavens && [
+      ...eventSnapshotData?.event_codes?.byRole?.mavens,
+    ];
+    if (!data) throw new Error();
+
+    if (previouslyPresentEventCodes?.length > 0) {
       await eventRef.update({
         event_codes: {
-          byRole: {
-            mavens: [
-              ...eventSnapshotData?.event_codes?.byRole?.mavens,
-              {
-                ...data,
-              },
-            ],
+          by_role: {
+            mavens: [...previouslyPresentEventCodes, data?.id],
+          },
+        },
+      });
+    } else {
+      await eventRef.update({
+        event_codes: {
+          by_role: {
+            mavens: [data?.id],
           },
         },
       });
     }
+
     return data;
   } catch (error) {
     logger.error("Error in adding data", error);

--- a/models/events.js
+++ b/models/events.js
@@ -192,9 +192,10 @@ const createEventCode = async (eventCodeData) => {
     const docSnapshot = await docRef.get();
     const data = docSnapshot.data();
 
-    const previouslyPresentEventCodes = eventSnapshotData?.event_codes?.byRole?.mavens && [
-      ...eventSnapshotData?.event_codes?.byRole?.mavens,
+    const previouslyPresentEventCodes = eventSnapshotData?.event_codes?.by_role?.mavens && [
+      ...eventSnapshotData?.event_codes?.by_role?.mavens,
     ];
+
     if (!data) throw new Error();
 
     if (previouslyPresentEventCodes?.length > 0) {
@@ -215,7 +216,21 @@ const createEventCode = async (eventCodeData) => {
       });
     }
 
-    return data;
+    const updatedEventRef = eventModel.doc(eventCodeData.event_id);
+    const updatedEventSnapshot = await updatedEventRef.get();
+    const updatedEventSnapshotData = updatedEventSnapshot.data();
+    const allEventCodesIdsForMavens = updatedEventSnapshotData?.event_codes?.by_role?.mavens;
+
+    const allEventCodesIdsForMavensPromises = allEventCodesIdsForMavens.map(async (eventCodeRefId) => {
+      const eventCodeRef = eventCodeModel.doc(eventCodeRefId);
+      const eventCodeSnapshot = await eventCodeRef.get();
+      const eventCodeData = eventCodeSnapshot.data();
+      return eventCodeData;
+    });
+
+    const allEventCodesForMavens = await Promise.all(allEventCodesIdsForMavensPromises);
+
+    return allEventCodesForMavens;
   } catch (error) {
     logger.error("Error in adding data", error);
     throw error;

--- a/routes/events.js
+++ b/routes/events.js
@@ -12,5 +12,6 @@ router.patch("/", authenticate, eventsValidator.updateEvent, events.updateEvent)
 router.patch("/end", authenticate, eventsValidator.endActiveEvent, events.endActiveEvent);
 router.post("/:id/peers", authenticate, eventsValidator.addPeerToEvent, events.addPeerToEvent);
 router.patch("/:id/peers/kickout", authenticate, eventsValidator.kickoutPeer, events.kickoutPeer);
+router.post("/:id/codes", authenticate, eventsValidator.generateEventCode, events.generateEventCode);
 
 module.exports = router;

--- a/test/fixtures/events/event-codes.js
+++ b/test/fixtures/events/event-codes.js
@@ -1,0 +1,25 @@
+module.exports = [
+  {
+    message: "Event code created succesfully!",
+    data: [
+      {
+        event_id: "64d4eeb24467618438785156",
+        code: "satyam75",
+        role: "maven",
+        id: "3042c55c-89ad-4273-b553-d65b203ea251",
+      },
+      {
+        event_id: "64d4eeb24467618438785156",
+        code: "sanket75",
+        role: "maven",
+        id: "4c9b0986-a9e9-4ad7-985f-c542e88563bd",
+      },
+      {
+        event_id: "64d4eeb24467618438785156",
+        code: "prerana75",
+        role: "maven",
+        id: "4af0b60d-5f10-4f79-b2ac-1dcf68b6332a",
+      },
+    ],
+  },
+];

--- a/test/integration/events.test.js
+++ b/test/integration/events.test.js
@@ -399,9 +399,15 @@ describe("events", function () {
     });
 
     it("should return unauthorized error if user is not authenticated", function (done) {
+      const id = event1Data.id;
+      const payload = {
+        eventCode: "test-code",
+        role: "moderator",
+      };
       chai
         .request(app)
-        .patch("/events")
+        .post(`/events/${id}/codes`)
+        .send({ ...payload })
         .end((error, response) => {
           if (error) {
             return done(error);
@@ -414,5 +420,122 @@ describe("events", function () {
           return done();
         });
     });
+  });
+
+  describe("POST /events/:id/codes", function () {
+    it("should return bad request if the role is not maven", function (done) {
+      const id = event1Data.id;
+      const payload = {
+        id: "test-id",
+        eventCode: "test-code",
+        role: "moderator",
+      };
+      chai
+        .request(app)
+        .post(`/events/${id}/codes`)
+        .set("cookie", `${cookieName}=${authToken}`)
+        .send({ ...payload })
+        .end((error, response) => {
+          if (error) {
+            return done(error);
+          }
+
+          expect(response).to.have.status(400);
+          expect(response.body).to.be.an("object");
+          expect(response.body.message).to.equal("Currently the room codes feature is only for mavens!");
+          expect(response.body.message).to.be.a("string");
+
+          return done();
+        });
+    });
+    it("should return unauthorized error if user is not authenticated", function (done) {
+      const id = event1Data.id;
+      // const payload = {
+      //   id: "test-id",
+      //   eventCode: "test-code",
+      //   role: "moderator",
+      // };
+      chai
+        .request(app)
+        .post(`/events/${id}/codes`)
+        .end((error, response) => {
+          if (error) {
+            return done(error);
+          }
+
+          expect(response).to.have.status(401);
+          expect(response.body.error).to.be.equal("Unauthorized");
+          expect(response.body.message).to.be.equal("Unauthenticated User");
+
+          return done();
+        });
+    });
+    // it('should return room code created successfully', function (done) {
+    //   const id = event1Data.id;
+
+    //   const payload = {
+    //     eventCode: 'test-code', role: 'maven'
+    //   }
+
+    //   const demo = {
+    //     id: 'test-id',
+    //     event_id: event1Data.id,
+    //     code: 'test-code',
+    //     role: 'maven',
+    //   }
+
+    //   const createEventCodeStub = sinon.stub(eventQuery, 'createEventCode');
+    //   createEventCodeStub.resolves(demo);
+
+    //   console.log(createEventCodeStub.callCount)
+
+    //   // Stub eventRef.update method for updating event data
+    //   const eventRefStub = {
+    //     update: sinon.stub().resolves(),
+    //   };
+    //   console.log(eventRefStub.callCount)
+
+    //   eventRefStub.update({
+    //     event_codes: {
+    //       by_role: {
+    //         mavens: ['test-code'],
+    //       },
+    //     },
+    //   });
+
+    //   // Stub eventModel.doc method to return the eventRefStub
+    //   const eventModelStub = {
+    //     doc: sinon.stub().returns(eventRefStub),
+    //   };
+
+    //   // Replace the original eventModel with the stubbed version
+    //   const originalEventModel = eventQuery.eventModel;
+    //   eventQuery.eventModel = eventModelStub;
+    //   // eventQuery.createEventCode(payload);
+    //   chai
+    //     .request(app)
+    //     .post(`/events/${id}/codes`)
+    //     .set("cookie", `${cookieName}=${authToken}`)
+    //     .send({ ...payload })
+    //     .end((error, response) => {
+    //       if (error) {
+    //         console.log({ error })
+    //         return done(error);
+    //       }
+    //       expect(response).to.have.status(201);
+    //       expect(response.body).to.be.an("object");
+    //       expect(response.body.message).to.equal('Event code created succesfully!');
+    //       expect(response.body.message).to.be.a("string");
+    //       expect(response.body.eventCodeObjectFromDB).to.be.an('object');
+    //       // expect(response.body.eventCodeObjectFromDB.id).to.equal('test-id');
+    //       expect(response.body.eventCodeObjectFromDB.event_id).to.equal(id);
+    //       expect(response.body.eventCodeObjectFromDB.code).to.equal('test-code');
+    //       expect(response.body.eventCodeObjectFromDB.role).to.equal('maven');
+
+    //       return done();
+    //     });
+    //   eventQuery.eventModel = originalEventModel;
+    //   createEventCodeStub.restore();
+    // })
   });
 });

--- a/test/unit/models/events.test.js
+++ b/test/unit/models/events.test.js
@@ -114,4 +114,55 @@ describe("Events", function () {
       expect(data.joinedEvents[0].role).to.equal(peerData.role);
     });
   });
+
+  describe("createEventCode", function () {
+    it("should create a new event document if it doesn't exist", async function () {
+      const docRef = await eventModel.add(eventData);
+
+      const peerData = {
+        peerId: "someid",
+        name: "NonExistingPeer",
+        eventId: docRef.id,
+        role: "participant",
+        joinedAt: new Date(),
+      };
+
+      const result = await eventQuery.addPeerToEvent(peerData);
+
+      const docSnapshot = await peerModel.doc(result.peerId).get();
+      const data = docSnapshot.data();
+
+      expect(data.name).to.equal(peerData.name);
+      expect(data.joinedEvents).to.have.lengthOf(1);
+      expect(data.joinedEvents[0].event_id).to.equal(peerData.eventId);
+      expect(data.joinedEvents[0].role).to.equal(peerData.role);
+    });
+
+    it("should update the joinedEvents array if the peer document exists", async function () {
+      const docRef = await eventModel.add(eventData);
+
+      const peerData = {
+        peerId: "someid",
+        name: "ExistingPeer",
+        eventId: docRef.id,
+        role: "participant",
+        joinedAt: new Date(),
+      };
+
+      await peerModel.add({
+        peerId: peerData.peerId,
+        name: peerData.name,
+        joinedEvents: [],
+      });
+
+      await eventQuery.addPeerToEvent(peerData);
+
+      const docSnapshot = await peerModel.doc(peerData.peerId).get();
+      const data = docSnapshot.data();
+
+      expect(data.joinedEvents).to.have.lengthOf(1);
+      expect(data.joinedEvents[0].event_id).to.equal(peerData.eventId);
+      expect(data.joinedEvents[0].role).to.equal(peerData.role);
+    });
+  });
 });

--- a/test/unit/models/events.test.js
+++ b/test/unit/models/events.test.js
@@ -116,53 +116,48 @@ describe("Events", function () {
   });
 
   describe("createEventCode", function () {
-    it("should create a new event document if it doesn't exist", async function () {
-      const docRef = await eventModel.add(eventData);
-
-      const peerData = {
-        peerId: "someid",
-        name: "NonExistingPeer",
-        eventId: docRef.id,
-        role: "participant",
-        joinedAt: new Date(),
+    it("should create a new event code document if it doesn't exist", async function () {
+      const eventDocRef = await eventModel.add(eventData);
+      const eventCodeData = {
+        code: "test-code",
+        role: "maven",
+        event_id: eventDocRef.id,
+        id: "test-id",
       };
 
-      const result = await eventQuery.addPeerToEvent(peerData);
+      const result = await eventQuery.createEventCode(eventCodeData);
 
-      const docSnapshot = await peerModel.doc(result.peerId).get();
-      const data = docSnapshot.data();
-
-      expect(data.name).to.equal(peerData.name);
-      expect(data.joinedEvents).to.have.lengthOf(1);
-      expect(data.joinedEvents[0].event_id).to.equal(peerData.eventId);
-      expect(data.joinedEvents[0].role).to.equal(peerData.role);
+      expect(result[0].code).to.equal(eventCodeData.code);
+      expect(result[0].event_id).to.equal(eventCodeData.event_id);
+      expect(result[0].role).to.equal(eventCodeData.role);
+      expect(result[0].id).to.equal(eventCodeData.id);
     });
 
-    it("should update the joinedEvents array if the peer document exists", async function () {
-      const docRef = await eventModel.add(eventData);
+    it("should update the event code in events modal event_codes array if the event codes already exists", async function () {
+      const eventDocRef = await eventModel.add(eventData);
 
-      const peerData = {
-        peerId: "someid",
-        name: "ExistingPeer",
-        eventId: docRef.id,
-        role: "participant",
-        joinedAt: new Date(),
+      const eventCodeDataFirst = {
+        code: "test-code-1",
+        role: "maven",
+        event_id: eventDocRef.id,
+        id: "test-id-1",
       };
 
-      await peerModel.add({
-        peerId: peerData.peerId,
-        name: peerData.name,
-        joinedEvents: [],
-      });
+      const eventCodeDataSecond = {
+        code: "test-code-2",
+        role: "maven",
+        event_id: eventDocRef.id,
+        id: "test-id-2",
+      };
 
-      await eventQuery.addPeerToEvent(peerData);
+      await eventQuery.createEventCode(eventCodeDataFirst);
+      const result2 = await eventQuery.createEventCode(eventCodeDataSecond);
 
-      const docSnapshot = await peerModel.doc(peerData.peerId).get();
-      const data = docSnapshot.data();
-
-      expect(data.joinedEvents).to.have.lengthOf(1);
-      expect(data.joinedEvents[0].event_id).to.equal(peerData.eventId);
-      expect(data.joinedEvents[0].role).to.equal(peerData.role);
+      expect(result2).to.have.lengthOf(2);
+      expect(result2[0].id).to.equal(eventCodeDataFirst.id);
+      expect(result2[1].id).to.equal(eventCodeDataSecond.id);
+      expect(result2[0].code).to.equal(eventCodeDataFirst.code);
+      expect(result2[1].code).to.equal(eventCodeDataSecond.code);
     });
   });
 });


### PR DESCRIPTION
Closes #1424
In this PR I have created a API to generate event codes.

This API creates a event code entry/object/entity in event code collection and and stores reference of it's id to event collection.

Query params - id
Req body - {eventCode: "<String, required>", role: "String, required"}

Tests coverage
//unit
![image](https://github.com/Real-Dev-Squad/website-backend/assets/85296770/a35addd3-f0da-47a0-be61-ea3a20afee46)

//controllers

![image](https://github.com/Real-Dev-Squad/website-backend/assets/85296770/7f23684c-c7ae-46bb-997e-353a797208ca)

//utils
![image](https://github.com/Real-Dev-Squad/website-backend/assets/85296770/b96c3780-1458-48c2-86a9-893e516f7781)

//routes
![image](https://github.com/Real-Dev-Squad/website-backend/assets/85296770/022d6755-2ebc-4c74-b7fb-335585d9de37)


