### PR TITLE
TDD: Feature- Update User Nickname for OOO

### DIFF
--- a/test/fixtures/user/user.js
+++ b/test/fixtures/user/user.js
@@ -361,5 +361,17 @@ module.exports = () => {
       updated_at: Date.now(),
       created_at: Date.now(),
     },
+    {
+      first_name: "Jane",
+      last_name: "Doe",
+      yoe: 1,
+      img: "./img.png",
+      linkedin_id: "jane-doe",
+      github_id: "jane-doe",
+      github_display_name: "Jane Doe",
+      phone: "1234567890",
+      email: "janedoe@gmail.com",
+      chaincode: "12345",
+    },
   ];
 };

--- a/test/unit/services/users.test.js
+++ b/test/unit/services/users.test.js
@@ -80,4 +80,45 @@ describe("Users services", function () {
       });
     });
   });
+
+  /* Skipping since test changes will go through before the util changes */
+  // eslint-disable-next-line mocha/no-skipped-tests
+  describe.skip("getUserDiscordIdUsername", function () {
+    const userDetails = [];
+
+    before(async function () {
+      const addedUsers = [];
+
+      userDataArray.forEach((user) => {
+        addedUsers.push(userModel.add(user));
+      });
+      const userInfo = await Promise.all(addedUsers);
+      userDetails.push(userInfo);
+    });
+
+    afterEach(async function () {
+      Sinon.restore();
+    });
+
+    it("Should successfully return the username and discordId of the user whose userId is passed", async function () {});
+
+    it("Should fail to return the data when userId is invalid", async function () {});
+
+    it("Should fail to return the data when userId is valid but username is unavailable", async function () {});
+
+    it("Should fail to return the data when userId is valid but discord id is unavailable", async function () {
+      // const userWithoutUserName = {
+      //   first_name: "John",
+      //   last_name: "Doe",
+      //   discordId: "12345",
+      // };
+    });
+
+    it("Should fail to return the data when userId is valid but both usernam and discord id are unavailable", async function () {
+      // const userWithoutDiscordIdAndUsername = {
+      //   first_name: "Jane",
+      //   last_name: "Doe",
+      // };
+    });
+  });
 });

--- a/test/unit/services/users.test.js
+++ b/test/unit/services/users.test.js
@@ -5,7 +5,7 @@ const firestore = require("../../../utils/firestore");
 const userModel = firestore.collection("users");
 const cleanDb = require("../../utils/cleanDb");
 const userDataArray = require("../../fixtures/user/user")();
-const { archiveUsers } = require("../../../services/users");
+const { archiveUsers, getUserDiscordIdUsername } = require("../../../services/users");
 
 describe("Users services", function () {
   describe("archive inactive discord users in bulk", function () {
@@ -53,7 +53,7 @@ describe("Users services", function () {
 
       expect(res).to.deep.equal({
         message: "Successfully completed batch updates",
-        totalUsersArchived: 16,
+        totalUsersArchived: userDetails.length,
         totalOperationsFailed: 0,
         updatedUserDetails: userDetails,
         failedUserDetails: [],
@@ -74,7 +74,7 @@ describe("Users services", function () {
       expect(res).to.deep.equal({
         message: "Firebase batch operation failed",
         totalUsersArchived: 0,
-        totalOperationsFailed: 16,
+        totalOperationsFailed: userDetails.length,
         updatedUserDetails: [],
         failedUserDetails: userDetails,
       });
@@ -82,8 +82,7 @@ describe("Users services", function () {
   });
 
   /* Skipping since test changes will go through before the util changes */
-  // eslint-disable-next-line mocha/no-skipped-tests
-  describe.skip("getUserDiscordIdUsername", function () {
+  describe("getUserDiscordIdUsername", function () {
     const userDetails = [];
 
     before(async function () {
@@ -92,33 +91,68 @@ describe("Users services", function () {
       userDataArray.forEach((user) => {
         addedUsers.push(userModel.add(user));
       });
-      const userInfo = await Promise.all(addedUsers);
-      userDetails.push(userInfo);
+      await Promise.all(addedUsers);
+
+      const snapshot = await userModel.get();
+
+      snapshot.forEach((user) => {
+        const id = user.id;
+        const userData = user.data();
+        userDetails.push({ ...userData, id });
+      });
     });
 
     afterEach(async function () {
       Sinon.restore();
     });
 
-    it("Should successfully return the username and discordId of the user whose userId is passed", async function () {});
+    it("Should successfully return the username and discordId of the user whose userId is passed", async function () {
+      const userData = userDetails.filter((user) => user.discordId)[0];
+      const { id: userId, discordId, username } = userData;
 
-    it("Should fail to return the data when userId is invalid", async function () {});
+      const fetchedUserData = await getUserDiscordIdUsername(userId);
 
-    it("Should fail to return the data when userId is valid but username is unavailable", async function () {});
+      expect(fetchedUserData).to.have.property("discordId", discordId);
+      expect(fetchedUserData).to.have.property("username", username);
+    });
+
+    it("Should fail to return the data when userId is invalid", async function () {
+      const error = new Error("User data not found! Invalid id passed");
+      Sinon.stub(userModel, "get").rejects(error);
+      await getUserDiscordIdUsername("randomId").catch((err) => {
+        expect(err).to.be.instanceOf(Error);
+        expect(err).to.be.deep.equal(err);
+      });
+    });
+
+    it("Should fail to return the data when userId is valid but username is unavailable", async function () {
+      const userData = userDetails.filter((user) => !user.username)[0];
+      const { id: userId } = userData;
+
+      await getUserDiscordIdUsername(userId).catch((err) => {
+        expect(err).to.be.instanceOf(Error);
+        expect(err.message).to.be.equal("Complete user information unavailable!");
+      });
+    });
 
     it("Should fail to return the data when userId is valid but discord id is unavailable", async function () {
-      // const userWithoutUserName = {
-      //   first_name: "John",
-      //   last_name: "Doe",
-      //   discordId: "12345",
-      // };
+      const userData = userDetails.filter((user) => !user.discordId)[0];
+      const { id: userId } = userData;
+
+      await getUserDiscordIdUsername(userId).catch((err) => {
+        expect(err).to.be.instanceOf(Error);
+        expect(err.message).to.be.equal("Complete user information unavailable!");
+      });
     });
 
     it("Should fail to return the data when userId is valid but both usernam and discord id are unavailable", async function () {
-      // const userWithoutDiscordIdAndUsername = {
-      //   first_name: "Jane",
-      //   last_name: "Doe",
-      // };
+      const userData = userDetails.filter((user) => !user.discordId && !user.username)[0];
+      const { id: userId } = userData;
+
+      await getUserDiscordIdUsername(userId).catch((err) => {
+        expect(err).to.be.instanceOf(Error);
+        expect(err.message).to.be.equal("Complete user information unavailable!");
+      });
     });
   });
 });

--- a/test/unit/services/usersStatusService.test.js
+++ b/test/unit/services/usersStatusService.test.js
@@ -6,7 +6,8 @@ const { generateOOONickname } = require("../../../utils/userStatus");
 let fetchStub;
 
 /* Skipping since test changes will go through before the discordService changes */
-describe("Users status services", function () {
+// eslint-disable-next-line mocha/no-skipped-tests
+describe.skip("Users status services", function () {
   describe("updateDiscordUserNickname", function () {
     beforeEach(function () {
       fetchStub = Sinon.stub(global, "fetch");
@@ -25,13 +26,13 @@ describe("Users status services", function () {
       fetchStub.returns(
         Promise.resolve({
           status: 200,
-          json: () => Promise.resolve(responseObject),
+          ok: true,
+          text: () => Promise.resolve(responseObject),
         })
       );
 
       const nickname = generateOOONickname(username, from, until);
       const response = await updateDiscordUserNickname(discordId, nickname);
-
       expect(response).to.deep.equal(responseObject);
       expect(fetchStub.calledOnce).to.be.equal(true);
     });

--- a/test/unit/services/usersStatusService.test.js
+++ b/test/unit/services/usersStatusService.test.js
@@ -1,0 +1,54 @@
+const { expect } = require("chai");
+const { updateDiscordUserNickname } = require("../../../services/usersStatusService");
+const Sinon = require("sinon");
+const userDataArray = require("../../fixtures/user/user")();
+const { generateOOONickname } = require("../../../utils/userStatus");
+let fetchStub;
+
+/* Skipping since test changes will go through before the discordService changes */
+describe("Users status services", function () {
+  describe("updateDiscordUserNickname", function () {
+    beforeEach(function () {
+      fetchStub = Sinon.stub(global, "fetch");
+    });
+
+    afterEach(function () {
+      fetchStub.restore();
+    });
+
+    it("Changes the nickname of the user whose discordId is passed and returns positive response", async function () {
+      const responseObject = { message: ["User nickname changed successfully"] };
+      const { username, discordId } = userDataArray[0];
+      const from = new Date().getTime();
+      const until = new Date().getTime();
+
+      fetchStub.returns(
+        Promise.resolve({
+          status: 200,
+          json: () => Promise.resolve(responseObject),
+        })
+      );
+
+      const nickname = generateOOONickname(username, from, until);
+      const response = await updateDiscordUserNickname(discordId, nickname);
+
+      expect(response).to.deep.equal(responseObject);
+      expect(fetchStub.calledOnce).to.be.equal(true);
+    });
+
+    it("Fails to update nickname of the user and returns error", async function () {
+      const errorMessage = "🚫 Bad Request Signature";
+      fetchStub.rejects(
+        new Error({
+          error: errorMessage,
+        })
+      );
+
+      const { username, discordId } = userDataArray[0];
+      updateDiscordUserNickname(discordId, username).catch((error) => {
+        expect(error).to.be.an.instanceOf(Error);
+        expect(error.message).to.equal(errorMessage);
+      });
+    });
+  });
+});

--- a/test/unit/utils/userStatus.test.js
+++ b/test/unit/utils/userStatus.test.js
@@ -151,4 +151,14 @@ describe("User Status Functions", function () {
       expect(nickname).to.be.equal(`${username.substring(0, usernameLen)} ${oooMessage}`);
     });
   });
+
+  /* Skipping since test changes will go through before the util changes */
+  // eslint-disable-next-line mocha/no-skipped-tests
+  describe.skip("updateNickname", function () {
+    it("should call the user status service to update user's discord nickname successfully", async function () {});
+
+    it("should not call the user status service to update user's discord nickname when there's an error while fetching user details", async function () {});
+
+    it("should throw error when the users status service call to update user's discord nickname fails", async function () {});
+  });
 });

--- a/test/unit/utils/userStatus.test.js
+++ b/test/unit/utils/userStatus.test.js
@@ -94,7 +94,8 @@ describe("User Status Functions", function () {
   });
 
   /* Skipping since test changes will go through before the util changes */
-  describe("generateOOONickname", function () {
+  // eslint-disable-next-line mocha/no-skipped-tests
+  describe.skip("generateOOONickname", function () {
     it("should return nickname of the user when username, from and status is passed", async function () {
       const { username } = userData;
       const from = new Date();

--- a/test/unit/utils/userStatus.test.js
+++ b/test/unit/utils/userStatus.test.js
@@ -1,7 +1,8 @@
 const chai = require("chai");
 const { expect } = chai;
-const { generateNewStatus, checkIfUserHasLiveTasks } = require("../../../utils/userStatus");
-const { userState } = require("../../../constants/userStatus");
+const { generateNewStatus, checkIfUserHasLiveTasks, generateOOONickname } = require("../../../utils/userStatus");
+const { userState, discordNicknameLength, month } = require("../../../constants/userStatus");
+const userData = require("../../fixtures/user/user")()[0];
 
 describe("User Status Functions", function () {
   describe("generateNewStatus", function () {
@@ -89,6 +90,64 @@ describe("User Status Functions", function () {
         expect(error).to.be.instanceOf(Error);
         expect(error.message).to.equal(errorMessage);
       }
+    });
+  });
+
+  /* Skipping since test changes will go through before the util changes */
+  describe("generateOOONickname", function () {
+    it("should return nickname of the user when username, from and status is passed", async function () {
+      const { username } = userData;
+      const from = new Date();
+      const until = new Date();
+      const nickname = generateOOONickname(username, from.getTime(), until.getTime());
+
+      const fromDate = from.getDate();
+      const untilDate = until.getDate();
+      const fromMonth = month[from.getMonth()];
+      const untilMonth = month[until.getMonth()];
+
+      const oooMessage = `(OOO ${fromMonth} ${fromDate} - ${untilMonth} ${untilDate})`;
+      const oooMessageLen = oooMessage.length;
+      const usernameLen = discordNicknameLength - oooMessageLen - 1;
+      expect(nickname).to.be.equal(`${username.substring(0, usernameLen)} ${oooMessage}`);
+    });
+
+    it("should return nickname of the user with from and until date when username, from and until OOO dates are passed", async function () {
+      const { username } = userData;
+      const from = new Date();
+      const until = new Date();
+      const status = {
+        from: from.getTime(),
+        until: from.getTime(),
+      };
+      const nickname = generateOOONickname(username, status.from, status.until);
+
+      const fromDate = from.getDate();
+      const untilDate = until.getDate();
+      const fromMonth = month[from.getMonth()];
+      const untilMonth = month[until.getMonth()];
+
+      const oooMessage = `(OOO ${fromMonth} ${fromDate} - ${untilMonth} ${untilDate})`;
+      const oooMessageLen = oooMessage.length;
+      const usernameLen = discordNicknameLength - oooMessageLen - 1;
+      expect(nickname).to.be.equal(`${username.substring(0, usernameLen)} ${oooMessage}`);
+    });
+
+    it("should return nickname of the user only with until date when username and OOO until are passed, but not OOO from date", async function () {
+      const { username } = userData;
+      const until = new Date();
+      const status = {
+        until: until.getTime(),
+      };
+      const nickname = generateOOONickname(username, status.from, status.until);
+
+      const untilDate = until.getDate();
+      const untilMonth = month[until.getMonth()];
+
+      const oooMessage = `(OOO ${untilMonth} ${untilDate})`;
+      const oooMessageLen = oooMessage.length;
+      const usernameLen = discordNicknameLength - oooMessageLen - 1;
+      expect(nickname).to.be.equal(`${username.substring(0, usernameLen)} ${oooMessage}`);
     });
   });
 });


### PR DESCRIPTION
The draft PR contains initial test cases for https://github.com/Real-Dev-Squad/website-backend/issues/1119 to change the user's discord nickname during OOO period.

The draft PR contains test cases for:
- `generateOOONickname` which generates user nickname during OOO when user's username, OOO from and (or) until dates are passed
- `updateDiscordUserNickname()` which updates the user's discord nickname when the new nickname and discord id are passed.