### PR TITLE
Feat: added reason (optional) in the archiving process

### DIFF
--- a/controllers/users.js
+++ b/controllers/users.js
@@ -23,6 +23,7 @@ const {
   USERS_PATCH_HANDLER_ERROR_MESSAGES,
   USERS_PATCH_HANDLER_SUCCESS_MESSAGES,
 } = require("../constants/users");
+const { addLog } = require("../models/logs");
 
 const verifyUser = async (req, res) => {
   const userId = req.userData.id;
@@ -673,9 +674,27 @@ const updateRoles = async (req, res) => {
     const result = await dataAccess.retrieveUsers({ id: req.params.id });
     if (result?.userExists) {
       const dataToUpdate = req.body;
+      const roles = req?.userData?.roles;
+      const { reason } = req.body;
+      const superUserId = req.userData.id;
+
       const response = await getRoleToUpdate(result.user, dataToUpdate);
       if (response.updateRole) {
         await userQuery.addOrUpdate(response.newUserRoles, result.user.id);
+        if (dataToUpdate?.archived) {
+          const body = {
+            reason: reason || "",
+            archived_user: {
+              user_id: result.user.id,
+              username: result.user.username,
+            },
+            archived_by: {
+              user_id: superUserId,
+              roles: roles,
+            },
+          };
+          addLog("archived-details", {}, body);
+        }
         return res.json({
           message: "role updated successfully!",
         });

--- a/middlewares/validators/user.js
+++ b/middlewares/validators/user.js
@@ -260,17 +260,18 @@ const validateImageVerificationQuery = async (req, res, next) => {
 };
 
 async function validateUpdateRoles(req, res, next) {
-  const schema = joi.object().strict().min(1).max(1).keys({
+  const schema = joi.object().strict().min(1).max(2).keys({
+    // either member or archived with reason (optional) is allowed
     member: joi.boolean(),
     archived: joi.boolean(),
+    reason: joi.string().optional(), // reason is optional
   });
-
   try {
     await schema.validateAsync(req.body);
     next();
   } catch (error) {
     logger.error(`Error validating updateRoles query params : ${error}`);
-    res.boom.badRequest("we only allow either role member or archieve");
+    res.boom.badRequest("we only allow either role member or archived with a reason");
   }
 }
 

--- a/test/integration/users.test.js
+++ b/test/integration/users.test.js
@@ -1642,6 +1642,7 @@ describe("Users", function () {
           .send({
             member: true,
             archived: true,
+            reason: "test reason",
           })
           .end((err, res) => {
             if (err) {
@@ -1649,7 +1650,7 @@ describe("Users", function () {
             }
 
             expect(res).to.have.status(400);
-            expect(res.body.message).to.be.equal("we only allow either role member or archieve");
+            expect(res.body.message).to.be.equal("we only allow either role member or archived with a reason");
             return done();
           });
       });
@@ -1670,7 +1671,7 @@ describe("Users", function () {
             }
 
             expect(res).to.have.status(400);
-            expect(res.body.message).to.be.equal("we only allow either role member or archieve");
+            expect(res.body.message).to.be.equal("we only allow either role member or archived with a reason");
             return done();
           });
       });

--- a/test/unit/middlewares/users-validator.test.js
+++ b/test/unit/middlewares/users-validator.test.js
@@ -40,11 +40,12 @@ describe("Test the roles update validator", function () {
     expect(nextSpy.callCount).to.be.equal(1);
   });
 
-  it("Throws an error if both member and archived properties are present", async function () {
+  it("Throws an error if both member and archived with reason properties are present", async function () {
     const req = {
       body: {
         member: true,
         archived: true,
+        reason: "test reason",
       },
     };
     const res = {


### PR DESCRIPTION
**Problem Statement:**

The legacy API endpoint, previously located at `/members/archiveMembers/${id}`, has been deprecated. The new endpoint for this functionality is now available at `/users/${id}/temporary/data` ([updated API endpoint](https://github.com/Real-Dev-Squad/website-members/pull/549/files#diff-3b3e89342fdb3bc17dfd7a2647442154ca1b61f5d70a7244d715c9132aa52785)).

**Proposed Solution:**

This pull request addresses the task of remaking the "Add logs" feature for archived details, similar to ([Issue #1329](https://github.com/Real-Dev-Squad/website-backend/pull/1329)), using the updated API endpoint.

**Changes Made:**

Added `reason` as a body parameter (optional) in the existing function `validateUpdateRoles`, which is now being utilized in the `archived-details` logs.

**Test Case Results:**

![Screenshot 2023-09-01 131728](https://github.com/Real-Dev-Squad/website-backend/assets/75125943/b4b13b54-ecb4-445a-9797-7f9b59585a7d)

![Screenshot 2](https://github.com/Real-Dev-Squad/website-backend/assets/75125943/ea138098-3cec-448c-b93d-fbfebc4b527a)

![Screenshot 3](https://github.com/Real-Dev-Squad/website-backend/assets/75125943/7a222317-8baf-4713-a15d-2b6cbd452daf)

**Linked Issue:**

This PR is linked to #1465.