### PR TITLE
refact: added assignee filter in the overdue tasks api

### DIFF
--- a/models/tasks.js
+++ b/models/tasks.js
@@ -105,7 +105,7 @@ const getBuiltTasks = async (tasksSnapshot, searchTerm) => {
     updatedTasks = updatedTasks.filter((task) => task.title.toLowerCase().includes(searchTerm.toLowerCase()));
   }
   const taskPromises = updatedTasks.map(async (task) => {
-    task.status = TASK_STATUS[task.status.toUpperCase()] || task.status;
+    task.status = TASK_STATUS[task.status?.toUpperCase()] || task.status;
     const taskId = task.id;
     const dependencySnapshot = await dependencyModel.where("taskId", "==", taskId).get();
     task.dependsOn = [];
@@ -135,6 +135,12 @@ const fetchPaginatedTasks = async ({
     if (status === TASK_STATUS.OVERDUE && dev) {
       const currentTime = Math.floor(Date.now() / 1000);
       initialQuery = tasksModel.where("endsOn", "<", currentTime);
+      if (assignee) {
+        const user = await userUtils.getUserId(assignee);
+        if (user) {
+          initialQuery = initialQuery.where("assignee", "==", user);
+        }
+      }
     } else {
       initialQuery = tasksModel.orderBy("title");
       if (status) {

--- a/test/integration/tasks.test.js
+++ b/test/integration/tasks.test.js
@@ -252,6 +252,31 @@ describe("Tasks", function () {
         });
     });
 
+    it("Should get all overdue tasks filtered with assignee when passed to GET /tasks", function (done) {
+      chai
+        .request(app)
+        .get(`/tasks?dev=true&status=overdue&assignee=${appOwner.username}`)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          expect(res).to.have.status(200);
+          expect(res.body).to.be.a("object");
+          expect(res.body.message).to.equal("Tasks returned successfully!");
+          expect(res.body.tasks).to.be.a("array");
+          expect(res.body).to.have.property("next");
+          expect(res.body).to.have.property("prev");
+
+          const tasksData = res.body.tasks ?? [];
+          tasksData.forEach((task) => {
+            expect(task.assignee).to.equal(appOwner.username);
+            expect(task.title).to.include("Test task");
+          });
+          return done();
+        });
+    });
+
     it("Should get tasks when correct query parameters are passed", function (done) {
       chai
         .request(app)


### PR DESCRIPTION
## Brief
- Added a `assignee` filter in overdue tasks API
- this may need us to create additional indexes on the firstore

### Indexes needed on firestore
![image](https://github.com/Real-Dev-Squad/website-backend/assets/73058928/d4da50c7-4c98-40f4-965a-384d0ddb2bee)
