### PR TITLE
Fix/nickname sync api

### DIFF
--- a/controllers/discordactions.js
+++ b/controllers/discordactions.js
@@ -203,7 +203,7 @@ const updateDiscordNicknames = async (req, res) => {
 
     const discordServerUsers = await dataAccess.retrieveDiscordUsers();
     const nonSuperUsers = discordServerUsers.filter((user) => !user.roles.super_user);
-    let errorsArr = [];
+    const errorsArr = [];
     let successCounter = 0;
     let errorCounter = 0;
     const batchUpdate = nonSuperUsers.map(async (user) => {

--- a/controllers/discordactions.js
+++ b/controllers/discordactions.js
@@ -203,14 +203,27 @@ const updateDiscordNicknames = async (req, res) => {
 
     const discordServerUsers = await dataAccess.retrieveDiscordUsers();
     const nonSuperUsers = discordServerUsers.filter((user) => !user.roles.super_user);
+    let errorsArr = [];
+    let successCounter = 0;
+    let errorCounter = 0;
     const batchUpdate = nonSuperUsers.map(async (user) => {
       const { discordId, username } = user;
-      return await setUserDiscordNickname(username, discordId);
+      try {
+        await setUserDiscordNickname(username, discordId);
+        successCounter++;
+      } catch (error) {
+        errorsArr.push(`User: ${username}, ${error.message}`);
+        errorCounter++;
+      }
     });
 
     response = await Promise.all(batchUpdate);
+
     return res.json({
-      numberOfUsersEffected: response.length,
+      errorsArr,
+      numberOfUnEffectedUsers: errorCounter,
+      numberOfUsersEffected: successCounter,
+      totalusersChecked: response.length,
       message: `Users Nicknames updated successfully`,
     });
   } catch (error) {

--- a/services/discordService.js
+++ b/services/discordService.js
@@ -69,7 +69,7 @@ const removeRoleFromUser = async (roleId, discordId) => {
 
 const setUserDiscordNickname = async (userName, discordId) => {
   try {
-    const authToken = await generateAuthTokenForCloudflare();
+    const authToken =  generateAuthTokenForCloudflare();
 
     const response = await (
       await fetch(`${DISCORD_BASE_URL}/guild/member`, {

--- a/services/discordService.js
+++ b/services/discordService.js
@@ -69,7 +69,7 @@ const removeRoleFromUser = async (roleId, discordId) => {
 
 const setUserDiscordNickname = async (userName, discordId) => {
   try {
-    const authToken =  generateAuthTokenForCloudflare();
+    const authToken = generateAuthTokenForCloudflare();
 
     const response = await (
       await fetch(`${DISCORD_BASE_URL}/guild/member`, {

--- a/test/integration/discordactions.test.js
+++ b/test/integration/discordactions.test.js
@@ -230,7 +230,7 @@ describe("Discord actions", function () {
         });
     });
 
-    it("returns an error for unsuccessful updating nicknames with POST method", function (done) {
+    it("returns an error array with users whose nicknames are failed to update", function (done) {
       fetchStub.returns(Promise.reject(new Error("User not verified")));
 
       chai
@@ -241,9 +241,9 @@ describe("Discord actions", function () {
           if (err) {
             return done(err);
           }
-          expect(res).to.have.status(500);
+          expect(res).to.have.status(200);
           const response = res.body;
-          expect(response.message).to.be.equal("An internal server error occurred");
+          expect(response.errorsArr.length).to.be.equal(3);
           return done();
         });
     });

--- a/test/integration/discordactions.test.js
+++ b/test/integration/discordactions.test.js
@@ -224,6 +224,8 @@ describe("Discord actions", function () {
           expect(res).to.have.status(200);
           expect(res.body.message).to.be.equal("Users Nicknames updated successfully");
           expect(res.body.numberOfUsersEffected).to.be.equal(3);
+          expect(res.body.numberOfUnEffectedUsers).to.be.equal(0);
+          expect(res.body.totalusersChecked).to.be.equal(3);
           return done();
         });
     });


### PR DESCRIPTION
### Changes done:
- Added a try-catch block to handle the error case efficiently, where we try to update nicknames of users who exist on the database and do not exist in the Discord server.

### Test-stats for the extra changes:
![API-refactor-test-stats](https://github.com/Real-Dev-Squad/website-backend/assets/69259490/7c9b3baf-29cf-437e-b6f8-511fe26124d0)
