### PR TITLE
Set in_discord to true upon user verification

### DIFF
--- a/controllers/users.js
+++ b/controllers/users.js
@@ -291,7 +291,19 @@ const updateSelf = async (req, res) => {
       await userQuery.setIncompleteUserDetails(userId);
     }
 
-    const user = await userQuery.addOrUpdate(req.body, userId);
+    let updatedUserData = req.body;
+    if (req.body.discordId) {
+      // The request is from /verify, set in_discord to true
+      updatedUserData = {
+        ...updatedUserData,
+        roles: {
+          ...req.userData.roles,
+          in_discord: true,
+        },
+      };
+    }
+
+    const user = await userQuery.addOrUpdate(updatedUserData, userId);
 
     if (!user.isNewUser) {
       // Success criteria, user finished the sign up process.

--- a/test/integration/users.test.js
+++ b/test/integration/users.test.js
@@ -143,6 +143,25 @@ describe("Users", function () {
         });
     });
 
+    it("Should update the discordId and role", function (done) {
+      chai
+        .request(app)
+        .patch("/users/self")
+        .set("cookie", `${cookieName}=${jwt}`)
+        .send({
+          discordId: "12345",
+        })
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          expect(res).to.have.status(204);
+
+          return done();
+        });
+    });
+
     it("Should return 400 for invalid status value", function (done) {
       chai
         .request(app)


### PR DESCRIPTION
## Description
Currently, when users verify themselves, their account properties are not being appropriately updated in our system. To ensure accurate user management, we need to implement changes that set the "archived" property to false and the "in_discord" property to true for users upon successful verification.

## Issue
https://github.com/Real-Dev-Squad/website-backend/issues/1394

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

- [x] Is dev tested
- [ ] Is not dev tested
 
### Testing details
User data before fix
```
{
   "created_at" : 1694630004093,
   "discordId" : "232533446310887426",
   "github_created_at" : 1490287565000,
   "github_display_name" : "Shardul Silswal",
   "github_id" : "shardul08",
   "incompleteUserDetails" : true,
   "roles" : {
      "archived" : false,
      "in_discord " : false
   },
   "updated_at" : 1694630004093
}
```

User data after the fix
```
{
   "created_at" : 1694630004093,
   "discordId" : "232533446310887426",
   "github_created_at" : 1490287565000,
   "github_display_name" : "Shardul Silswal",
   "github_id" : "shardul08",
   "incompleteUserDetails" : true,
   "roles" : {
      "archived" : false,
      "in_discord" : true
   },
   "updated_at" : 1694630110577
}
```

