### PR TITLE
Get logs w.r.t the taskID

### DIFF
--- a/models/logs.js
+++ b/models/logs.js
@@ -37,8 +37,11 @@ const fetchLogs = async (query, param) => {
   try {
     let call = logsModel.where("type", "==", param);
     Object.keys(query).forEach((key) => {
-      // eslint-disable-next-line security/detect-object-injection
-      if (key !== "limit" && key !== "lastDocId") {
+      if (key === "meta") {
+        Object.keys(query[key]).forEach((metakey) => {
+          call = call.where(`meta.${metakey}`, "==", query.meta[metakey]); // fetch extension logs of a task with its task ID
+        });
+      } else if (key !== "limit" && key !== "lastDocId") {
         call = call.where(key, "==", query[key]);
       }
     });

--- a/test/fixtures/logs/extensionRequests.js
+++ b/test/fixtures/logs/extensionRequests.js
@@ -1,0 +1,72 @@
+const extensionRequestLogsModel = [
+  {
+    meta: {
+      userId: "IypJP86s4epXQDqHzquR",
+      taskId: "JOV4ouXGkNUJeLIgqbBG",
+      username: "LOLs",
+    },
+    type: "extensionRequests",
+    body: {
+      status: "DENIED",
+    },
+    timestamp: {
+      _seconds: 1694627641,
+      _nanoseconds: 711000000,
+    },
+  },
+  {
+    meta: {
+      createdBy: "IypJP86s4epXQDqHzquR",
+      taskId: "JOV4ouXGkNUJeLIgqbBG",
+    },
+    type: "extensionRequests",
+    body: {
+      extensionRequestId: "U60V4BRvNH0TP8fa5L2r",
+      newEndsOn: 1693765800,
+      oldEndsOn: 1689206400,
+      assignee: "IypJP86s4epXQDqHzquR",
+      status: "PENDING",
+    },
+    timestamp: {
+      _seconds: 1694627406,
+      _nanoseconds: 875000000,
+    },
+  },
+  {
+    type: "extensionRequests",
+    body: {
+      status: "APPROVED",
+    },
+    timestamp: {
+      _seconds: 1694564415,
+      _nanoseconds: 722000000,
+    },
+    meta: {
+      userId: "IypJP86s4epXQDqHzquR",
+      username: "mahima",
+      taskId: "mahima",
+    },
+  },
+  {
+    meta: {
+      createdBy: "IypJP86s4epXQDqHzquR",
+      taskId: "ADEkRT1RAW8AbyT5AabI",
+    },
+    type: "extensionRequests",
+    body: {
+      extensionRequestId: "nMqJCFhdkkxct8GHeOZY",
+      newEndsOn: 1693765800,
+      oldEndsOn: 1689206400,
+      assignee: "IypJP86s4epXQDqHzquR",
+      status: "PENDING",
+    },
+    timestamp: {
+      _seconds: 1694564095,
+      _nanoseconds: 148000000,
+    },
+  },
+];
+
+module.exports = {
+  extensionRequestLogsModel,
+};

--- a/test/unit/models/logs.test.js
+++ b/test/unit/models/logs.test.js
@@ -1,19 +1,33 @@
 const chai = require("chai");
+
 const { expect } = chai;
 
 const cleanDb = require("../../utils/cleanDb");
+
 const logsQuery = require("../../../models/logs");
+
 const cacheData = require("../../fixtures/cloudflareCache/data");
+
 const logsData = require("../../fixtures/logs/archievedUsers");
+
+const extensionRequestLogs = require("../../fixtures/logs/extensionRequests");
+
 const app = require("../../../server");
+
 const Sinon = require("sinon");
+
 const { INTERNAL_SERVER_ERROR } = require("../../../constants/errorMessages");
+
 const userData = require("../../fixtures/user/user")();
+
 const addUser = require("../../utils/addUser");
+
 const cookieName = config.get("userToken.cookieName");
+
 const authService = require("../../../services/authService");
 
 const superUser = userData[4];
+
 const userToBeMadeMember = userData[1];
 
 describe("Logs", function () {
@@ -119,6 +133,20 @@ describe("Logs", function () {
       expect(data).to.be.an("array").with.lengthOf(0);
       expect(response).to.have.status(404);
       expect(response.body.message).to.be.equal("Not Found");
+    });
+  });
+  describe("GET /logs/extensionRequests", function () {
+    it("Should fetch all extension request logs", async function () {
+      const { type, meta, body } = extensionRequestLogs.extensionRequestLogsModel[0];
+      const query = {};
+      await logsQuery.addLog(type, meta, body);
+      const data = await logsQuery.fetchLogs(query, type);
+
+      expect(data).to.be.an("array").with.lengthOf.greaterThan(0);
+      expect(data[0]).to.have.property("timestamp").that.is.an("object");
+      expect(data[0].timestamp).to.have.property("_seconds").that.is.a("number");
+      expect(data[0].timestamp).to.have.property("_nanoseconds").that.is.a("number");
+      expect(data[0].meta).to.have.property("taskId").that.is.a("string");
     });
   });
 });


### PR DESCRIPTION
## Description
The extension requests API 's GET method gives us all the extension requests and the logs API's GET method with type extensionRequests give us the logs of extension requests created, updated, timestamp, taskID etc. We need to get the extenion logs related to a particular taskID such that when we try to call GET method on extensionRequests/logs , we get logs of all the extension requests related user events of that task

## Issue
https://github.com/Real-Dev-Squad/website-backend/issues/1515

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

- [x] Is dev tested
- [ ] Is not dev tested

## Files modified

models/logs.js => Added query params to get the task with respect to a taskID


