### PR TITLE
Allow task status update to VERIFIED iff percentage completed is 100.

### DIFF
--- a/controllers/tasks.js
+++ b/controllers/tasks.js
@@ -321,7 +321,10 @@ const updateTaskStatus = async (req, res, next) => {
       }
     }
 
-    if (req.body.status === TASK_STATUS.COMPLETED && task.taskData.percentCompleted !== 100) {
+    if (
+      (req.body.status === TASK_STATUS.COMPLETED || req.body.status === TASK_STATUS.VERIFIED) &&
+      task.taskData.percentCompleted !== 100
+    ) {
       if (req.body.percentCompleted !== 100) {
         return res.boom.badRequest("Status cannot be updated. Task is not completed yet");
       }

--- a/test/integration/tasks.test.js
+++ b/test/integration/tasks.test.js
@@ -903,6 +903,31 @@ describe("Tasks", function () {
       expect(res).to.have.status(400);
       expect(res.body.message).to.be.equal("Status cannot be updated. Task is not completed yet");
     });
+
+    it("Should give 400 if status is COMPLETED and newpercent is less than 100", async function () {
+      const taskData = {
+        title: "Test task",
+        type: "feature",
+        endsOn: 1234,
+        startedOn: 4567,
+        status: "COMPLETED",
+        percentCompleted: 100,
+        participants: [],
+        assignee: appOwner.username,
+        completionAward: { [DINERO]: 3, [NEELAM]: 300 },
+        lossRate: { [DINERO]: 1 },
+        isNoteworthy: true,
+      };
+      taskId = (await tasks.updateTask(taskData)).taskId;
+      const res = await chai
+        .request(app)
+        .patch(`/tasks/self/${taskId}`)
+        .set("cookie", `${cookieName}=${jwt}`)
+        .send({ percentCompleted: 80 });
+
+      expect(res).to.have.status(400);
+      expect(res.body.message).to.be.equal("Task percentCompleted can't updated as status is COMPLETED");
+    });
   });
 
   describe("GET /tasks/overdue", function () {

--- a/test/integration/tasks.test.js
+++ b/test/integration/tasks.test.js
@@ -892,29 +892,16 @@ describe("Tasks", function () {
       expect(res.body.message).to.be.equal("Status cannot be updated. Task is not completed yet");
     });
 
-    it("Should give 400 if status is COMPLETED and newpercent is less than 100", async function () {
-      const taskData = {
-        title: "Test task",
-        type: "feature",
-        endsOn: 1234,
-        startedOn: 4567,
-        status: "COMPLETED",
-        percentCompleted: 100,
-        participants: [],
-        assignee: appOwner.username,
-        completionAward: { [DINERO]: 3, [NEELAM]: 300 },
-        lossRate: { [DINERO]: 1 },
-        isNoteworthy: true,
-      };
-      taskId = (await tasks.updateTask(taskData)).taskId;
+    it("Should give 400 if percentCompleted is not 100 and new status is VERIFIED ", async function () {
+      taskId = (await tasks.updateTask({ ...taskData, status: "REVIEW", assignee: appOwner.username })).taskId;
       const res = await chai
         .request(app)
         .patch(`/tasks/self/${taskId}`)
         .set("cookie", `${cookieName}=${jwt}`)
-        .send({ percentCompleted: 80 });
+        .send({ ...taskStatusData, status: "VERIFIED" });
 
       expect(res).to.have.status(400);
-      expect(res.body.message).to.be.equal("Task percentCompleted can't updated as status is COMPLETED");
+      expect(res.body.message).to.be.equal("Status cannot be updated. Task is not completed yet");
     });
   });
 


### PR DESCRIPTION
# Description 
Users are able to move their task status to VERIFIED even if the percentage completed is not 100%. This PR adds a validation to let only the tasks which has percentage completed 100% to be moved to VERIFIED.


<img width="1076" alt="Screenshot 2023-09-19 at 8 50 27 PM" src="https://github.com/Real-Dev-Squad/website-backend/assets/98796547/5287a6b8-40d3-4d07-b8b8-039ee7f5a845">
