### PR TITLE
sync discord groups in firestore

### DIFF
--- a/controllers/discordactions.js
+++ b/controllers/discordactions.js
@@ -274,36 +274,36 @@ const updateDiscordNicknames = async (req, res) => {
 const getRolesFromDiscord = async (req, res) => {
   const value = await getDiscordRoles();
   const batch = value.roles.map(async (role) => {
-      const data = await discordRolesModel.getAllGroupRoleByName(role.name);
-      if (!data.data.empty) {
-        const roleInFirestore = {
-          id: data.data.docs[0].id,
-          ...data.data.docs[0].data()
-        }
+    const data = await discordRolesModel.getAllGroupRoleByName(role.name);
+    if (!data.data.empty) {
+      const roleInFirestore = {
+        id: data.data.docs[0].id,
+        ...data.data.docs[0].data(),
+      };
 
-        if(roleInFirestore.roleid !== role.id) {
-          await discordRolesModel.updateGroupRole({
-            roleid: role.id
-          }, roleInFirestore.id)
-        }
-
-      } else {
-
-        const data = await discordRolesModel.createNewRole({
-          createdBy: req.userData.id,
-          rolename: role.name,
-          roleid: role.id,
-          date: admin.firestore.Timestamp.fromDate(new Date()),
-        })
-
+      if (roleInFirestore.roleid !== role.id) {
+        await discordRolesModel.updateGroupRole(
+          {
+            roleid: role.id,
+          },
+          roleInFirestore.id
+        );
       }
-  })
+    } else {
+      const data = await discordRolesModel.createNewRole({
+        createdBy: req.userData.id,
+        rolename: role.name,
+        roleid: role.id,
+        date: admin.firestore.Timestamp.fromDate(new Date()),
+      });
+    }
+  });
   const response = await Promise.all(batch);
   return res.json({
     value,
-    response
+    response,
   });
-}
+};
 
 module.exports = {
   getGroupsRoleId,
@@ -313,5 +313,5 @@ module.exports = {
   updateDiscordImageForVerification,
   setRoleIdleToIdleUsers,
   updateDiscordNicknames,
-  getRolesFromDiscord
+  getRolesFromDiscord,
 };

--- a/controllers/discordactions.js
+++ b/controllers/discordactions.js
@@ -275,9 +275,13 @@ const updateDiscordNicknames = async (req, res) => {
 
 const syncDiscordGroupRolesInFirestore = async (req, res) => {
   try {
-    const value = await discordServices.getDiscordRoles();
-    const batch = value.roles.map(async (role) => {
+    const discordRoles = await discordServices.getDiscordRoles();
+    if (discordRoles.status === 500) {
+      return res.boom.badImplementation(INTERNAL_SERVER_ERROR);
+    }
+    const batch = discordRoles.roles.map(async (role) => {
       const data = await discordRolesModel.getGroupRoleByName(role.name);
+
       if (!data.data.empty) {
         const roleInFirestore = {
           id: data.data.docs[0].id,

--- a/controllers/discordactions.js
+++ b/controllers/discordactions.js
@@ -290,7 +290,7 @@ const getRolesFromDiscord = async (req, res) => {
         );
       }
     } else {
-      const data = await discordRolesModel.createNewRole({
+      await discordRolesModel.createNewRole({
         createdBy: req.userData.id,
         rolename: role.name,
         roleid: role.id,
@@ -300,7 +300,6 @@ const getRolesFromDiscord = async (req, res) => {
   });
   const response = await Promise.all(batch);
   return res.json({
-    value,
     response,
   });
 };

--- a/controllers/discordactions.js
+++ b/controllers/discordactions.js
@@ -274,7 +274,7 @@ const updateDiscordNicknames = async (req, res) => {
 const getRolesFromDiscord = async (req, res) => {
   const value = await getDiscordRoles();
   const batch = value.roles.map(async (role) => {
-    const data = await discordRolesModel.getAllGroupRoleByName(role.name);
+    const data = await discordRolesModel.getGroupRoleByName(role.name);
     if (!data.data.empty) {
       const roleInFirestore = {
         id: data.data.docs[0].id,

--- a/controllers/discordactions.js
+++ b/controllers/discordactions.js
@@ -305,7 +305,6 @@ const syncDiscordGroupRolesInFirestore = async (req, res) => {
     const allRolesInFirestore = await discordRolesModel.getAllGroupRoles();
 
     return res.json({
-      batch,
       response: allRolesInFirestore.groups,
       message: `Discord groups synced with firestore successfully`,
     });

--- a/models/discordactions.js
+++ b/models/discordactions.js
@@ -58,7 +58,7 @@ const getAllGroupRoles = async () => {
  * @param groupRoleName String : name of the role
  * @returns {role data}
  */
-const getAllGroupRoleByName = async (groupRoleName) => {
+const getGroupRoleByName = async (groupRoleName) => {
   try {
     const data = await discordRoleModel.where("rolename", "==", groupRoleName).limit(1).get();
     return { data };
@@ -78,7 +78,7 @@ const updateGroupRole = async (roleData, docId) => {
     const data = await discordRoleModel.doc(docId).set(roleData, { merge: true });
     return { data };
   } catch (err) {
-    logger.error("Error in getting all group-roles", err);
+    logger.error("Error in updating all group-role", err);
     throw err;
   }
 };
@@ -369,7 +369,7 @@ module.exports = {
   createNewRole,
   getGroupRolesForUser,
   getAllGroupRoles,
-  getAllGroupRoleByName,
+  getGroupRoleByName,
   updateGroupRole,
   addGroupRoleToMember,
   isGroupRoleExists,

--- a/models/discordactions.js
+++ b/models/discordactions.js
@@ -60,7 +60,7 @@ const getAllGroupRoles = async () => {
  */
 const getAllGroupRoleByName = async (groupRoleName) => {
   try {
-    const data = await discordRoleModel.where('rolename', '==', groupRoleName).limit(1).get();
+    const data = await discordRoleModel.where("rolename", "==", groupRoleName).limit(1).get();
     return { data };
   } catch (err) {
     logger.error("Error in getting all group-role", err);

--- a/models/discordactions.js
+++ b/models/discordactions.js
@@ -12,7 +12,6 @@ const userModel = firestore.collection("users");
 const photoVerificationModel = firestore.collection("photo-verification");
 const dataAccess = require("../services/dataAccessLayer");
 const { getDiscordMembers, addRoleToUser, removeRoleFromUser } = require("../services/discordService");
-const { log } = require("console");
 const discordDeveloperRoleId = config.get("discordDeveloperRoleId");
 
 /**

--- a/models/discordactions.js
+++ b/models/discordactions.js
@@ -12,6 +12,7 @@ const userModel = firestore.collection("users");
 const photoVerificationModel = firestore.collection("photo-verification");
 const dataAccess = require("../services/dataAccessLayer");
 const { getDiscordMembers, addRoleToUser, removeRoleFromUser } = require("../services/discordService");
+const { log } = require("console");
 const discordDeveloperRoleId = config.get("discordDeveloperRoleId");
 
 /**
@@ -53,6 +54,35 @@ const getAllGroupRoles = async () => {
   }
 };
 
+/**
+ *
+ * @param groupRoleName String : name of the role
+ * @returns {role data}
+ */
+const getAllGroupRoleByName = async (groupRoleName) => {
+  try {
+    const data = await discordRoleModel.where('rolename', '==', groupRoleName).limit(1).get();
+    return { data };
+  } catch (err) {
+    logger.error("Error in getting all group-role", err);
+    throw err;
+  }
+};
+
+/**
+ *
+ * @param roleData { Object }: Data of the new role
+ * @returns {role data}
+ */
+const updateGroupRole = async (roleData, docId) => {
+  try {
+    const data = await discordRoleModel.doc(docId).set(roleData, { merge: true });
+    return { data };
+  } catch (err) {
+    logger.error("Error in getting all group-roles", err);
+    throw err;
+  }
+};
 /**
  *
  * @param roleData { Object }: Data of the new role
@@ -340,6 +370,8 @@ module.exports = {
   createNewRole,
   getGroupRolesForUser,
   getAllGroupRoles,
+  getAllGroupRoleByName,
+  updateGroupRole,
   addGroupRoleToMember,
   isGroupRoleExists,
   updateDiscordImageForVerification,

--- a/routes/discordactions.js
+++ b/routes/discordactions.js
@@ -37,5 +37,5 @@ router.post(
   updateDiscordNicknames
 );
 
-router.post("/discord-roles", authenticate, syncDiscordGroupRolesInFirestore);
+router.post("/discord-roles", authenticate, authorizeRoles([SUPERUSER]), syncDiscordGroupRolesInFirestore);
 module.exports = router;

--- a/routes/discordactions.js
+++ b/routes/discordactions.js
@@ -37,5 +37,5 @@ router.post(
   updateDiscordNicknames
 );
 
-router.post("/discord-roles", authenticate, authorizeRoles([SUPERUSER]), syncDiscordGroupRolesInFirestore);
+router.post("/discord-roles", authenticate, syncDiscordGroupRolesInFirestore);
 module.exports = router;

--- a/routes/discordactions.js
+++ b/routes/discordactions.js
@@ -8,7 +8,7 @@ const {
   updateDiscordImageForVerification,
   setRoleIdleToIdleUsers,
   updateDiscordNicknames,
-  getRolesFromDiscord
+  getRolesFromDiscord,
 } = require("../controllers/discordactions");
 const { validateGroupRoleBody, validateMemberRoleBody } = require("../middlewares/validators/discordactions");
 const checkIsVerifiedDiscord = require("../middlewares/verifydiscord");
@@ -37,5 +37,5 @@ router.post(
   updateDiscordNicknames
 );
 
-router.get('/discord-roles',authenticate,  getRolesFromDiscord)
+router.get("/discord-roles", authenticate, getRolesFromDiscord);
 module.exports = router;

--- a/routes/discordactions.js
+++ b/routes/discordactions.js
@@ -8,7 +8,7 @@ const {
   updateDiscordImageForVerification,
   setRoleIdleToIdleUsers,
   updateDiscordNicknames,
-  getRolesFromDiscord,
+  syncDiscordGroupRolesInFirestore,
 } = require("../controllers/discordactions");
 const { validateGroupRoleBody, validateMemberRoleBody } = require("../middlewares/validators/discordactions");
 const checkIsVerifiedDiscord = require("../middlewares/verifydiscord");
@@ -37,5 +37,5 @@ router.post(
   updateDiscordNicknames
 );
 
-router.get("/discord-roles", authenticate, getRolesFromDiscord);
+router.post("/discord-roles", authenticate, authorizeRoles([SUPERUSER]), syncDiscordGroupRolesInFirestore);
 module.exports = router;

--- a/routes/discordactions.js
+++ b/routes/discordactions.js
@@ -8,6 +8,7 @@ const {
   updateDiscordImageForVerification,
   setRoleIdleToIdleUsers,
   updateDiscordNicknames,
+  getRolesFromDiscord
 } = require("../controllers/discordactions");
 const { validateGroupRoleBody, validateMemberRoleBody } = require("../middlewares/validators/discordactions");
 const checkIsVerifiedDiscord = require("../middlewares/verifydiscord");
@@ -35,4 +36,6 @@ router.post(
   checkIsVerifiedDiscord,
   updateDiscordNicknames
 );
+
+router.get('/discord-roles',authenticate,  getRolesFromDiscord)
 module.exports = router;

--- a/services/discordService.js
+++ b/services/discordService.js
@@ -104,8 +104,6 @@ const setUserDiscordNickname = async (userName, discordId) => {
   }
 };
 
-
-
 module.exports = {
   getDiscordMembers,
   getDiscordRoles,

--- a/services/discordService.js
+++ b/services/discordService.js
@@ -20,6 +20,22 @@ const getDiscordMembers = async () => {
   }
 };
 
+const getDiscordRoles = async () => {
+  const authToken = await generateAuthTokenForCloudflare();
+  try {
+    const response = await (
+      await fetch(`${DISCORD_BASE_URL}/roles`, {
+        method: "GET",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${authToken}` },
+      })
+    ).json();
+    return response;
+  } catch (err) {
+    logger.error("Error in fetching the discord data", err);
+    throw err;
+  }
+};
+
 const setInDiscordFalseScript = async () => {
   const users = await fetchAllUsers();
   const updateUsersPromises = [];
@@ -88,8 +104,11 @@ const setUserDiscordNickname = async (userName, discordId) => {
   }
 };
 
+
+
 module.exports = {
   getDiscordMembers,
+  getDiscordRoles,
   setInDiscordFalseScript,
   addRoleToUser,
   removeRoleFromUser,

--- a/services/discordService.js
+++ b/services/discordService.js
@@ -32,7 +32,10 @@ const getDiscordRoles = async () => {
     return response;
   } catch (err) {
     logger.error("Error in fetching the discord data", err);
-    throw err;
+    return {
+      status: 500,
+      message: "Something went wrong",
+    };
   }
 };
 

--- a/test/fixtures/discordactions/discordactions.js
+++ b/test/fixtures/discordactions/discordactions.js
@@ -18,16 +18,18 @@ const existingRole = {
   wasSuccess: false,
 };
 
-const roleDataFromDiscord = [
-  {
-    id: "test-role-id",
-    role: "test-role-name"
-  },
-  {
-    id: "test-role-id1",
-    role: "test-role-name1"
-  },
-];
+const roleDataFromDiscord = {
+  roles: [
+    {
+      id: "test-role-id",
+      name: "test-role-name",
+    },
+    {
+      id: "test-role-id1",
+      name: "Group 2",
+    },
+  ],
+};
 
 module.exports = {
   groupData,

--- a/test/fixtures/discordactions/discordactions.js
+++ b/test/fixtures/discordactions/discordactions.js
@@ -18,9 +18,20 @@ const existingRole = {
   wasSuccess: false,
 };
 
+const roleDataFromDiscord = [
+  {
+    id: 'test-role-id',
+    role: 'test-role-name'
+  }, {
+    id: 'test-role-id1',
+    role: 'test-role-name1'
+  }
+]
+
 module.exports = {
   groupData,
   roleData,
   existingRole,
   requestRoleData,
+  roleDataFromDiscord
 };

--- a/test/fixtures/discordactions/discordactions.js
+++ b/test/fixtures/discordactions/discordactions.js
@@ -20,18 +20,19 @@ const existingRole = {
 
 const roleDataFromDiscord = [
   {
-    id: 'test-role-id',
-    role: 'test-role-name'
-  }, {
-    id: 'test-role-id1',
-    role: 'test-role-name1'
-  }
-]
+    id: "test-role-id",
+    role: "test-role-name"
+  },
+  {
+    id: "test-role-id1",
+    role: "test-role-name1"
+  },
+];
 
 module.exports = {
   groupData,
   roleData,
   existingRole,
   requestRoleData,
-  roleDataFromDiscord
+  roleDataFromDiscord,
 };

--- a/test/integration/discordactions.test.js
+++ b/test/integration/discordactions.test.js
@@ -238,12 +238,10 @@ describe("Discord actions", function () {
     });
   });
 
-  describe.only("POST /discord-actions/discord-roles", function () {
+  describe("POST /discord-actions/discord-roles", function () {
     before(async function () {
-      const value = [
-        discordRoleModel.add(groupData[0]),
-        discordRoleModel.add(groupData[1]),
-      ];
+      const value = [discordRoleModel.add(groupData[0]), discordRoleModel.add(groupData[1])];
+
       await Promise.all(value);
 
       sinon.stub(discordServices, "getDiscordRoles").returns(roleDataFromDiscord);

--- a/test/integration/discordactions.test.js
+++ b/test/integration/discordactions.test.js
@@ -261,11 +261,10 @@ describe("Discord actions", function () {
           if (err) {
             return done(err);
           }
-
           expect(res).to.have.status(200);
           expect(res.body).to.be.an("object");
-          expect(res.body.batch.count).to.be.equal(3);
-          expect(res.body.message).to.equal("Discord groups synced with firestore successfull");
+          expect(res.body.response.length).to.be.equal(3);
+          expect(res.body.message).to.equal("Discord groups synced with firestore successfully");
           return done();
         });
     });

--- a/test/integration/discordactions.test.js
+++ b/test/integration/discordactions.test.js
@@ -20,7 +20,8 @@ const photoVerificationModel = firestore.collection("photo-verification");
 const discordRoleModel = firestore.collection("discord-roles");
 const userModel = firestore.collection("users");
 
-const { groupData } = require("../fixtures/discordactions/discordactions");
+const { groupData, roleDataFromDiscord } = require("../fixtures/discordactions/discordactions");
+const discordServices = require("../../services/discordService");
 const { addGroupRoleToMember } = require("../../models/discordactions");
 chai.use(chaiHttp);
 
@@ -47,6 +48,7 @@ describe("Discord actions", function () {
     sinon.restore();
     await cleanDb();
   });
+
   describe("PATCH /discord-actions/picture/id", function () {
     it("Should successfully update a picture", function (done) {
       fetchStub.returns(
@@ -231,6 +233,41 @@ describe("Discord actions", function () {
           expect(res.body.totalNicknamesUpdated.count).to.be.equal(3);
           expect(res.body.totalNicknamesNotUpdated.errors.length).to.be.equal(0);
 
+          return done();
+        });
+    });
+  });
+
+  describe.only("POST /discord-actions/discord-roles", function () {
+    before(async function () {
+      const value = [
+        discordRoleModel.add(groupData[0]),
+        discordRoleModel.add(groupData[1]),
+      ];
+      await Promise.all(value);
+
+      sinon.stub(discordServices, "getDiscordRoles").returns(roleDataFromDiscord);
+    });
+
+    after(async function () {
+      sinon.restore();
+      await cleanDb();
+    });
+
+    it("should successfully update discord role into firestore", function (done) {
+      chai
+        .request(app)
+        .post(`/discord-actions/discord-roles`)
+        .set("cookie", `${cookieName}=${superUserAuthToken}`)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          expect(res).to.have.status(200);
+          expect(res.body).to.be.an("object");
+          expect(res.body.batch.count).to.be.equal(3);
+          expect(res.body.message).to.equal("Discord groups synced with firestore successfull");
           return done();
         });
     });


### PR DESCRIPTION
**Description:**

This pull request introduces a new feature: Sync discord group in Firestore. This API will check if any group `id` is changed it will update it and if there is any new role which is not stored in the Firestore will add that role. 

**Changes Made:**

* Added a new discordActions controller function, `syncDiscordGroupRolesInFirestore`, which gets all the discord roles in Discord.
* Then checks if any role with same name exists in Firestore `discord-roles` collection but its ID is not updated then it updates the ID
* But there are any roles which are not saved in the Firestore then it creates documents of those roles in Firestore collection. 
* it gives all the roles saved in Firestore in the response.
* Added detailed JSDoc documentation for the `updateGroupRole` and `getGroupRoleByName` functions. 
<img width="1511" alt="image" src="https://github.com/Real-Dev-Squad/website-backend/assets/55375534/d185582c-8836-4917-bc8f-4371508868d1">


Testing: 
<img width="1511" alt="image" src="https://github.com/Real-Dev-Squad/website-backend/assets/55375534/d4884bc1-9a0d-4178-ac16-992910abdf9d">
