### PR TITLE
REFACTOR: return rds-session token in response

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -139,7 +139,7 @@ const updateAuthStatus = async (req, res) => {
     const authStatus = req.params.authorization_status;
     let token;
     if (authStatus === "AUTHORIZED") {
-      token = await generateUniqueToken();
+      token = await generateUniqueToken(userId);
     }
     const result = await QrCodeAuthModel.updateStatus(userId, authStatus, token);
 

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -139,7 +139,7 @@ const updateAuthStatus = async (req, res) => {
     const authStatus = req.params.authorization_status;
     let token;
     if (authStatus === "AUTHORIZED") {
-      token = await generateUniqueToken(userId);
+      token = generateUniqueToken(userId);
     }
     const result = await QrCodeAuthModel.updateStatus(userId, authStatus, token);
 

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -8,7 +8,6 @@ const {
   DATA_ADDED_SUCCESSFULLY,
   USER_DOES_NOT_EXIST_ERROR,
 } = require("../constants/errorMessages");
-const { generateUniqueToken } = require("../utils/generateUniqueToken");
 
 /**
  * Makes authentication call to GitHub statergy
@@ -139,7 +138,7 @@ const updateAuthStatus = async (req, res) => {
     const authStatus = req.params.authorization_status;
     let token;
     if (authStatus === "AUTHORIZED") {
-      token = generateUniqueToken(userId);
+      token = authService.generateAuthToken({ userId });
     }
     const result = await QrCodeAuthModel.updateStatus(userId, authStatus, token);
 

--- a/test/unit/services/generateAuthToken.test.js
+++ b/test/unit/services/generateAuthToken.test.js
@@ -1,9 +1,10 @@
 const { expect } = require("chai");
-const { generateUniqueToken } = require("../../../utils/generateUniqueToken");
+const { generateAuthToken } = require("../../../services/authService");
 
 describe("RDS-session cookie as a unique token", function () {
   it("should generate cookie as token", function () {
-    const data = generateUniqueToken();
+    const userId = "HluRbHU6I7YLqSFBa7qC";
+    const data = generateAuthToken({ userId });
     expect(data).to.include("eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9");
   });
 });

--- a/test/unit/utils/generateUniqueToken.test.js
+++ b/test/unit/utils/generateUniqueToken.test.js
@@ -1,0 +1,9 @@
+const { expect } = require("chai");
+const { generateUniqueToken } = require("../../../utils/generateUniqueToken");
+
+describe("RDS-session cookie as a unique token", function () {
+  it("should generate cookie as token", function () {
+    const data = generateUniqueToken();
+    expect(data).to.include("eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9");
+  });
+});

--- a/utils/generateUniqueToken.js
+++ b/utils/generateUniqueToken.js
@@ -1,6 +1,0 @@
-import { generateAuthToken } from "../services/authService";
-
-export const generateUniqueToken = (userId) => {
-  const token = generateAuthToken({ userId });
-  return token;
-};

--- a/utils/generateUniqueToken.js
+++ b/utils/generateUniqueToken.js
@@ -1,6 +1,6 @@
 import { generateAuthToken } from "../services/authService";
 
-export const generateUniqueToken = async (userId) => {
+export const generateUniqueToken = (userId) => {
   const token = generateAuthToken({ userId });
   return token;
 };

--- a/utils/generateUniqueToken.js
+++ b/utils/generateUniqueToken.js
@@ -1,12 +1,6 @@
-const crypto = require("crypto");
+import { generateAuthToken } from "../services/authService";
 
-export const generateUniqueToken = async () => {
-  const uuidToken = crypto.randomUUID();
-  const randomNumber = Math.floor(Math.random() * 1000000);
-  const generationTime = Date.now();
-  const encoder = new TextEncoder();
-  const encodedString = encoder.encode(uuidToken + randomNumber + generationTime);
-  const hash = await crypto.subtle.digest("SHA-256", encodedString);
-  const token = [...new Uint8Array(hash)].map((x) => x.toString(16).padStart(2, "0")).join("");
+export const generateUniqueToken = async (userId) => {
+  const token = generateAuthToken({ userId });
   return token;
 };


### PR DESCRIPTION
#### issue addressed: https://github.com/Real-Dev-Squad/website-backend/issues/1503
This PR addresses the **Token Generation** part of the above mentioned issue as follows:
Initially a unique token was being sent when user authenticate themselves using **Scan with QR**, but while hitting the API endpoints we do need the session cookie of the user to Authorize each request.
### Changes done:
Instead of sending a unique token, rds-session cookie is being sent as a part of the response, which can be used to make successful API calls.
 
![rds-session-token-respose_censored](https://github.com/Real-Dev-Squad/website-backend/assets/69259490/136e63df-4fda-4f91-a494-0389e824d499)

Test coverage stats:
![image](https://github.com/Real-Dev-Squad/website-backend/assets/69259490/24d9a75f-e2b2-4f22-96b3-7a7d427bdc50)

![image](https://github.com/Real-Dev-Squad/website-backend/assets/69259490/3ca45d81-2489-4458-8f9d-d0f2ab879ffe)
