### PR TITLE
Create a data access middleware

### DIFF
--- a/test/unit/middlewares/data-access-layer.test.js
+++ b/test/unit/middlewares/data-access-layer.test.js
@@ -1,0 +1,60 @@
+const { expect } = require("chai");
+const sinon = require("sinon");
+const { dataAccessMiddleware } = require("../../../utils/data-access");
+const { SUPERUSER } = require("../../../constants/roles");
+
+describe("dataAccessMiddleware", function () {
+  it("should remove sensitive fields from the response body based if the user does not have access", function () {
+    const req = { userData: {} };
+
+    const res = {
+      send: (body) => {
+        expect(body).to.deep.equal({
+          publicField: "publicValue",
+        });
+      },
+    };
+
+    const next = sinon.spy();
+    const rules = [
+      {
+        allowedRoles: [SUPERUSER],
+        keyPath: "privateField",
+      },
+      {
+        allowedRoles: [SUPERUSER],
+        keyPath: "privateField2",
+      },
+    ];
+
+    const middleware = dataAccessMiddleware({ rules });
+
+    middleware(req, res, next);
+
+    res.send({ privateField: "privateValue", privateField2: "privateValue", publicField: "publicValue" });
+  });
+
+  it("should not remove sensitive fields from the response body if the user has access", function () {
+    const req = { userData: { roles: { super_user: true } } };
+
+    const res = {
+      send: (body) => {
+        expect(body).to.deep.equal({ privateField: "privateValue", publicField: "publicValue" });
+      },
+    };
+
+    const next = sinon.spy();
+    const rules = [
+      {
+        allowedRoles: [SUPERUSER],
+        keyPath: "privateField",
+      },
+    ];
+
+    const middleware = dataAccessMiddleware({ rules });
+
+    middleware(req, res, next);
+
+    res.send({ privateField: "privateValue", publicField: "publicValue" });
+  });
+});

--- a/test/unit/utils/data-access.test.js
+++ b/test/unit/utils/data-access.test.js
@@ -1,0 +1,134 @@
+const { expect } = require("chai");
+const { removeObjectField } = require("../../../utils/data-access");
+
+describe("removeObjectField", function () {
+  it("should remove a field from a nested object", function () {
+    const obj = {
+      a: {
+        b: {
+          c: 42,
+          d: "hello",
+        },
+      },
+    };
+
+    removeObjectField("a.b.c", obj);
+
+    expect(obj).to.deep.equal({
+      a: {
+        b: {
+          d: "hello",
+        },
+      },
+    });
+  });
+
+  it("should remove a field from an array of objects", function () {
+    const arr = [
+      { id: 1, a: "abc" },
+      { id: 2, a: "def" },
+      { id: 3, b: "ghi" },
+    ];
+
+    removeObjectField("*.a", arr);
+
+    expect(arr).to.deep.equal([{ id: 1 }, { id: 2 }, { id: 3, b: "ghi" }]);
+  });
+
+  it("should remove a field from nested array of objects", function () {
+    const arr = [
+      {
+        id: 1,
+        a: "abc",
+        z: [
+          { a: "abc", b: "def" },
+          { a: "def", b: "def" },
+        ],
+      },
+      {
+        id: 2,
+        a: "def",
+        z: [
+          { a: "abc", b: "def" },
+          { a: "def", b: "def" },
+        ],
+      },
+      {
+        id: 3,
+        b: "ghi",
+        z: [
+          { a: "abc", b: "def" },
+          { a: "def", b: "def" },
+        ],
+      },
+    ];
+
+    removeObjectField("*.z.*.a", arr);
+
+    expect(arr).to.deep.equal([
+      {
+        id: 1,
+        a: "abc",
+        z: [{ b: "def" }, { b: "def" }],
+      },
+      {
+        id: 2,
+        a: "def",
+        z: [{ b: "def" }, { b: "def" }],
+      },
+      {
+        id: 3,
+        b: "ghi",
+        z: [{ b: "def" }, { b: "def" }],
+      },
+    ]);
+  });
+  it("should handle wildcard at the root level", function () {
+    const obj = {
+      a: {
+        b: {
+          c: 42,
+          d: "hello",
+        },
+      },
+    };
+
+    removeObjectField("*", obj);
+
+    expect(obj).to.deep.equal({});
+  });
+
+  it("should not modify the object if the path does not exist", function () {
+    const obj = {
+      b: {
+        c: 42,
+        d: "hello",
+      },
+    };
+
+    removeObjectField("x.y.z", obj);
+
+    expect(obj).to.deep.equal({
+      b: {
+        c: 42,
+        d: "hello",
+      },
+    });
+  });
+
+  it("should handle an empty object gracefully", function () {
+    const obj = {};
+
+    removeObjectField("a.b.c", obj);
+
+    expect(obj).to.deep.equal({});
+  });
+
+  it("should handle falsy value as object", function () {
+    const obj = undefined;
+
+    removeObjectField("a.b.c", obj);
+
+    expect(obj).to.deep.equal(undefined);
+  });
+});

--- a/utils/data-access.js
+++ b/utils/data-access.js
@@ -45,6 +45,9 @@ const dataAccessMiddleware = (options = {}) => {
         for (const rule of rules) {
           const userHasPermission = rule?.allowedRoles?.some((role) => roles[`${role}`]);
 
+          if (typeof body === "string") {
+            body = JSON.parse(body);
+          }
           if (!userHasPermission) {
             removeObjectField(rule.keyPath, body);
           }
@@ -78,8 +81,10 @@ function removeObjectField(path, object) {
   let currentObj = object;
   for (let i = 0; i < pathList.length; i++) {
     const key = pathList[i];
-
     if (key === "*") {
+      if (typeof currentObj !== "object") {
+        continue;
+      }
       let newPath = "";
       for (let j = i + 1; j < pathList.length; j++) {
         newPath += pathList[j] + ".";
@@ -90,9 +95,10 @@ function removeObjectField(path, object) {
         removeObjectField(newPath, childObj);
       }
       break;
-    }
-    if (Object.prototype.hasOwnProperty.call(currentObj, key) && typeof currentObj[key] === "object") {
+    } else if (Object.prototype.hasOwnProperty.call(currentObj, key) && typeof currentObj[key] === "object") {
       currentObj = currentObj[key];
+    } else {
+      break;
     }
   }
   if (lastKey === "*") {

--- a/utils/data-access.js
+++ b/utils/data-access.js
@@ -1,0 +1,108 @@
+/**
+ * Middleware function for removing sensitive fields from the response object
+ * based on user roles and predefined rules.
+ *
+ * @param {Object} options - Options for configuring the middleware.
+ * @param {Array<Object>} options.rules - An array of rules specifying which fields
+ *   to remove based on allowed roles and key paths.
+ *   - `keyPath` {string}: A key path (e.g., 'sensitive.field1') representing the field
+ *     or subfield in the response object. You can use a wildcard (*) to match multiple
+ *     subfields (e.g., 'sensitive.*' to match all subfields under 'sensitive').
+ *   - `allowedRoles` {Array<string>}: An array of user roles that are allowed to access
+ *     the field specified by the `keyPath`. If the user has one of these roles, the field
+ *     will not be removed.
+ * @returns {Function} - Express middleware function.
+ *
+ * @example
+ * // Define rules for removing fields based on user roles
+ * const rules = [
+ *   {
+ *     allowedRoles: [SUPERUSER,MEMBER],
+ *     keyPath: 'sensitive.field1',
+ *   },
+ *   {
+ *     allowedRoles: [SUPERUSER],
+ *     keyPath: 'sensitive.field2',
+ *   },
+ *   {
+ *     allowedRoles: [SUPERUSER],
+ *     keyPath: 'sensitive.*', // Using a wildcard (*) to match all subfields under 'sensitive'
+ *   },
+ * ];
+ * // Use the middleware in your Express app
+ * app.use(dataAccessMiddleware({ rules }));
+ */
+const dataAccessMiddleware = (options = {}) => {
+  const rules = options.rules;
+
+  return (req, res, next) => {
+    try {
+      const { roles = {} } = req.userData;
+
+      const oldSend = res.send;
+
+      res.send = (body) => {
+        for (const rule of rules) {
+          const userHasPermission = rule?.allowedRoles?.some((role) => roles[`${role}`]);
+
+          if (!userHasPermission) {
+            removeObjectField(rule.keyPath, body);
+          }
+        }
+        res.send = oldSend;
+        return res.send(body);
+      };
+    } catch (error) {
+      logger.error(`Error ocurred while removing sensitive fields: ${error}`);
+    } finally {
+      next();
+    }
+  };
+};
+
+/**
+ * Recursively removes a field or a set of fields from an object based on a given path.
+ *
+ * @param {string} path - The path specifying the field(s) to remove. You can use dot notation
+ *   to traverse nested objects and use a wildcard (*) to match multiple subfields.
+ * @param {object} object - The object from which the field(s) will be removed.
+ */
+function removeObjectField(path, object) {
+  if (!object) {
+    return;
+  }
+  const pathString = path;
+  const pathList = pathString.split(".");
+  const lastKey = pathList.pop();
+
+  let currentObj = object;
+  for (let i = 0; i < pathList.length; i++) {
+    const key = pathList[i];
+
+    if (key === "*") {
+      let newPath = "";
+      for (let j = i + 1; j < pathList.length; j++) {
+        newPath += pathList[j] + ".";
+      }
+      newPath += lastKey;
+
+      for (const childObj of currentObj) {
+        removeObjectField(newPath, childObj);
+      }
+      break;
+    }
+    if (Object.prototype.hasOwnProperty.call(currentObj, key) && typeof currentObj[key] === "object") {
+      currentObj = currentObj[key];
+    }
+  }
+  if (lastKey === "*") {
+    Object.keys(currentObj).forEach((key) => delete currentObj[key]);
+  } else if (Object.prototype.hasOwnProperty.call(currentObj, lastKey)) {
+    delete currentObj[lastKey];
+  }
+}
+
+module.exports = {
+  removeObjectField,
+  dataAccessMiddleware,
+};


### PR DESCRIPTION
**Description**:

This pull request introduces a new feature: Data Access Middleware. This middleware allows for fine-grained control over which fields are exposed in API responses based on user roles and predefined rules.

**Changes Made**:

- Added a new middleware function, `dataAccessMiddleware`, which takes an `options` object as its configuration.
- The `options` object can include an array of `rules`, specifying which fields should be removed based on allowed user roles and key paths.
- The middleware iterates through the specified rules and removes sensitive fields from the response if the user does not have the required role.
- Added detailed JSDoc documentation for the `dataAccessMiddleware` function, including usage examples.

**Testing**:
<img width="728" alt="Screenshot 2023-09-27 at 12 17 31 AM" src="https://github.com/Real-Dev-Squad/website-backend/assets/98796547/179b463a-3a6d-4f18-ac17-b273d886fbd2">


