### PR TITLE
remove nickname-synced field API

### DIFF
--- a/controllers/users.js
+++ b/controllers/users.js
@@ -29,8 +29,6 @@ const {
 const { addLog } = require("../models/logs");
 const { getUserStatus } = require("../models/userStatus");
 
-const { removeNicknameSyncedFieldScript } = require("../services/users");
-
 const verifyUser = async (req, res) => {
   const userId = req.userData.id;
   try {
@@ -842,15 +840,6 @@ async function usersPatchHandler(req, res) {
   }
 }
 
-const removeNicknameSyncedField = async (req, res) => {
-  try {
-    await removeNicknameSyncedFieldScript();
-    return res.json({ message: "Successfully removed the nickname_synced field for all users" });
-  } catch (err) {
-    return res.boom.badImplementation({ message: INTERNAL_SERVER_ERROR });
-  }
-};
-
 module.exports = {
   verifyUser,
   generateChaincode,
@@ -880,5 +869,4 @@ module.exports = {
   updateDiscordUserNickname,
   archiveUserIfNotInDiscord,
   usersPatchHandler,
-  removeNicknameSyncedField,
 };

--- a/routes/users.js
+++ b/routes/users.js
@@ -59,7 +59,6 @@ router.patch(
 router.get("/picture/:id", authenticate, authorizeRoles([SUPERUSER]), users.getUserImageForVerification);
 router.patch("/profileURL", authenticate, userValidator.updateProfileURL, users.profileURL);
 router.patch("/rejectDiff", authenticate, authorizeRoles([SUPERUSER]), users.rejectProfileDiff);
-router.patch("/nickname-synced-field", authenticate, authorizeRoles([SUPERUSER]), users.removeNicknameSyncedField);
 router.patch("/:userId", authenticate, authorizeRoles([SUPERUSER]), users.updateUser);
 router.get("/suggestedUsers/:skillId", authenticate, authorizeRoles([SUPERUSER]), users.getSuggestedUsers);
 module.exports = router;

--- a/services/users.js
+++ b/services/users.js
@@ -1,7 +1,6 @@
 const { USERS_PATCH_HANDLER_SUCCESS_MESSAGES, USERS_PATCH_HANDLER_ERROR_MESSAGES } = require("../constants/users");
 const firestore = require("../utils/firestore");
 const userModel = firestore.collection("users");
-const admin = require("firebase-admin");
 const archiveUsers = async (usersData) => {
   const batch = firestore.batch();
   const usersBatch = [];
@@ -41,23 +40,6 @@ const archiveUsers = async (usersData) => {
   }
 };
 
-const removeNicknameSyncedFieldScript = async () => {
-  const users = [];
-  const usersQuerySnapshot = await userModel.get();
-  usersQuerySnapshot.forEach((user) => users.push({ ...user.data(), id: user.id }));
-  const updateUsersPromises = [];
-  users.forEach((user) => {
-    const id = user.id;
-    const usersRef = userModel.doc(id);
-    updateUsersPromises.push(
-      usersRef.update({
-        nickname_synced: admin.firestore.FieldValue.delete(),
-      })
-    );
-  });
-  await Promise.all(updateUsersPromises);
-};
 module.exports = {
   archiveUsers,
-  removeNicknameSyncedFieldScript,
 };


### PR DESCRIPTION
### Changes done:

Set of removals done in this PR
- The route for removing nickname-synced field of the user document.
- The controller function of the route.
- The service function that removes the **nickname_synced** field from all the users using a batch update