### PR TITLE
Returning tasks with status other than COMPLETED and AVAILABLE

### DIFF
--- a/models/tasks.js
+++ b/models/tasks.js
@@ -132,7 +132,9 @@ const fetchPaginatedTasks = async ({
   try {
     let initialQuery = tasksModel;
 
-    if (status === TASK_STATUS.OVERDUE) {
+    if (status === TASK_STATUS.NOT_COMPLETED) {
+      initialQuery = tasksModel.orderBy("status").where("status", "not-in", ["COMPLETED", "AVAILABLE"]);
+    } else if (status === TASK_STATUS.OVERDUE) {
       const currentTime = Math.floor(Date.now() / 1000);
       const OVERDUE_TASK_STATUSES = [
         IN_PROGRESS,


### PR DESCRIPTION
This is developed in accordance with the task to add the missed updates of a task to logs collection.
All the tasks which are not either COMPLETED or AVAILABLE will require bi-weekly updates (Wednesday and Saturday). Failing to do so will add an missed updates document to our logs collection.

In this PR, we have introduced a new possible value for status query param, NOT_COMPLETED. 
To get this response the URL will be as follows: /tasks?status=NOT_COMPLETED&dev=true
This endpoint is currently behind the dev flag. 
This endpoint is also paginated so we can also pass the size parameter to get the desired number of records
or, we can pass the page.