### PR TITLE
Update time stamp for OOO

### DIFF
--- a/models/userStatus.js
+++ b/models/userStatus.js
@@ -13,6 +13,7 @@ const {
   generateErrorResponse,
   generateNewStatus,
   getNextDayTimeStamp,
+  convertTimestampsToUTC,
 } = require("../utils/userStatus");
 const { TASK_STATUS } = require("../constants/tasks");
 const userStatusModel = firestore.collection("usersStatus");
@@ -201,11 +202,12 @@ const getAllUserStatus = async (query) => {
  * @returns Promise<userStatusModel|Object>
  */
 
-const updateUserStatus = async (userId, newStatusData) => {
+const updateUserStatus = async (userId, updatedStatusData) => {
   try {
+    const newStatusData = convertTimestampsToUTC({ ...updatedStatusData });
     const userStatusDocs = await userStatusModel.where("userId", "==", userId).limit(1).get();
     const [userStatusDoc] = userStatusDocs.docs;
-    const tommorow = getTomorrowTimeStamp();
+    const tomorrow = getTomorrowTimeStamp();
     if (userStatusDoc) {
       const docId = userStatusDoc.id;
       const userStatusData = userStatusDoc.data();
@@ -223,7 +225,7 @@ const updateUserStatus = async (userId, newStatusData) => {
           newStatusData.futureStatus = {};
         }
         if (isNewStateOoo) {
-          if (newStatusData.currentStatus.from >= tommorow) {
+          if (newStatusData.currentStatus.from >= tomorrow) {
             newStatusData.futureStatus = { ...newStatusData.currentStatus };
             delete newStatusData.currentStatus;
           } else {
@@ -245,7 +247,7 @@ const updateUserStatus = async (userId, newStatusData) => {
         filterStatusData(newStatusData);
         const isNewStateOOO = newStatusData.currentStatus.state === userState.OOO;
         if (isNewStateOOO) {
-          if (newStatusData.currentStatus.from >= tommorow) {
+          if (newStatusData.currentStatus.from >= tomorrow) {
             newStatusData.futureStatus = { ...newStatusData.currentStatus };
             delete newStatusData.currentStatus;
           }

--- a/test/fixtures/userStatus/userStatus.js
+++ b/test/fixtures/userStatus/userStatus.js
@@ -185,6 +185,28 @@ const getStatusData = () => {
   ];
 };
 
+const inputFixtureForFnConvertTimestampsToUTC = {
+  currentStatus: {
+    from: 1696439365987, // Wed Oct 04 2023 17:09:25 UTC
+    until: 1697124600000, // Thu Oct 12, 2023, 15:30:00
+  },
+  futureStatus: {
+    from: 1696439365987, // Wed Oct 04 2023 17:09:25 UTC
+    until: "", // An empty string
+  },
+};
+
+const OutputFixtureForFnConvertTimestampsToUTC = {
+  currentStatus: {
+    from: 1696377600000, // October 4, 2023, 00:00:00 UTC
+    until: 1697155199999, // Thu Oct 12, 2023, 23:59:59 UTC
+  },
+  futureStatus: {
+    from: 1696377600000, // October 4, 2023, 00:00:00 UTC
+    until: "", // No conversion for an empty string
+  },
+};
+
 module.exports = {
   userStatusDataForNewUser,
   userStatusDataAfterSignup,
@@ -197,4 +219,6 @@ module.exports = {
   generateStatusDataForCancelOOO,
   generateStatusDataForState,
   getStatusData,
+  inputFixtureForFnConvertTimestampsToUTC,
+  OutputFixtureForFnConvertTimestampsToUTC,
 };

--- a/test/integration/userStatus.test.js
+++ b/test/integration/userStatus.test.js
@@ -23,6 +23,7 @@ const { updateUserStatus } = require("../../models/userStatus");
 const { userState } = require("../../constants/userStatus");
 const cookieName = config.get("userToken.cookieName");
 const userStatusModel = require("../../models/userStatus");
+const { convertTimestampToUTCStartOrEndOfDay } = require("../../utils/userStatus");
 
 chai.use(chaiHttp);
 
@@ -128,7 +129,7 @@ describe("UserStatus", function () {
     let clock;
     beforeEach(async function () {
       clock = sinon.useFakeTimers({
-        now: new Date(2022, 10, 12).getTime(),
+        now: new Date(2022, 10, 12, 12, 0, 0).getTime(),
         toFake: ["Date"],
       });
       testUserId = await addUser(userData[1]);
@@ -143,7 +144,9 @@ describe("UserStatus", function () {
       // creating Active Status from 12th Nov 2022 (1669401000000)
       const updatedAtDate = Date.now(); // 12th Nov 2022
       const fromDate = updatedAtDate + 12 * 24 * 60 * 60 * 1000; // 24th Nov 2022
+      const fromDateInUTC = convertTimestampToUTCStartOrEndOfDay(fromDate, false);
       const untilDate = updatedAtDate + 16 * 24 * 60 * 60 * 1000; // 28th Nov 2022
+      const untilDateInUTC = convertTimestampToUTCStartOrEndOfDay(untilDate, true);
 
       const statusData = generateUserStatusData("ACTIVE", updatedAtDate, updatedAtDate);
       statusData.userId = testUserId;
@@ -160,8 +163,8 @@ describe("UserStatus", function () {
       expect(response2.body.data).to.have.own.property("futureStatus");
       expect(response2.body.data.futureStatus.state).to.equal("OOO");
       expect(response2.body.data.futureStatus.message).to.equal("Vacation Trip");
-      expect(response2.body.data.futureStatus.from).to.equal(fromDate);
-      expect(response2.body.data.futureStatus.until).to.equal(untilDate);
+      expect(response2.body.data.futureStatus.from).to.equal(fromDateInUTC);
+      expect(response2.body.data.futureStatus.until).to.equal(untilDateInUTC);
       expect(response2.body.data.futureStatus.updatedAt).to.equal(updatedAtDate);
 
       // Mocking date to be 26th Nov 2022
@@ -277,7 +280,7 @@ describe("UserStatus", function () {
 
     beforeEach(async function () {
       clock = sinon.useFakeTimers({
-        now: new Date(2022, 10, 12).getTime(),
+        now: new Date(2022, 10, 12, 12, 0, 0).getTime(),
         toFake: ["Date"],
       });
       testUserId = await addUser(userData[1]);
@@ -483,7 +486,9 @@ describe("UserStatus", function () {
 
       // Initially Marking OOO Status from 24th Nov 2022 to 28th Nov 2022
       let fromDate = new Date(2022, 10, 24).getTime();
+      let fromDateInUTC = convertTimestampToUTCStartOrEndOfDay(fromDate, false);
       let untilDate = new Date(2022, 10, 28).getTime();
+      let untilDateInUTC = convertTimestampToUTCStartOrEndOfDay(untilDate, true);
       const response2 = await chai
         .request(app)
         .patch(`/users/status/self`)
@@ -493,12 +498,14 @@ describe("UserStatus", function () {
       expect(response2.body.message).to.equal("User Status updated successfully.");
       expect(response2.body.data).to.have.own.property("futureStatus");
       expect(response2.body.data.futureStatus.state).to.equal("OOO");
-      expect(response2.body.data.futureStatus.from).to.equal(fromDate); // 24th Nov 2022
-      expect(response2.body.data.futureStatus.until).to.equal(untilDate); // 28th Nov 2022
+      expect(response2.body.data.futureStatus.from).to.equal(fromDateInUTC); // 24th Nov 2022
+      expect(response2.body.data.futureStatus.until).to.equal(untilDateInUTC); // 28th Nov 2022
 
       // Changing OOO status again from 1st Dec 2022 to 5th Dec 2022
       fromDate = new Date(2022, 11, 1).getTime();
       untilDate = new Date(2022, 11, 5).getTime();
+      fromDateInUTC = convertTimestampToUTCStartOrEndOfDay(fromDate, false);
+      untilDateInUTC = convertTimestampToUTCStartOrEndOfDay(untilDate, true);
       const response3 = await chai
         .request(app)
         .patch(`/users/status/self`)
@@ -508,8 +515,8 @@ describe("UserStatus", function () {
       expect(response3.body.message).to.equal("User Status updated successfully.");
       expect(response3.body.data).to.have.own.property("futureStatus");
       expect(response3.body.data.futureStatus.state).to.equal("OOO");
-      expect(response3.body.data.futureStatus.from).to.equal(fromDate); // 1st Dec 2022
-      expect(response3.body.data.futureStatus.until).to.equal(untilDate); // 5th Dec 2022
+      expect(response3.body.data.futureStatus.from).to.equal(fromDateInUTC); // 1st Dec 2022
+      expect(response3.body.data.futureStatus.until).to.equal(untilDateInUTC); // 5th Dec 2022
 
       // Checking the current status
       const response4 = await chai.request(app).get(`/users/status/self`).set("Cookie", `${cookieName}=${testUserJwt}`);
@@ -520,14 +527,16 @@ describe("UserStatus", function () {
       expect(response4.body.data.currentStatus.state).to.equal("ACTIVE");
       expect(response4.body.data).to.have.property("futureStatus");
       expect(response4.body.data.futureStatus.state).to.equal("OOO");
-      expect(response3.body.data.futureStatus.from).to.equal(fromDate); // 1st Dec 2022
-      expect(response3.body.data.futureStatus.until).to.equal(untilDate); // 5th Dec 2022
+      expect(response3.body.data.futureStatus.from).to.equal(fromDateInUTC); // 1st Dec 2022
+      expect(response3.body.data.futureStatus.until).to.equal(untilDateInUTC); // 5th Dec 2022
     });
 
     it("should clear future OOO Status if current Status is marked as OOO", async function () {
       // Initially Marking OOO Status from 24th Nov 2022 to 28th Nov 2022.
       let fromDate = new Date(2022, 10, 24).getTime(); // 24th Nov 2022
       let untilDate = new Date(2022, 10, 28).getTime(); // 28th Nov 2022
+      let fromDateInUTC = convertTimestampToUTCStartOrEndOfDay(fromDate, false);
+      let untilDateInUTC = convertTimestampToUTCStartOrEndOfDay(untilDate, true);
       const response1 = await chai
         .request(app)
         .patch(`/users/status/self`)
@@ -537,12 +546,14 @@ describe("UserStatus", function () {
       expect(response1.body.message).to.equal("User Status created successfully.");
       expect(response1.body.data).to.have.own.property("futureStatus");
       expect(response1.body.data.futureStatus.state).to.equal("OOO");
-      expect(response1.body.data.futureStatus.from).to.equal(fromDate); // 24th Nov 2022
-      expect(response1.body.data.futureStatus.until).to.equal(untilDate); // 28th Nov 2022
+      expect(response1.body.data.futureStatus.from).to.equal(fromDateInUTC); // 24th Nov 2022
+      expect(response1.body.data.futureStatus.until).to.equal(untilDateInUTC); // 28th Nov 2022
 
       // Changing OOO status from today
-      fromDate = new Date(2022, 10, 12).getTime(); // 17th Nov 2022
-      untilDate = new Date(2022, 10, 17).getTime(); // 17th Nov 2022
+      fromDate = new Date(2022, 10, 12, 12, 0, 0).getTime(); // 17th Nov 2022
+      untilDate = new Date(2022, 10, 17, 12, 0, 0).getTime(); // 17th Nov 2022
+      fromDateInUTC = convertTimestampToUTCStartOrEndOfDay(fromDate, false);
+      untilDateInUTC = convertTimestampToUTCStartOrEndOfDay(untilDate, true);
       const response2 = await chai
         .request(app)
         .patch(`/users/status/self`)
@@ -552,8 +563,8 @@ describe("UserStatus", function () {
       expect(response2.body.message).to.equal("User Status updated successfully.");
       expect(response2.body.data).to.have.own.property("currentStatus");
       expect(response2.body.data.currentStatus.state).to.equal("OOO");
-      expect(response2.body.data.currentStatus.from).to.equal(fromDate); // 12 Nov 2022
-      expect(response2.body.data.currentStatus.until).to.equal(untilDate); // 17 Nov 2022
+      expect(response2.body.data.currentStatus.from).to.equal(fromDateInUTC); // 12 Nov 2022
+      expect(response2.body.data.currentStatus.until).to.equal(untilDateInUTC); // 17 Nov 2022
       expect(response2.body.data.futureStatus.state).to.equal(undefined);
     });
   });

--- a/test/integration/userStatus.test.js
+++ b/test/integration/userStatus.test.js
@@ -23,7 +23,7 @@ const { updateUserStatus } = require("../../models/userStatus");
 const { userState } = require("../../constants/userStatus");
 const cookieName = config.get("userToken.cookieName");
 const userStatusModel = require("../../models/userStatus");
-const { convertTimestampToUTCStartOrEndOfDay } = require("../../utils/userStatus");
+const { convertTimestampToUTCStartOrEndOfDay } = require("../../utils/time");
 
 chai.use(chaiHttp);
 

--- a/test/unit/utils/time.test.js
+++ b/test/unit/utils/time.test.js
@@ -63,4 +63,32 @@ describe("time", function () {
       }
     });
   });
+
+  describe("convertTimestampToUTCStartOrEndOfDay", function () {
+    it("should convert a timestamp to UTC 00:00:00 when isEndOfDay is false", function () {
+      const timestamp = 1696439365987; // Wed Oct 04 2023 17:09:25 UTC
+      const isEndOfDay = false;
+      const result = timeUtils.convertTimestampToUTCStartOrEndOfDay(timestamp, isEndOfDay);
+
+      // Expected result: 1696377600000 Wed Oct 04 2023 00:00:00 UTC
+      expect(result).to.equal(1696377600000);
+    });
+
+    it("should convert a timestamp to UTC 23:59:59.999 when isEndOfDay is true", function () {
+      const timestamp = 1696439365987; // Wed Oct 04 2023 17:09:25 UTC
+      const isEndOfDay = true;
+      const result = timeUtils.convertTimestampToUTCStartOrEndOfDay(timestamp, isEndOfDay);
+
+      // Expected result: 1696463999999 Wed Oct 04 2023 23:59:59 UTC
+      expect(result).to.equal(1696463999999);
+    });
+
+    it("should should return null if timestamp is not a valid timestamp", function () {
+      const timestamp = "random text";
+      const isEndOfDay = true;
+      const result = timeUtils.convertTimestampToUTCStartOrEndOfDay(timestamp, isEndOfDay);
+
+      expect(result).to.equal(null);
+    });
+  });
 });

--- a/test/unit/utils/userStatus.test.js
+++ b/test/unit/utils/userStatus.test.js
@@ -121,7 +121,6 @@ describe("User Status Functions", function () {
       const isEndOfDay = true;
       const result = convertTimestampToUTCStartOrEndOfDay(timestamp, isEndOfDay);
 
-      // Expected result: 1696463999999 Wed Oct 04 2023 23:59:59 UTC
       expect(result).to.equal(null);
     });
   });

--- a/test/unit/utils/userStatus.test.js
+++ b/test/unit/utils/userStatus.test.js
@@ -1,6 +1,11 @@
 const chai = require("chai");
 const { expect } = chai;
-const { generateNewStatus, checkIfUserHasLiveTasks } = require("../../../utils/userStatus");
+const {
+  generateNewStatus,
+  checkIfUserHasLiveTasks,
+  convertTimestampToUTCStartOrEndOfDay,
+  convertTimestampsToUTC,
+} = require("../../../utils/userStatus");
 const { userState } = require("../../../constants/userStatus");
 
 describe("User Status Functions", function () {
@@ -89,6 +94,56 @@ describe("User Status Functions", function () {
         expect(error).to.be.instanceOf(Error);
         expect(error.message).to.equal(errorMessage);
       }
+    });
+  });
+
+  describe("convertTimestampToUTCStartOrEndOfDay", function () {
+    it("should convert a timestamp to UTC 00:00:00 when isEndOfDay is false", function () {
+      const timestamp = 1696439365987; // Wed Oct 04 2023 17:09:25 UTC
+      const isEndOfDay = false;
+      const result = convertTimestampToUTCStartOrEndOfDay(timestamp, isEndOfDay);
+
+      // Expected result: 1696377600000 Wed Oct 04 2023 00:00:00 UTC
+      expect(result).to.equal(1696377600000);
+    });
+
+    it("should convert a timestamp to UTC 23:59:59.999 when isEndOfDay is true", function () {
+      const timestamp = 1696439365987; // Wed Oct 04 2023 17:09:25 UTC
+      const isEndOfDay = true;
+      const result = convertTimestampToUTCStartOrEndOfDay(timestamp, isEndOfDay);
+
+      // Expected result: 1696463999999 Wed Oct 04 2023 23:59:59 UTC
+      expect(result).to.equal(1696463999999);
+    });
+  });
+
+  describe("convertTimestampsToUTC", function () {
+    it("should convert timestamps within the input object to UTC 00:00:00 (start of day) and UTC 23:59:59 (end of day)", function () {
+      const inputObject = {
+        currentStatus: {
+          from: 1696439365987, // Wed Oct 04 2023 17:09:25 UTC
+          until: 1697124600000, // Thu Oct 12, 2023, 15:30:00
+        },
+        futureStatus: {
+          from: 1696439365987, // Wed Oct 04 2023 17:09:25 UTC
+          until: "", // An empty string
+        },
+      };
+
+      // Expected output object with timestamps converted to UTC
+      const expectedOutput = {
+        currentStatus: {
+          from: 1696377600000, // October 4, 2023, 00:00:00 UTC
+          until: 1697155199999, // Thu Oct 12, 2023, 23:59:59 UTC
+        },
+        futureStatus: {
+          from: 1696377600000, // October 4, 2023, 00:00:00 UTC
+          until: "", // No conversion for an empty string
+        },
+      };
+
+      const result = convertTimestampsToUTC(inputObject);
+      expect(result).to.deep.equal(expectedOutput);
     });
   });
 });

--- a/test/unit/utils/userStatus.test.js
+++ b/test/unit/utils/userStatus.test.js
@@ -115,6 +115,15 @@ describe("User Status Functions", function () {
       // Expected result: 1696463999999 Wed Oct 04 2023 23:59:59 UTC
       expect(result).to.equal(1696463999999);
     });
+
+    it("should should return null if timestamp is not a valid timestamp", function () {
+      const timestamp = "random text";
+      const isEndOfDay = true;
+      const result = convertTimestampToUTCStartOrEndOfDay(timestamp, isEndOfDay);
+
+      // Expected result: 1696463999999 Wed Oct 04 2023 23:59:59 UTC
+      expect(result).to.equal(null);
+    });
   });
 
   describe("convertTimestampsToUTC", function () {

--- a/test/unit/utils/userStatus.test.js
+++ b/test/unit/utils/userStatus.test.js
@@ -1,12 +1,11 @@
 const chai = require("chai");
 const { expect } = chai;
-const {
-  generateNewStatus,
-  checkIfUserHasLiveTasks,
-  convertTimestampToUTCStartOrEndOfDay,
-  convertTimestampsToUTC,
-} = require("../../../utils/userStatus");
+const { generateNewStatus, checkIfUserHasLiveTasks, convertTimestampsToUTC } = require("../../../utils/userStatus");
 const { userState } = require("../../../constants/userStatus");
+const {
+  OutputFixtureForFnConvertTimestampsToUTC,
+  inputFixtureForFnConvertTimestampsToUTC,
+} = require("../../fixtures/userStatus/userStatus");
 
 describe("User Status Functions", function () {
   describe("generateNewStatus", function () {
@@ -97,61 +96,10 @@ describe("User Status Functions", function () {
     });
   });
 
-  describe("convertTimestampToUTCStartOrEndOfDay", function () {
-    it("should convert a timestamp to UTC 00:00:00 when isEndOfDay is false", function () {
-      const timestamp = 1696439365987; // Wed Oct 04 2023 17:09:25 UTC
-      const isEndOfDay = false;
-      const result = convertTimestampToUTCStartOrEndOfDay(timestamp, isEndOfDay);
-
-      // Expected result: 1696377600000 Wed Oct 04 2023 00:00:00 UTC
-      expect(result).to.equal(1696377600000);
-    });
-
-    it("should convert a timestamp to UTC 23:59:59.999 when isEndOfDay is true", function () {
-      const timestamp = 1696439365987; // Wed Oct 04 2023 17:09:25 UTC
-      const isEndOfDay = true;
-      const result = convertTimestampToUTCStartOrEndOfDay(timestamp, isEndOfDay);
-
-      // Expected result: 1696463999999 Wed Oct 04 2023 23:59:59 UTC
-      expect(result).to.equal(1696463999999);
-    });
-
-    it("should should return null if timestamp is not a valid timestamp", function () {
-      const timestamp = "random text";
-      const isEndOfDay = true;
-      const result = convertTimestampToUTCStartOrEndOfDay(timestamp, isEndOfDay);
-
-      expect(result).to.equal(null);
-    });
-  });
-
   describe("convertTimestampsToUTC", function () {
     it("should convert timestamps within the input object to UTC 00:00:00 (start of day) and UTC 23:59:59 (end of day)", function () {
-      const inputObject = {
-        currentStatus: {
-          from: 1696439365987, // Wed Oct 04 2023 17:09:25 UTC
-          until: 1697124600000, // Thu Oct 12, 2023, 15:30:00
-        },
-        futureStatus: {
-          from: 1696439365987, // Wed Oct 04 2023 17:09:25 UTC
-          until: "", // An empty string
-        },
-      };
-
-      // Expected output object with timestamps converted to UTC
-      const expectedOutput = {
-        currentStatus: {
-          from: 1696377600000, // October 4, 2023, 00:00:00 UTC
-          until: 1697155199999, // Thu Oct 12, 2023, 23:59:59 UTC
-        },
-        futureStatus: {
-          from: 1696377600000, // October 4, 2023, 00:00:00 UTC
-          until: "", // No conversion for an empty string
-        },
-      };
-
-      const result = convertTimestampsToUTC(inputObject);
-      expect(result).to.deep.equal(expectedOutput);
+      const result = convertTimestampsToUTC(inputFixtureForFnConvertTimestampsToUTC);
+      expect(result).to.deep.equal(OutputFixtureForFnConvertTimestampsToUTC);
     });
   });
 });

--- a/utils/time.js
+++ b/utils/time.js
@@ -55,10 +55,31 @@ const getBeforeHourTime = (timestamp, hours = 0) => {
   return currentTime;
 };
 
+/**
+ * Converts a timestamp to either the start or end of a day in UTC time.
+ *
+ * @param {number} timestamp - The timestamp to be converted.
+ * @param {boolean} isEndOfDay - A flag indicating whether to convert to the end of the day (true) or the start of the day (false).
+ * @returns {number} The converted timestamp.
+ */
+const convertTimestampToUTCStartOrEndOfDay = (timestamp, isEndOfDay = false) => {
+  if (isNaN(timestamp)) {
+    return null;
+  }
+  const currTime = new Date(timestamp);
+  if (isEndOfDay) {
+    currTime.setUTCHours(23, 59, 59, 999);
+  } else {
+    currTime.setUTCHours(0, 0, 0, 0);
+  }
+  return currTime.getTime();
+};
+
 module.exports = {
   convertDaysToMilliseconds,
   convertHoursToMilliseconds,
   convertMinutesToMilliseconds,
   getTimeInSecondAfter,
   getBeforeHourTime,
+  convertTimestampToUTCStartOrEndOfDay,
 };

--- a/utils/userStatus.js
+++ b/utils/userStatus.js
@@ -1,5 +1,6 @@
 const { NotFound } = require("http-errors");
 const { userState } = require("../constants/userStatus");
+const { convertTimestampToUTCStartOrEndOfDay } = require("./time");
 
 /* returns the User Id based on the route path
  *  @param req {Object} : Express request object
@@ -303,26 +304,6 @@ const getNextDayTimeStamp = (timeStamp) => {
 };
 
 /**
- * Converts a timestamp to either the start or end of a day in UTC time.
- *
- * @param {number} timestamp - The timestamp to be converted.
- * @param {boolean} isEndOfDay - A flag indicating whether to convert to the end of the day (true) or the start of the day (false).
- * @returns {number} The converted timestamp.
- */
-const convertTimestampToUTCStartOrEndOfDay = (timestamp, isEndOfDay) => {
-  if (isNaN(timestamp)) {
-    return null;
-  }
-  const currTime = new Date(timestamp);
-  if (isEndOfDay) {
-    currTime.setUTCHours(23, 59, 59, 999);
-  } else {
-    currTime.setUTCHours(0, 0, 0, 0);
-  }
-  return currTime.getTime();
-};
-
-/**
  * Converts timestamps within an input object to either UTC 00:00:00 (start of day)
  * or UTC 23:59:59 (end of day) based on specified flags.
  *
@@ -365,6 +346,5 @@ module.exports = {
   generateErrorResponse,
   generateNewStatus,
   getNextDayTimeStamp,
-  convertTimestampToUTCStartOrEndOfDay,
   convertTimestampsToUTC,
 };

--- a/utils/userStatus.js
+++ b/utils/userStatus.js
@@ -310,6 +310,9 @@ const getNextDayTimeStamp = (timeStamp) => {
  * @returns {number} The converted timestamp.
  */
 const convertTimestampToUTCStartOrEndOfDay = (timestamp, isEndOfDay) => {
+  if (isNaN(timestamp)) {
+    return null;
+  }
   const currTime = new Date(timestamp);
   if (isEndOfDay) {
     currTime.setUTCHours(23, 59, 59, 999);

--- a/utils/userStatus.js
+++ b/utils/userStatus.js
@@ -22,7 +22,7 @@ const getUserIdBasedOnRoute = (req) => {
 const getTomorrowTimeStamp = () => {
   const today = new Date();
   today.setDate(today.getDate() + 1);
-  today.setHours(0, 0, 0, 0);
+  today.setUTCHours(0, 0, 0, 0);
   return today.getTime();
 };
 
@@ -302,6 +302,52 @@ const getNextDayTimeStamp = (timeStamp) => {
   return nextDateDateTime.getTime();
 };
 
+/**
+ * Converts a timestamp to either the start or end of a day in UTC time.
+ *
+ * @param {number} timestamp - The timestamp to be converted.
+ * @param {boolean} isEndOfDay - A flag indicating whether to convert to the end of the day (true) or the start of the day (false).
+ * @returns {number} The converted timestamp.
+ */
+const convertTimestampToUTCStartOrEndOfDay = (timestamp, isEndOfDay) => {
+  const currTime = new Date(timestamp);
+  if (isEndOfDay) {
+    currTime.setUTCHours(23, 59, 59, 999);
+  } else {
+    currTime.setUTCHours(0, 0, 0, 0);
+  }
+  return currTime.getTime();
+};
+
+/**
+ * Converts timestamps within an input object to either UTC 00:00:00 (start of day)
+ * or UTC 23:59:59 (end of day) based on specified flags.
+ *
+ * @param {Object} obj - The input object containing 'currentStatus' and 'futureStatus' keys.
+ * @returns {Object} The modified input object with timestamps converted to UTC time.
+ */
+const convertTimestampsToUTC = (obj) => {
+  const statusKeys = ["currentStatus", "futureStatus"];
+
+  for (const key of statusKeys) {
+    if (obj[key]) {
+      const { from, until } = obj[key];
+      const fromType = typeof from;
+      const untilType = typeof until;
+
+      if ((fromType === "string" || fromType === "number") && String(from).trim() !== "") {
+        obj[key].from = convertTimestampToUTCStartOrEndOfDay(from, false);
+      }
+
+      if ((untilType === "string" || untilType === "number") && String(until).trim() !== "") {
+        obj[key].until = convertTimestampToUTCStartOrEndOfDay(until, true);
+      }
+    }
+  }
+
+  return obj;
+};
+
 module.exports = {
   getUserIdBasedOnRoute,
   getTomorrowTimeStamp,
@@ -316,4 +362,6 @@ module.exports = {
   generateErrorResponse,
   generateNewStatus,
   getNextDayTimeStamp,
+  convertTimestampToUTCStartOrEndOfDay,
+  convertTimestampsToUTC,
 };


### PR DESCRIPTION
Issue Ticket Number:-
- #1579 

Backend changes
- [x] Yes
- [ ] No

Frontend Changes
- [ ] Yes
- [x] No

Database changes
- [ ] Yes 
- [x] No

Breaking changes (If your feature is breaking/missing something please mention pending tickets)
- [ ] Yes
- [x] No

### Deployment notes
None

### Description
Currently, when a user selects OOO from website-my, the timestamp for the chosen date is stored as 00:00:00 UTC. However, a problem arises when the user chooses OOO for just one day, as both the from and until timestamps are set to 00:00:00 UTC, resulting in them being equal and causing a OOO duration of 0 milliseconds. To address this issue, the from and until timestamps for a single-day OOO should be set to 00:00:00 UTC and 23:50:59 UTC, respectively, to avoid conflicts when updating the user's Discord nickname.

### Testing Stats:

Unit Tests :

models/userStatus.js

![image](https://github.com/Real-Dev-Squad/website-backend/assets/97341921/4a508d88-b25f-431e-8dd9-890fe8e87397)

utils/userStatus.js
![image](https://github.com/Real-Dev-Squad/website-backend/assets/97341921/370e2781-822b-4979-b0f1-ef15b29e623a)

Integration Tests:

![image](https://github.com/Real-Dev-Squad/website-backend/assets/97341921/b46060d5-46c1-4749-9ff5-3b5f82ab64c9)






