### PR TITLE
Bug / Reset future status when canceling OOO

### DIFF
--- a/models/userStatus.js
+++ b/models/userStatus.js
@@ -659,6 +659,9 @@ const cancelOooStatus = async (userId) => {
     }
     const updatedStatus = generateNewStatus(isActive);
     const newStatusData = { ...docData, ...updatedStatus };
+    if (futureStatus?.state) {
+      newStatusData.futureStatus = {};
+    }
     await userStatusModel.doc(docId).update(newStatusData);
     if (!isActive) {
       await addGroupIdleRoleToDiscordUser(userId);

--- a/test/fixtures/userStatus/userStatus.js
+++ b/test/fixtures/userStatus/userStatus.js
@@ -207,6 +207,17 @@ const OutputFixtureForFnConvertTimestampsToUTC = {
   },
 };
 
+const generateDefaultFutureStatus = (state, from, until) => {
+  const futureStatusData = {
+    state,
+    from,
+    until,
+    message: "",
+    updatedAt: new Date().getTime(),
+  };
+  return futureStatusData;
+};
+
 module.exports = {
   userStatusDataForNewUser,
   userStatusDataAfterSignup,
@@ -221,4 +232,5 @@ module.exports = {
   getStatusData,
   inputFixtureForFnConvertTimestampsToUTC,
   OutputFixtureForFnConvertTimestampsToUTC,
+  generateDefaultFutureStatus,
 };


### PR DESCRIPTION
Issue Ticket Number:-
- #1606

Backend changes
- [x] Yes
- [ ] No

Frontend Changes
- [ ] Yes
- [x] No

Database changes
- [ ] Yes 
- [x] No

Breaking changes (If your feature is breaking/missing something please mention pending tickets)
- [ ] Yes
- [x] No

### Deployment notes
None

### Description
When a user's status is set to "Out of Office" (OOO) and they decide to cancel their OOO status, the future status associated with the cancellation is not being reset as expected. Upon canceling the OOO, the future status should be automatically reset.

### Testing Stats:

Unit Tests :

`models/userStatus.js`

![image](https://github.com/Real-Dev-Squad/website-backend/assets/97341921/8d8d87a2-9d69-4a40-81c5-f2c489f480e8)








