### PR TITLE
Changes to support task assignment requests model in GET /taskRequests

### DIFF
--- a/controllers/tasksRequests.js
+++ b/controllers/tasksRequests.js
@@ -4,7 +4,8 @@ const tasksModel = require("../models/tasks.js");
 
 const fetchTaskRequests = async (_, res) => {
   try {
-    const data = await taskRequestsModel.fetchTaskRequests();
+    const { dev } = _.query;
+    const data = await taskRequestsModel.fetchTaskRequests(dev === "true");
 
     if (data.length > 0) {
       return res.status(200).json({

--- a/test/fixtures/task-requests/task-requests.js
+++ b/test/fixtures/task-requests/task-requests.js
@@ -57,7 +57,13 @@ const existingTaskRequest = {
   lastModifiedBy: "testUser",
   lastModifiedAt: 1697452229369,
 };
+const existingOldTaskRequest = {
+  requestors: ["user123"],
+  status: "PENDING",
+  taskId: "task123",
+};
 module.exports = {
+  existingOldTaskRequest,
   taskRequestData,
   existingTaskRequest,
   validAssignmentRequest,

--- a/test/unit/models/taskRequests.js
+++ b/test/unit/models/taskRequests.js
@@ -1,6 +1,7 @@
 const chai = require("chai");
 const sinon = require("sinon");
 const { expect } = chai;
+const { fetchTaskRequests } = require("./../../../models/taskRequests");
 const mockData = require("../../fixtures/task-requests/task-requests");
 const firestore = require("../../../utils/firestore");
 const taskRequestsCollection = firestore.collection("taskRequests");
@@ -23,7 +24,7 @@ describe("Task requests", function () {
       const result = await fetchTaskRequests();
       expect(result).to.be.an("array");
     });
-    it("should fetch task requests with associated tasks and requestors", async function () {
+    it("should fetch task requests with associated tasks and requestors of only the old task request models when dev is false", async function () {
       const taskData = { taskData: { title: "hello" } };
       const userData = { username: "hello" };
       sinon.stub(tasksModel, "fetchTask").resolves(taskData);
@@ -34,7 +35,7 @@ describe("Task requests", function () {
       expect(fetchedTaskRequest.task).to.deep.equal(taskData.taskData);
       expect(fetchedTaskRequest.requestors[0]).to.deep.equal(userData);
     });
-    it("should fetch task requests in development mode with associated requestors only", async function () {
+    it("should fetch task requests in development mode with associated requestors of all task request models when dev is true", async function () {
       const taskData = { taskData: { title: "hello" } };
       const userData = { username: "hello" };
       sinon.stub(tasksModel, "fetchTask").resolves(taskData);

--- a/test/unit/models/taskRequests.js
+++ b/test/unit/models/taskRequests.js
@@ -1,0 +1,52 @@
+const chai = require("chai");
+const sinon = require("sinon");
+const { expect } = chai;
+const mockData = require("../../fixtures/task-requests/task-requests");
+const firestore = require("../../../utils/firestore");
+const taskRequestsCollection = firestore.collection("taskRequests");
+const cleanDb = require("../../utils/cleanDb");
+const userModel = require("../../../models/users");
+const tasksModel = require("../../../models/tasks");
+
+describe("Task requests", function () {
+  afterEach(async function () {
+    sinon.restore();
+    await cleanDb();
+  });
+
+  describe("fetchTaskRequests", function () {
+    beforeEach(async function () {
+      await taskRequestsCollection.add(mockData.existingTaskRequest);
+      await taskRequestsCollection.add(mockData.existingOldTaskRequest);
+    });
+    it("should fetch all task requests", async function () {
+      const result = await fetchTaskRequests();
+      expect(result).to.be.an("array");
+    });
+    it("should fetch task requests with associated tasks and requestors", async function () {
+      const taskData = { taskData: { title: "hello" } };
+      const userData = { username: "hello" };
+      sinon.stub(tasksModel, "fetchTask").resolves(taskData);
+      sinon.stub(userModel, "fetchUser").resolves(userData);
+      const result = await fetchTaskRequests();
+      expect(result.length).to.be.equal(1);
+      const fetchedTaskRequest = result[0];
+      expect(fetchedTaskRequest.task).to.deep.equal(taskData.taskData);
+      expect(fetchedTaskRequest.requestors[0]).to.deep.equal(userData);
+    });
+    it("should fetch task requests in development mode with associated requestors only", async function () {
+      const taskData = { taskData: { title: "hello" } };
+      const userData = { username: "hello" };
+      sinon.stub(tasksModel, "fetchTask").resolves(taskData);
+      sinon.stub(userModel, "fetchUser").resolves(userData);
+      const result = await fetchTaskRequests(true);
+      expect(result.length).to.be.equal(2);
+      const fetchedOldTaskRequest = result[0];
+      expect(fetchedOldTaskRequest.task).to.equal(taskData.taskData);
+      expect(fetchedOldTaskRequest.requestors[0]).to.deep.equal(userData);
+      const fetchedNewTaskRequest = result[1];
+      expect(fetchedNewTaskRequest.task).to.equal(undefined);
+      expect(fetchedNewTaskRequest.requestors[0]).to.deep.equal(userData);
+    });
+  });
+});


### PR DESCRIPTION
### Issue:
- https://github.com/Real-Dev-Squad/website-status/issues/920

## Description : 
- Previously the task request models had mandatory field of taskId. But with the new type of task requests we have added some more fields, one among them is request type which can have values [ASSIGNMENT,CREATION]. 
- In the type CREATION task id is not mandatory. CREATION is supposed to create the task when super user approves it.
- Since this API previously used to fetch task details based on the given taskId, In CREATION requests taskId would be undefined. 
- This PR adds checks to return only the old task requests when dev flag is false and the new ones with newly added fields when the dev flag is true. 

Note: 
This is just a stop gap solution until migration of all the old task request model is done.
After migration this route will be re-visited to add pagination and other optimisation. 
- https://github.com/Real-Dev-Squad/website-backend/issues/1588
- https://github.com/Real-Dev-Squad/website-backend/issues/1613

## API Response: 
<img width="646" alt="Screenshot 2023-10-18 at 11 16 56 PM" src="https://github.com/Real-Dev-Squad/website-backend/assets/98796547/ab6a8a7a-0a2b-48b5-9563-05ec01f91347">

<img width="609" alt="Screenshot 2023-10-18 at 11 17 09 PM" src="https://github.com/Real-Dev-Squad/website-backend/assets/98796547/2566b828-39b4-4031-876c-840fcbee6e95">


# Test Code coverage:
Only the function changed in the current PR has tests in all of taskRequest model functions
<img width="916" alt="Screenshot 2023-10-19 at 12 19 28 AM" src="https://github.com/Real-Dev-Squad/website-backend/assets/98796547/e2c695e9-7d5a-4526-a745-92b1cc851209">

