### PR TITLE
MIGRATION: routes from members to users

### DIFF
--- a/models/users.js
+++ b/models/users.js
@@ -858,6 +858,49 @@ const getNonNickNameSyncedUsers = async () => {
   }
 };
 
+/**
+ * changes the role of a new user to member
+ * @param userId { String }: User id of user to be modified
+ * @return { Object }: whether moveToMember was successful or not and whether user is already a member or not
+ */
+
+const moveUserToMembers = async (userId) => {
+  try {
+    const userDoc = await userModel.doc(userId).get();
+    const user = userDoc.data();
+    if (user?.roles?.member) return { isAlreadyMember: true, movedToMember: false };
+    const roles = user.roles ? { ...user.roles, member: true } : { member: true };
+    await userModel.doc(userId).update({
+      roles,
+    });
+    return { isAlreadyMember: false, movedToMember: true };
+  } catch (err) {
+    logger.error("Error updating user", err);
+    throw err;
+  }
+};
+
+/**
+ * changes the role of a user to archived
+ * @param userId { String }: User id of user to be modified
+ * @return { Object }: whether moveToMember was successful or not and whether user is already a member or not
+ */
+
+const addArchiveRoleToUser = async (userId) => {
+  try {
+    const userDoc = await userModel.doc(userId).get();
+    const user = userDoc.data();
+    if (user?.roles && user.roles[ROLES.ARCHIVED]) return { isArchived: true };
+    const roles = { ...user.roles, [ROLES.ARCHIVED]: true };
+    await userModel.doc(userId).update({
+      roles,
+    });
+    return { isArchived: false };
+  } catch (err) {
+    logger.error("Error updating user", err);
+    throw err;
+  }
+};
 module.exports = {
   addOrUpdate,
   fetchPaginatedUsers,
@@ -887,4 +930,6 @@ module.exports = {
   fetchUsersListForMultipleValues,
   fetchUserForKeyValue,
   getNonNickNameSyncedUsers,
+  moveUserToMembers,
+  addArchiveRoleToUser,
 };

--- a/routes/users.js
+++ b/routes/users.js
@@ -62,4 +62,6 @@ router.patch("/rejectDiff", authenticate, authorizeRoles([SUPERUSER]), users.rej
 router.patch("/nickname-synced-field", authenticate, authorizeRoles([SUPERUSER]), users.removeNicknameSyncedField);
 router.patch("/:userId", authenticate, authorizeRoles([SUPERUSER]), users.updateUser);
 router.get("/suggestedUsers/:skillId", authenticate, authorizeRoles([SUPERUSER]), users.getSuggestedUsers);
+router.patch("/moveToMembers/:username", authenticate, authorizeRoles([SUPERUSER]), users.moveToMembers);
+router.patch("/archive/:username", authenticate, authorizeRoles([SUPERUSER]), users.archiveUser);
 module.exports = router;


### PR DESCRIPTION
### Issue:
- [ ] https://github.com/Real-Dev-Squad/website-members/issues/547


### Description:
As a part of deprecating the routes of `/members` with `/users`  two routes routes which are existing for members API should be created for the users API also for the functionalities, namely:
1. To make a user as member.
2. To archive a user


### Design Doc:
https://docs.google.com/document/d/1xvllP-qyZBAHFzp5Oh-7d-bTh_JHX7Ps_KsOTUSkPYE/edit?usp=sharing

### Changes:

- Created two new routes `/moveToMembers/:username` and `/archive/:username` with controllers and modals
- Added tests for the functionality of the above mentioned routes.

### Anything you would like to inform the reviewer about:
This PR is one of the multiple other PR's which are addressing the above mentioned issue.

### Dev Tested:
- [x] Yes

### Images/video of the change:
Promoting a user as Member:
![image](https://github.com/Real-Dev-Squad/website-backend/assets/69259490/f3e0510d-c47a-42da-bd56-2e0f907dd01e)

If the user is already a Member:
![image](https://github.com/Real-Dev-Squad/website-backend/assets/69259490/a0056c1f-4b67-435c-997c-7caf3cb23d65)

Archiving a user:
![image](https://github.com/Real-Dev-Squad/website-backend/assets/69259490/6706c1aa-2540-49c2-9e38-111e43e51b32)

If user is already archived:
![image](https://github.com/Real-Dev-Squad/website-backend/assets/69259490/00f3c7c1-6cf5-4ae9-bdf2-f9fbd2b27079)


### Test Coverage Stats:
![image](https://github.com/Real-Dev-Squad/website-backend/assets/69259490/ba70a9a9-2362-4623-b527-fb11709eb8c4)

website-backend/models
![image](https://github.com/Real-Dev-Squad/website-backend/assets/69259490/fd642f98-93d3-4b59-97d7-64f27b3b20a8)

website-backend/controllers
![image](https://github.com/Real-Dev-Squad/website-backend/assets/69259490/05eb0ceb-3b31-4aee-a63c-8a2f70e24484)



### Follow-up Issues (if any):
None
