### PR TITLE
Discard user to udpate their roles

### DIFF
--- a/controllers/users.js
+++ b/controllers/users.js
@@ -363,6 +363,8 @@ const updateSelf = async (req, res) => {
   try {
     const { id: userId } = req.userData;
     const { user } = await dataAccess.retrieveUsers({ id: userId });
+    // eslint-disable-next-line no-console
+    console.log("usrt", req.userdata);
 
     if (req.body.username) {
       if (!user.incompleteUserDetails) {
@@ -372,7 +374,7 @@ const updateSelf = async (req, res) => {
     }
 
     if (req.body.roles) {
-      if (user && user.roles.in_discord) {
+      if (user && user.roles.in_discord && !user.roles.developer) {
         return res.boom.forbidden("Cannot update roles");
       }
     }

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -363,8 +363,6 @@ const updateSelf = async (req, res) => {
   try {
     const { id: userId } = req.userData;
     const { user } = await dataAccess.retrieveUsers({ id: userId });
-    // eslint-disable-next-line no-console
-    console.log("usrt", req.userdata);
 
     if (req.body.username) {
       if (!user.incompleteUserDetails) {

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -372,7 +372,7 @@ const updateSelf = async (req, res) => {
     }
 
     if (req.body.roles) {
-      if (user && user.roles.in_discord && user.roles.developer) {
+      if ((user && user.roles.in_discord) || (user && user.roles.in_discord)) {
         return res.boom.forbidden("Cannot update roles");
       }
     }

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -372,7 +372,7 @@ const updateSelf = async (req, res) => {
     }
 
     if (req.body.roles) {
-      if ((user && user.roles.in_discord) || (user && user.roles.in_discord)) {
+      if (user && (user.roles.in_discord || user.roles.developer)) {
         return res.boom.forbidden("Cannot update roles");
       }
     }

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -372,7 +372,7 @@ const updateSelf = async (req, res) => {
     }
 
     if (req.body.roles) {
-      if (user && user.roles.in_discord && !user.roles.developer) {
+      if (user && user.roles.in_discord && user.roles.developer) {
         return res.boom.forbidden("Cannot update roles");
       }
     }

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -379,7 +379,7 @@ const updateSelf = async (req, res) => {
 
     const updatedUser = await userQuery.addOrUpdate(req.body, userId);
 
-    if (updatedUser.isNewUser) {
+    if (!updatedUser.isNewUser) {
       // Success criteria, user finished the sign-up process.
       userQuery.initializeUser(userId);
       return res.status(204).send();

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -362,18 +362,25 @@ const getSelfDetails = async (req, res) => {
 const updateSelf = async (req, res) => {
   try {
     const { id: userId } = req.userData;
+    const { user } = await dataAccess.retrieveUsers({ id: userId });
+
     if (req.body.username) {
-      const { user } = await dataAccess.retrieveUsers({ id: userId });
       if (!user.incompleteUserDetails) {
         return res.boom.forbidden("Cannot update username again");
       }
       await userQuery.setIncompleteUserDetails(userId);
     }
 
-    const user = await userQuery.addOrUpdate(req.body, userId);
+    if (req.body.roles) {
+      if (user && user.roles.in_discord) {
+        return res.boom.forbidden("Cannot update roles");
+      }
+    }
 
-    if (!user.isNewUser) {
-      // Success criteria, user finished the sign up process.
+    const updatedUser = await userQuery.addOrUpdate(req.body, userId);
+
+    if (updatedUser.isNewUser) {
+      // Success criteria, user finished the sign-up process.
       userQuery.initializeUser(userId);
       return res.status(204).send();
     }

--- a/middlewares/validators/user.js
+++ b/middlewares/validators/user.js
@@ -52,8 +52,6 @@ const updateUser = async (req, res, next) => {
         .optional(),
       discordId: joi.string().optional(),
       roles: joi.object().keys({
-        member: joi.boolean().optional(),
-        developer: joi.boolean().optional(),
         designer: joi.boolean().optional(),
         maven: joi.boolean().optional(),
         productmanager: joi.boolean().optional(),

--- a/middlewares/validators/user.js
+++ b/middlewares/validators/user.js
@@ -52,6 +52,7 @@ const updateUser = async (req, res, next) => {
         .optional(),
       discordId: joi.string().optional(),
       roles: joi.object().keys({
+        member: joi.boolean().optional(),
         developer: joi.boolean().optional(),
         designer: joi.boolean().optional(),
         maven: joi.boolean().optional(),

--- a/middlewares/validators/user.js
+++ b/middlewares/validators/user.js
@@ -52,8 +52,6 @@ const updateUser = async (req, res, next) => {
         .optional(),
       discordId: joi.string().optional(),
       roles: joi.object().keys({
-        archived: joi.boolean().required(),
-        in_discord: joi.boolean().required(),
         developer: joi.boolean().optional(),
         designer: joi.boolean().optional(),
         maven: joi.boolean().optional(),

--- a/test/fixtures/user/user.js
+++ b/test/fixtures/user/user.js
@@ -399,5 +399,18 @@ module.exports = () => {
       updated_at: Date.now(),
       created_at: Date.now(),
     },
+    {
+      id: "11",
+      first_name: "vinit",
+      last_name: "khandal",
+      github_id: "vinit717",
+      github_display_name: "vinit717",
+      roles: {
+        in_discord: false,
+      },
+      incompleteUserDetails: false,
+      updated_at: Date.now(),
+      created_at: Date.now(),
+    },
   ];
 };

--- a/test/fixtures/user/user.js
+++ b/test/fixtures/user/user.js
@@ -400,7 +400,6 @@ module.exports = () => {
       created_at: Date.now(),
     },
     {
-      id: "11",
       first_name: "vinit",
       last_name: "khandal",
       github_id: "vinit717",

--- a/test/integration/users.test.js
+++ b/test/integration/users.test.js
@@ -122,7 +122,7 @@ describe("Users", function () {
         });
     });
 
-    it("Should allow updating user role when in_discord is not present", function (done) {
+    it("Should allow updating user role when in_discord is not present and not is developer", function (done) {
       addUser(newUser).then((newUserId) => {
         const nonSuperUserJwt = authService.generateAuthToken({ userId: newUserId });
         chai

--- a/test/integration/users.test.js
+++ b/test/integration/users.test.js
@@ -121,7 +121,7 @@ describe("Users", function () {
         });
     });
 
-    it("Should update the user roles", function (done) {
+    it("Should not update the user roles", function (done) {
       chai
         .request(app)
         .patch("/users/self")
@@ -129,6 +129,7 @@ describe("Users", function () {
         .send({
           roles: {
             developer: true,
+            maven: true,
           },
         })
         .end((err, res) => {
@@ -136,7 +137,7 @@ describe("Users", function () {
             return done(err);
           }
 
-          expect(res).to.have.status(204);
+          expect(res).to.have.status(403);
 
           return done();
         });

--- a/test/integration/users.test.js
+++ b/test/integration/users.test.js
@@ -122,8 +122,7 @@ describe("Users", function () {
         });
     });
 
-    // eslint-disable-next-line mocha/no-exclusive-tests
-    it.only("Should allow updating user role when in_discord is not present", function (done) {
+    it("Should allow updating user role when in_discord is not present", function (done) {
       addUser(newUser).then((newUserId) => {
         const nonSuperUserJwt = authService.generateAuthToken({ userId: newUserId });
         chai

--- a/test/integration/users.test.js
+++ b/test/integration/users.test.js
@@ -122,7 +122,8 @@ describe("Users", function () {
         });
     });
 
-    it("Should allow updating user role when in_discord is not present", function (done) {
+    // eslint-disable-next-line mocha/no-exclusive-tests
+    it.only("Should allow updating user role when in_discord is not present", function (done) {
       addUser(newUser).then((newUserId) => {
         const nonSuperUserJwt = authService.generateAuthToken({ userId: newUserId });
         chai

--- a/test/integration/users.test.js
+++ b/test/integration/users.test.js
@@ -122,13 +122,13 @@ describe("Users", function () {
         });
     });
 
-    it("Should allow updating user role when in_discord is not present and not is developer", function (done) {
+    it("Should allow updating user role when in_discord is not present and  is not developer", function (done) {
       addUser(newUser).then((newUserId) => {
-        const nonSuperUserJwt = authService.generateAuthToken({ userId: newUserId });
+        const newUserJwt = authService.generateAuthToken({ userId: newUserId });
         chai
           .request(app)
           .patch(`/users/self`)
-          .set("cookie", `${cookieName}=${nonSuperUserJwt}`)
+          .set("cookie", `${cookieName}=${newUserJwt}`)
           .send({
             roles: {
               maven: true,

--- a/test/integration/users.test.js
+++ b/test/integration/users.test.js
@@ -32,6 +32,7 @@ const userAlreadyNotMember = userData[13];
 const userAlreadyArchived = userData[5];
 const userAlreadyUnArchived = userData[4];
 const nonSuperUser = userData[0];
+const newUser = userData[18];
 
 const cookieName = config.get("userToken.cookieName");
 const { userPhotoVerificationData } = require("../fixtures/user/photo-verification");
@@ -121,6 +122,28 @@ describe("Users", function () {
         });
     });
 
+    it("Should allow updating user role when in_discord is not present", function (done) {
+      addUser(newUser).then((newUserId) => {
+        const nonSuperUserJwt = authService.generateAuthToken({ userId: newUserId });
+        chai
+          .request(app)
+          .patch(`/users/self`)
+          .set("cookie", `${cookieName}=${nonSuperUserJwt}`)
+          .send({
+            roles: {
+              maven: true,
+            },
+          })
+          .end((err, res) => {
+            if (err) {
+              return done(err);
+            }
+
+            expect(res).to.have.status(204);
+            return done();
+          });
+      });
+    });
     it("Should not update the user roles", function (done) {
       chai
         .request(app)

--- a/test/integration/users.test.js
+++ b/test/integration/users.test.js
@@ -144,7 +144,7 @@ describe("Users", function () {
           });
       });
     });
-    it("Should not update the user roles", function (done) {
+    it("Should not update the user roles when user has in_discord and developer true", function (done) {
       chai
         .request(app)
         .patch("/users/self")

--- a/test/integration/users.test.js
+++ b/test/integration/users.test.js
@@ -128,7 +128,6 @@ describe("Users", function () {
         .set("cookie", `${cookieName}=${jwt}`)
         .send({
           roles: {
-            developer: true,
             maven: true,
           },
         })

--- a/test/integration/users.test.js
+++ b/test/integration/users.test.js
@@ -128,8 +128,6 @@ describe("Users", function () {
         .set("cookie", `${cookieName}=${jwt}`)
         .send({
           roles: {
-            archived: false,
-            in_discord: false,
             developer: true,
           },
         })

--- a/test/unit/middlewares/user-validator.test.js
+++ b/test/unit/middlewares/user-validator.test.js
@@ -103,8 +103,8 @@ describe("Middleware | Validators | User", function () {
       const req = {
         body: {
           roles: {
-            archived: false,
-            in_discord: false,
+            // archived: false,
+            // in_discord: false,
             developer: true,
           },
         },

--- a/test/unit/middlewares/user-validator.test.js
+++ b/test/unit/middlewares/user-validator.test.js
@@ -103,9 +103,7 @@ describe("Middleware | Validators | User", function () {
       const req = {
         body: {
           roles: {
-            // archived: false,
-            // in_discord: false,
-            developer: true,
+            maven: true,
           },
         },
       };

--- a/test/unit/services/users.test.js
+++ b/test/unit/services/users.test.js
@@ -74,7 +74,7 @@ describe("Users services", function () {
       expect(res).to.deep.equal({
         message: "Firebase batch operation failed",
         totalUsersArchived: 0,
-        totalOperationsFailed: 18,
+        totalOperationsFailed: 19,
         updatedUserDetails: [],
         failedUserDetails: userDetails,
       });

--- a/test/unit/services/users.test.js
+++ b/test/unit/services/users.test.js
@@ -53,7 +53,7 @@ describe("Users services", function () {
 
       expect(res).to.deep.equal({
         message: "Successfully completed batch updates",
-        totalUsersArchived: 18,
+        totalUsersArchived: 19,
         totalOperationsFailed: 0,
         updatedUserDetails: userDetails,
         failedUserDetails: [],


### PR DESCRIPTION
### Developer Name: vinit 

### Purpose
To prevent a user from updating their roles as it may cause a security concern and allow only those user who want to join as maven and have not joined Discord yet

### PR Number(s): 1624

### Backend Changes
- [x] Yes
- [ ] No

### Is Under Feature Flag
- [ ] Yes
- [x] No

### Database changes: 
- [ ] Yes
- [x] No

### Breaking changes (If your feature is breaking/missing something please mention pending tickets): 
- [ ] Yes
- [x] No

### Deployment notes:
NA

### Tested in local
- [x] Yes
- [ ] No

**When in_discord is false**
![image](https://github.com/Real-Dev-Squad/website-backend/assets/111434418/7834cba7-a734-4ff0-8ab9-17dc3b86a168)

**When in_discord is true** 
![image](https://github.com/Real-Dev-Squad/website-backend/assets/111434418/00c09836-b96d-4faa-a3b2-01bff7c84bb3)


**Tests Stats:**
![image](https://github.com/Real-Dev-Squad/website-backend/assets/111434418/c087aca2-a614-4959-93ef-29d08bbe76d7)
