### PR TITLE
Chore : Added timestamp of logs in self ER request

### DIFF
--- a/controllers/extensionRequests.js
+++ b/controllers/extensionRequests.js
@@ -249,6 +249,7 @@ const getSelfExtensionRequests = async (req, res) => {
                 const superUserId = logs[0].meta.userId;
                 const name = await getFullName(superUserId);
                 latestExtensionRequest.reviewedBy = `${name?.first_name} ${name?.last_name}`;
+                latestExtensionRequest.reviewedAt = logs[0].timestamp._seconds;
               }
             }
             allExtensionRequests = [latestExtensionRequest];


### PR DESCRIPTION
### Developer Name: Joy Gupta

### Purpose
Reviewed log should show the timestamp when the request was reviewed and not when it was created
### PR Number(s): 1635

### Backend Changes
- [x] Yes
- [ ] No

### Is Under Feature Flag
- [x] Yes
- [ ] No

### Database changes: 
- [ ] Yes
- [x] No

### Breaking changes (If your feature is breaking/missing something please mention pending tickets): 
- [ ] Yes
- [x] No

### Deployment notes:
NA

### Tested in local
- [x] Yes
- [ ] No

### List of PRs going in this Sync
- https://github.com/Real-Dev-Squad/website-my/pull/511

### QA Instructions, Screenshots, Recordings
<img width="1014" alt="Screenshot 2023-10-29 at 11 49 07" src="https://github.com/Real-Dev-Squad/website-backend/assets/56365512/5771f780-c52a-40a4-8c04-186fb2bdddd7">

### Working Proof
<img width="1416" alt="Screenshot 2023-10-29 at 11 54 41" src="https://github.com/Real-Dev-Squad/website-backend/assets/56365512/5bfa6cb2-75b9-412b-8404-f4317df120bd">
