### PR TITLE
Fix Issue: Update Specific Role Without Removing Others

### DIFF
--- a/models/users.js
+++ b/models/users.js
@@ -38,11 +38,14 @@ const addOrUpdate = async (userData, userId = null) => {
       const isNewUser = !user.data();
       // user exists update user
       if (user.data()) {
-        await userModel.doc(userId).set({
-          ...user.data(),
-          ...userData,
-          updated_at: Date.now(),
-        });
+        await userModel.doc(userId).set(
+          {
+            ...user.data(),
+            ...userData,
+            updated_at: Date.now(),
+          },
+          { merge: true }
+        );
       }
 
       return { isNewUser, userId };

--- a/test/integration/users.test.js
+++ b/test/integration/users.test.js
@@ -146,11 +146,7 @@ describe("Users", function () {
     });
 
     it("Should not remove old roles when updating user roles", async function () {
-      let newUserId;
-      await addUser(newUser).then((userId) => {
-        newUserId = userId;
-      });
-
+      const newUserId = await addUser(newUser);
       const newUserJwt = authService.generateAuthToken({ userId: newUserId });
 
       const getUserResponseBeforeUpdate = await chai


### PR DESCRIPTION
### Developer Name: vinit 

Issue: #1654

### Purpose
By adding new role data with the existing roles in the Firestore document then the previous roles got removed. This change will ensure that the update only affects the specified role without affecting other roles that may already be present.

### PR Number(s): 1653

### Backend Changes
- [x] Yes
- [ ] No

### Is Under Feature Flag
- [ ] Yes
- [x] No

### Database changes: 
- [ ] Yes
- [x] No

### Breaking changes (If your feature is breaking/missing something please mention pending tickets): 
- [ ] Yes
- [x] No

### Deployment notes:
NA

### Tested in local
- [ ] Yes
- [x] No

**Tests Stats**
![image](https://github.com/Real-Dev-Squad/website-backend/assets/111434418/e1b73e40-90c8-4697-ad11-ba2f8891fcb9)

