### PR TITLE
Migration script to add users count and also updates create task request for users count

### DIFF
--- a/constants/taskRequests.ts
+++ b/constants/taskRequests.ts
@@ -34,6 +34,7 @@ const TASK_REQUEST_SORT_VALUES = {
 const MIGRATION_TYPE = {
   ADD_NEW_FIELDS: "add-new-fields",
   REMOVE_OLD_FIELDS: "remove-redundant-fields",
+  ADD_COUNT_CREATED: "add-count-created-time"
 };
 
 module.exports = {

--- a/controllers/tasksRequests.js
+++ b/controllers/tasksRequests.js
@@ -228,6 +228,10 @@ const migrateTaskRequests = async (req, res) => {
         responseData = await taskRequestsModel.removeOldField();
         break;
       }
+      case MIGRATION_TYPE.ADD_COUNT_CREATED: {
+        responseData = await taskRequestsModel.addUsersCountAndCreatedAt();
+        break;
+      }
       default: {
         return res.boom.badRequest("Unknown action");
       }

--- a/models/taskRequests.js
+++ b/models/taskRequests.js
@@ -500,7 +500,7 @@ const addUsersCountAndCreatedAt = async () => {
       isDocumentModified = true;
     }
     if (!taskRequestData.createdAt) {
-      taskRequestData.createdAt = 0;
+      taskRequestData.createdAt = taskRequestsSnapshot.createTime.toMillis();
       isDocumentModified = true;
     }
 

--- a/models/taskRequests.js
+++ b/models/taskRequests.js
@@ -268,11 +268,14 @@ const createRequest = async (data, authenticatedUsername) => {
       if (!newTaskRequest.externalIssueUrl) delete newTaskRequest.externalIssueUrl;
       if (!newTaskRequest.taskId) delete newTaskRequest.taskId;
       if (!newTaskRequest.taskTitle) delete newTaskRequest.taskTitle;
-      const newTaskRequestRef = await taskRequestsCollection.add(newTaskRequest);
+
+      const newTaskRequestsDocRef = taskRequestsCollection.doc();
+      transaction.set(newTaskRequestsDocRef, newTaskRequest);
+
       return {
         isCreate: true,
         taskRequest: newTaskRequest,
-        id: newTaskRequestRef.id,
+        id: newTaskRequestsDocRef.id,
       };
     });
   } catch (err) {

--- a/test/integration/taskRequests.test.js
+++ b/test/integration/taskRequests.test.js
@@ -829,6 +829,21 @@ describe("Task Requests", function () {
       expect(res.body.documentsModified).to.be.equal(1);
       expect(res.body.totalDocuments).to.be.equal(2);
     });
+    it("should run the add Users count and created at script when the appropriate query param is passed", async function () {
+      const addsUsersCountCreatedStub = sinon
+        .stub(taskRequestsModel, "addUsersCountAndCreatedAt")
+        .resolves({ documentsModified: 1, totalDocuments: 2 });
+      const res = await chai
+        .request(app)
+        .post(url)
+        .set("cookie", `${cookieName}=${jwt}`)
+        .query({ action: MIGRATION_TYPE.ADD_COUNT_CREATED });
+      expect(res).to.have.status(200);
+      expect(res.body.message).to.equal("Task requests migration successful");
+      expect(addsUsersCountCreatedStub.calledOnce).to.be.equal(true);
+      expect(res.body.documentsModified).to.be.equal(1);
+      expect(res.body.totalDocuments).to.be.equal(2);
+    });
     it("should should handle any error thrown", async function () {
       sinon.stub(taskRequestsModel, "removeOldField").throws(new Error("Error message"));
       const res = await chai

--- a/test/unit/models/task-requests.test.js
+++ b/test/unit/models/task-requests.test.js
@@ -500,9 +500,10 @@ describe("Task requests | models", function () {
         const response = await addUsersCountAndCreatedAt();
         expect(response.totalDocuments).to.be.equal(1);
         expect(response.documentsModified).to.be.equal(1);
-        const taskRequestData = (await taskRequestsCollection.doc(taskRequestId1).get()).data();
+        const taskRequestSnapshot = await taskRequestsCollection.doc(taskRequestId1).get();
+        const taskRequestData = taskRequestSnapshot.data();
         expect(taskRequestData.usersCount).to.be.equal(1);
-        expect(taskRequestData.createdAt).to.be.equal(0);
+        expect(taskRequestData.createdAt).to.be.equal(taskRequestSnapshot.createTime.toMillis());
       });
       it("Should not update existing fields", async function () {
         const taskRequest = { ...mockData.existingTaskRequest };


### PR DESCRIPTION
Date: 20 November 2023
Developer Name: @Ajeyakrishna-k 

----

## Issue Ticket Number:- 
- #1588 

## Description: 
- Adds a models function which updates all the existing task requests documents to have usersCount(number of people requesting the same task) and createdAt. These fields are used for sorting. 
- Updates the existing create task requests models function to have usersCount.

## Docs: 
- https://github.com/Real-Dev-Squad/website-data-models/pull/55
- https://github.com/Real-Dev-Squad/website-api-contracts/pull/164
- https://github.com/Real-Dev-Squad/website-api-contracts/tree/main/task-requests

Is Under Feature Flag 
- [x] Yes
- [ ] No

Database changes
- [ ] Yes
- [x] No

Breaking changes (If your feature is breaking/missing something please mention pending tickets)
- [ ] Yes
- [x] No

Is Development Tested?

- [x] Yes
- [ ] No

### Add relevant Screenshot below ( e.g test coverage etc. )

<img width="1066" alt="Screenshot 2023-11-21 at 2 20 59 PM" src="https://github.com/Real-Dev-Squad/website-backend/assets/98796547/ea32e8a8-f207-441f-b023-cee4ee6b3360">


![Screenshot 2023-11-21 at 2 23 19 PM](https://github.com/Real-Dev-Squad/website-backend/assets/98796547/ceb553d5-6fa0-48e9-8ad1-879658a70411)

![Screenshot 2023-11-21 at 2 25 25 PM](https://github.com/Real-Dev-Squad/website-backend/assets/98796547/01be5b97-f98f-42fd-a4bf-39b4a06a4ea3)

