### PR TITLE
Add createdAt and updatedAt fields for task collection

### DIFF
--- a/controllers/tasks.js
+++ b/controllers/tasks.js
@@ -24,9 +24,12 @@ const addNewTask = async (req, res) => {
     const { id: createdBy } = req.userData;
     const dependsOn = req.body.dependsOn;
     let userStatusUpdate;
+    const timeStamp = Math.round(Date.now() / 1000);
     const body = {
       ...req.body,
       createdBy,
+      createdAt: timeStamp,
+      updatedAt: timeStamp,
     };
     delete body.dependsOn;
     const { taskId, taskDetails } = await tasks.updateTask(body);
@@ -270,7 +273,7 @@ const updateTask = async (req, res) => {
     if (!task.taskData) {
       return res.boom.notFound("Task not found");
     }
-    const requestData = { ...req.body };
+    const requestData = { ...req.body, updatedAt: Math.round(Date.now() / 1000) };
     if (requestData?.assignee) {
       const user = await dataAccess.retrieveUsers({ username: requestData.assignee });
       if (!user.userExists) {
@@ -310,6 +313,7 @@ const updateTask = async (req, res) => {
  */
 const updateTaskStatus = async (req, res, next) => {
   try {
+    req.body.updatedAt = Math.round(new Date().getTime() / 1000);
     let userStatusUpdate;
     const taskId = req.params.id;
     const { userStatusFlag } = req.query;

--- a/test/fixtures/tasks/tasks.js
+++ b/test/fixtures/tasks/tasks.js
@@ -14,6 +14,8 @@ module.exports = () => {
       type: "feature",
       assignee: "akshay",
       createdBy: "ankush",
+      createdAt: 1644753600,
+      updatedAt: 1644753600,
       status: "IN_PROGRESS",
       percentCompleted: 50,
       endsOn: 1647172800, // 13 march
@@ -25,6 +27,8 @@ module.exports = () => {
       type: "feature",
       assignee: "ankur",
       createdBy: "ankush",
+      createdAt: 1644753600,
+      updatedAt: 1644753600,
       status: "ASSIGNED",
       percentCompleted: 50,
       endsOn: 1647172800, // 13 march
@@ -36,6 +40,8 @@ module.exports = () => {
       type: "feature",
       assignee: "ankur",
       createdBy: "ankush",
+      createdAt: 1644753600,
+      updatedAt: 1644753600,
       status: "BLOCKED",
       percentCompleted: 50,
       endsOn: 1647172800,
@@ -51,6 +57,8 @@ module.exports = () => {
       percentCompleted: 50,
       endsOn: 1650032259,
       startedOn: 1644753600,
+      createdAt: 1644753600,
+      updatedAt: 1644753600,
     },
     {
       title: "Test task",
@@ -67,6 +75,8 @@ module.exports = () => {
       priority: "HIGH",
       isNoteworthy: true,
       assignee: false,
+      createdAt: 1644753600,
+      updatedAt: 1644753600,
     },
     {
       title: "Test task-dependency",
@@ -80,6 +90,8 @@ module.exports = () => {
       lossRate: { [DINERO]: 1 },
       isNoteworthy: true,
       assignee: false,
+      createdAt: 1644753600,
+      updatedAt: 1644753600,
     },
     {
       id: "P86Y1hVrS0zR5ZcVPwLZ",
@@ -102,6 +114,8 @@ module.exports = () => {
       status: "IN_PROGRESS",
       assigneeId: "WbceXEPcohuJ5IxHHecf",
       dependsOn: [],
+      createdAt: 1644753600,
+      updatedAt: 1644753600,
     },
     {
       id: "P86Y1fsvS0zR5ZcVPwLZ",
@@ -123,6 +137,8 @@ module.exports = () => {
       title: "Undefined status",
       assigneeId: "WbceXEPcdsuJ5IxHHecf",
       dependsOn: [],
+      createdAt: 1644753600,
+      updatedAt: 1644753600,
     },
   ];
 };

--- a/test/integration/tasks.test.js
+++ b/test/integration/tasks.test.js
@@ -111,10 +111,45 @@ describe("Tasks", function () {
           expect(res.body.message).to.equal("Task created successfully!");
           expect(res.body.task).to.be.a("object");
           expect(res.body.task.id).to.be.a("string");
+          expect(res.body.task.createdAt).to.be.a("number");
+          expect(res.body.task.updatedAt).to.be.a("number");
           expect(res.body.task.createdBy).to.equal(appOwner.username);
           expect(res.body.task.assignee).to.equal(appOwner.username);
           expect(res.body.task.participants).to.be.a("array");
           expect(res.body.task.dependsOn).to.be.a("array");
+          return done();
+        });
+    });
+    it("Should have same time for createdAt and updatedAt for new tasks", function (done) {
+      chai
+        .request(app)
+        .post("/tasks")
+        .set("cookie", `${cookieName}=${jwt}`)
+        .send({
+          title: "Test task - Create",
+          type: "feature",
+          endsOn: 123,
+          startedOn: 456,
+          status: "AVAILABLE",
+          percentCompleted: 10,
+          priority: "HIGH",
+          completionAward: { [DINERO]: 3, [NEELAM]: 300 },
+          lossRate: { [DINERO]: 1 },
+          assignee: appOwner.username,
+          participants: [],
+          dependsOn: [],
+        })
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+          expect(res).to.have.status(200);
+          expect(res.body).to.be.a("object");
+          expect(res.body.message).to.equal("Task created successfully!");
+          expect(res.body.task).to.be.a("object");
+          expect(res.body.task.createdAt).to.be.a("number");
+          expect(res.body.task.updatedAt).to.be.a("number");
+          expect(res.body.task.createdAt).to.be.eq(res.body.task.updatedAt);
           return done();
         });
     });
@@ -373,7 +408,7 @@ describe("Tasks", function () {
           matchingTasks.forEach((task) => {
             expect(task.title.toLowerCase()).to.include(searchTerm.toLowerCase());
           });
-          expect(matchingTasks).to.have.length(3);
+          expect(matchingTasks).to.have.length(4);
 
           return done();
         });
@@ -534,7 +569,7 @@ describe("Tasks", function () {
   });
 
   describe("PATCH /tasks", function () {
-    it("Should update the task for the given taskid", function (done) {
+    it("Should update the task for the given taskId", function (done) {
       chai
         .request(app)
         .patch("/tasks/" + taskId1)
@@ -550,6 +585,41 @@ describe("Tasks", function () {
           return done();
         });
     });
+
+    it("should update updatedAt field when patch request is made", function (done) {
+      chai
+        .request(app)
+        .patch("/tasks/" + taskId1)
+        .set("cookie", `${cookieName}=${jwt}`)
+        .send({
+          title: "new-title",
+        })
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+          expect(res).to.have.status(204);
+          return done();
+        });
+    });
+
+    it("should update updatedAt field", function (done) {
+      chai
+        .request(app)
+        .get(`/tasks/${taskId1}/details`)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+          expect(res).to.have.status(200);
+          expect(res.body).to.be.a("object");
+          expect(res.body.taskData.updatedAt).to.be.a("number");
+          expect(res.body.taskData.updatedAt).to.be.not.eq(tasksData[0].updatedAt);
+          expect(res.body.taskData.updatedAt).to.be.not.eq(res.body.taskData.createdAt);
+          return done();
+        });
+    });
+
     it("Should update dependency", async function () {
       taskId = (await tasks.updateTask(tasksData[5])).taskId;
       const taskId1 = (await tasks.updateTask(tasksData[5])).taskId;


### PR DESCRIPTION
Date: 22-11-23

Developer Name: @prakashchoudhary07 

----

## Issue Ticket Number:- 
- Closes #1709 

## Description: 
Adds createdAt field to tasks model when creating a new Task (Initially createdAt and updatedAt will be same)
Adds updatedAt field to tasks model when tasks are being updated

Following Migration script PR to be merged https://github.com/Real-Dev-Squad/website-backend/pull/1715

## Documentation
- https://github.com/Real-Dev-Squad/website-data-models/pull/58 [data-models]
-https://github.com/Real-Dev-Squad/website-api-contracts/issues/167 [api-contracts]
Is Under the Feature Flag 
- [ ] Yes
- [x] No

Database changes
- [x] Yes
- [ ] No

Breaking changes (If your feature is breaking/missing something please mention pending tickets)
- [ ] Yes
- [x] No

Is Development Tested?

- [x] Yes
- [ ] No

Tested in staging?

- [x] Yes
- [ ] No

### Add relevant Screenshot below ( e.g test coverage etc. )

<img width="1038" alt="image" src="https://github.com/Real-Dev-Squad/website-backend/assets/34452139/e97af66b-163f-4e06-a1a5-da1d6541f9f2">

Creating new task
<img width="410" alt="image" src="https://github.com/Real-Dev-Squad/website-backend/assets/34452139/4a208e51-f427-4016-b6a1-6d938e6bfa33">

After Updating a task
<img width="414" alt="image" src="https://github.com/Real-Dev-Squad/website-backend/assets/34452139/64c06afc-6142-4fbb-968e-13a522e54668">

