### PR TITLE
I1712 migration script to add created at updated at in task doc

### DIFF
--- a/controllers/tasks.js
+++ b/controllers/tasks.js
@@ -12,6 +12,7 @@ const { getPaginatedLink } = require("../utils/helper");
 const { updateUserStatusOnTaskUpdate, updateStatusOnTaskCompletion } = require("../models/userStatus");
 const dataAccess = require("../services/dataAccessLayer");
 const { parseSearchQuery } = require("../utils/tasks");
+const { addTaskCreatedAtAndUpdatedAtFields } = require("../services/tasks");
 /**
  * Creates new task
  *
@@ -428,6 +429,11 @@ const assignTask = async (req, res) => {
 
 const updateStatus = async (req, res) => {
   try {
+    const { action, field } = req.body;
+    if (action === "ADD" && field === "CREATED_AT+UPDATED_AT") {
+      const updateStats = await addTaskCreatedAtAndUpdatedAtFields();
+      return res.json(updateStats);
+    }
     const response = await tasks.updateTaskStatus();
     return res.status(200).json(response);
   } catch (error) {

--- a/services/tasks.js
+++ b/services/tasks.js
@@ -43,6 +43,8 @@ const addTaskCreatedAtAndUpdatedAtFields = async () => {
     return operationStats;
   }
 
+  operationStats.totalTasks = tasks.size;
+
   tasks.forEach(async (task) => {
     const taskData = task.data();
     taskData.createdAt = task.createTime.seconds;
@@ -58,7 +60,6 @@ const addTaskCreatedAtAndUpdatedAtFields = async () => {
     tasks.forEach(({ id, data }) => {
       batch.update(tasksModel.doc(id), data);
     });
-    operationStats.totalTasks += tasks.length;
     try {
       await batch.commit();
       multipleTasksUpdateBatch.push(batch);

--- a/test/integration/tasks.test.js
+++ b/test/integration/tasks.test.js
@@ -1077,7 +1077,7 @@ describe("Tasks", function () {
       });
       expect(res).to.have.status(200);
       expect(res.body.totalFailedTasks).to.be.equal(0);
-      expect(res.body.totalTasks).to.be.equal(22);
+      expect(res.body.totalTasks).to.be.equal(23);
       expect(res.body.failedTasksIds).to.deep.equal([]);
     });
 
@@ -1094,9 +1094,9 @@ describe("Tasks", function () {
         field: "CREATED_AT+UPDATED_AT",
       });
       expect(res).to.have.status(200);
-      expect(res.body.totalFailedTasks).to.be.equal(22);
-      expect(res.body.totalTasks).to.be.equal(22);
-      expect(res.body.failedTasksIds.length).to.equal(22);
+      expect(res.body.totalFailedTasks).to.be.equal(23);
+      expect(res.body.totalTasks).to.be.equal(23);
+      expect(res.body.failedTasksIds.length).to.equal(23);
     });
   });
 });

--- a/test/integration/tasks.test.js
+++ b/test/integration/tasks.test.js
@@ -1080,7 +1080,8 @@ describe("Tasks", function () {
       expect(res.body.totalTasks).to.be.equal(22);
       expect(res.body.failedTasksIds).to.deep.equal([]);
     });
-    it("should throw an error if firestore batch operations fail for updating createdAt and updatedAt", async function () {
+
+    it("should return failed stats if firestore batch operations fail for adding createdAt and updatedAt", async function () {
       const stub = sinon.stub(firestore, "batch");
       stub.returns({
         update: function () {},

--- a/test/integration/tasks.test.js
+++ b/test/integration/tasks.test.js
@@ -1077,7 +1077,7 @@ describe("Tasks", function () {
       });
       expect(res).to.have.status(200);
       expect(res.body.totalFailedTasks).to.be.equal(0);
-      expect(res.body.totalTasks).to.be.equal(3);
+      expect(res.body.totalTasks).to.be.equal(22);
       expect(res.body.failedTasksIds).to.deep.equal([]);
     });
     it("should throw an error if firestore batch operations fail for updating createdAt and updatedAt", async function () {
@@ -1093,9 +1093,9 @@ describe("Tasks", function () {
         field: "CREATED_AT+UPDATED_AT",
       });
       expect(res).to.have.status(200);
-      expect(res.body.totalFailedTasks).to.be.equal(3);
-      expect(res.body.totalTasks).to.be.equal(3);
-      expect(res.body.failedTasksIds.length).to.equal(3);
+      expect(res.body.totalFailedTasks).to.be.equal(22);
+      expect(res.body.totalTasks).to.be.equal(22);
+      expect(res.body.failedTasksIds.length).to.equal(22);
     });
   });
 });

--- a/test/integration/tasks.test.js
+++ b/test/integration/tasks.test.js
@@ -1070,7 +1070,7 @@ describe("Tasks", function () {
     });
 
     // TASK createdAt and updatedAt migration script
-    it("Should update status createAt and updateAt", async function () {
+    it("Should update status createdAt and updatedAt", async function () {
       const res = await chai.request(app).post("/tasks/migration").set("cookie", `${cookieName}=${superUserJwt}`).send({
         action: "ADD",
         field: "CREATED_AT+UPDATED_AT",


### PR DESCRIPTION
Date: 23-11-23

Developer Name: @prakashchoudhary07 

----

## Issue Ticket Number:- 
- Closes #1712 

## Description: 
Migration script for adding createdAt and updatedAt fields in task documents

API CALL: 

```
POST: /tasks/migration
body: {
    "action": "ADD",
    "field": "CREATED_AT+UPDATED_AT"
}

```


Is Under the Feature Flag 
- [ ] Yes
- [x] No

Database changes
- [x] Yes
- [ ] No

Breaking changes (If your feature is breaking/missing something please mention pending tickets)
- [ ] Yes
- [x] No

Is Development Tested?

- [x] Yes
- [ ] No

Tested in staging?

- [ ] Yes
- [ ] No

### Add relevant Screenshot below ( e.g test coverage etc. )
<img width="360" alt="image" src="https://github.com/Real-Dev-Squad/website-backend/assets/34452139/e789d00e-5072-442e-9cee-161572a0cdea">

Test coverage
<img width="1024" alt="image" src="https://github.com/Real-Dev-Squad/website-backend/assets/34452139/ee058aea-ae3f-4431-91ae-53814e4d60ce">

