### PR TITLE
I1720 change task orderby desc order

### DIFF
--- a/models/tasks.js
+++ b/models/tasks.js
@@ -159,7 +159,7 @@ const fetchPaginatedTasks = async ({
         }
       }
     } else {
-      initialQuery = tasksModel.orderBy("title");
+      initialQuery = tasksModel.orderBy("updatedAt", "desc");
       if (status) {
         initialQuery = initialQuery.where("status", "==", status);
       }

--- a/test/integration/tasks.test.js
+++ b/test/integration/tasks.test.js
@@ -353,7 +353,6 @@ describe("Tasks", function () {
           if (err) {
             return done(err);
           }
-
           expect(res).to.have.status(200);
           expect(res.body).to.be.a("object");
           expect(res.body.message).to.equal("Tasks returned successfully!");
@@ -450,6 +449,26 @@ describe("Tasks", function () {
           expect(res.body.message).to.equal("No tasks found.");
           expect(res.body.tasks).to.be.a("array");
           expect(res.body.tasks).to.have.lengthOf(0);
+          return done();
+        });
+    });
+    it("Should get paginated tasks ordered by updatedAt in desc order ", function (done) {
+      chai
+        .request(app)
+        .get("/tasks?dev=true&size=5&page=0")
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+          expect(res).to.have.status(200);
+          expect(res.body).to.be.a("object");
+          expect(res.body.message).to.equal("Tasks returned successfully!");
+          expect(res.body.tasks).to.be.a("array");
+          const tasks = res.body.tasks;
+          // Check if Tasks are returned in desc order of updatedAt field
+          for (let i = 0; i < tasks.length - 1; i++) {
+            expect(tasks[+i].updatedAt).to.be.greaterThanOrEqual(tasks[i + 1].updatedAt);
+          }
           return done();
         });
     });

--- a/test/integration/tasks.test.js
+++ b/test/integration/tasks.test.js
@@ -24,6 +24,40 @@ const superUser = userData[4];
 
 let jwt, superUserJwt;
 
+const taskData = [
+  {
+    title: "Test task",
+    type: "feature",
+    endsOn: 1234,
+    startedOn: 4567,
+    status: "IN_PROGRESS",
+    percentCompleted: 10,
+    participants: [],
+    assignee: appOwner.username,
+    completionAward: { [DINERO]: 3, [NEELAM]: 300 },
+    lossRate: { [DINERO]: 1 },
+    isNoteworthy: true,
+    isCollapsed: true,
+  },
+  {
+    title: "Test task",
+    purpose: "To Test mocha",
+    featureUrl: "<testUrl>",
+    type: "group",
+    links: ["test1"],
+    endsOn: 1234,
+    startedOn: 54321,
+    status: "completed",
+    percentCompleted: 10,
+    dependsOn: ["d12", "d23"],
+    participants: [appOwner.username],
+    completionAward: { [DINERO]: 3, [NEELAM]: 300 },
+    lossRate: { [DINERO]: 1 },
+    isNoteworthy: false,
+    assignee: appOwner.username,
+  },
+];
+
 describe("Tasks", function () {
   let taskId1, taskId;
 
@@ -32,40 +66,6 @@ describe("Tasks", function () {
     const superUserId = await addUser(superUser);
     jwt = authService.generateAuthToken({ userId });
     superUserJwt = authService.generateAuthToken({ userId: superUserId });
-
-    const taskData = [
-      {
-        title: "Test task",
-        type: "feature",
-        endsOn: 1234,
-        startedOn: 4567,
-        status: "IN_PROGRESS",
-        percentCompleted: 10,
-        participants: [],
-        assignee: appOwner.username,
-        completionAward: { [DINERO]: 3, [NEELAM]: 300 },
-        lossRate: { [DINERO]: 1 },
-        isNoteworthy: true,
-        isCollapsed: true,
-      },
-      {
-        title: "Test task",
-        purpose: "To Test mocha",
-        featureUrl: "<testUrl>",
-        type: "group",
-        links: ["test1"],
-        endsOn: 1234,
-        startedOn: 54321,
-        status: "completed",
-        percentCompleted: 10,
-        dependsOn: ["d12", "d23"],
-        participants: [appOwner.username],
-        completionAward: { [DINERO]: 3, [NEELAM]: 300 },
-        lossRate: { [DINERO]: 1 },
-        isNoteworthy: false,
-        assignee: appOwner.username,
-      },
-    ];
 
     // Add the active task
     taskId = (await tasks.updateTask(taskData[0])).taskId;
@@ -184,6 +184,11 @@ describe("Tasks", function () {
   });
 
   describe("GET /tasks", function () {
+    before(async function () {
+      await tasks.updateTask({ ...taskData[0], createdAt: 1621717694, updatedAt: 1700680830 });
+      await tasks.updateTask({ ...taskData[1], createdAt: 1621717694, updatedAt: 1700775753 });
+    });
+
     it("Should get all the list of tasks", function (done) {
       chai
         .request(app)
@@ -409,7 +414,7 @@ describe("Tasks", function () {
           matchingTasks.forEach((task) => {
             expect(task.title.toLowerCase()).to.include(searchTerm.toLowerCase());
           });
-          expect(matchingTasks).to.have.length(4);
+          expect(matchingTasks).to.have.length(6);
 
           return done();
         });


### PR DESCRIPTION
Date: 24-11-23

Developer Name: @prakashchoudhary07 

----

## Issue Ticket Number:- 
- Closes #1720 

## Description: 
Change task orderBy to updatedAt field for paginations API
The requirement is to show the data in desc order of updatedAt field


Is Under the Feature Flag 
- [x] Yes
- [ ] No

Database changes
- [ ] Yes
- [x] No

Breaking changes (If your feature is breaking/missing something please mention pending tickets)
- [ ] Yes
- [x] No

Is Development Tested?

- [x] Yes
- [ ] No

Tested in staging?

- [ ] Yes
- [x] No

### Add relevant Screenshot below ( e.g test coverage etc. )
<img width="1044" alt="image" src="https://github.com/Real-Dev-Squad/website-backend/assets/34452139/482c61b9-81dd-442c-b7b7-a5571796f94f">

