### PR TITLE
fix: update remaining count key

### DIFF
--- a/controllers/cloudflareCache.js
+++ b/controllers/cloudflareCache.js
@@ -81,7 +81,7 @@ const fetchPurgedCacheMetadata = async (req, res) => {
       const { timestamp } = latestCacheMetadata;
       return res.json({
         message: "Purged cache metadata returned successfully!",
-        count: logs.length,
+        remainingCount: MAX_CACHE_PURGE_COUNT - logs.length,
         timeLastCleared: timestamp._seconds,
       });
     } else if ((await logsQuery.fetchLastAddedCacheLog(id)).length !== 0) {
@@ -89,13 +89,13 @@ const fetchPurgedCacheMetadata = async (req, res) => {
       const { timestamp } = lastLog[0];
       return res.json({
         message: "Purged cache metadata returned successfully!",
-        count: 0,
+        remainingCount: MAX_CACHE_PURGE_COUNT,
         timeLastCleared: timestamp._seconds,
       });
     } else {
       return res.json({
         message: "No cache is cleared yet",
-        count: 0,
+        remainingCount: MAX_CACHE_PURGE_COUNT,
       });
     }
   } catch (error) {

--- a/test/integration/cloudflareCache.test.js
+++ b/test/integration/cloudflareCache.test.js
@@ -48,7 +48,7 @@ describe("Purged Cache Metadata", function () {
           expect(response).to.have.status(200);
           expect(response.body).to.be.an("object");
           expect(response.body.message).to.equal("No cache is cleared yet");
-          expect(response.body.count).to.equal(0);
+          expect(response.body.remainingCount).to.equal(3);
           return done();
         });
     });
@@ -67,7 +67,7 @@ describe("Purged Cache Metadata", function () {
           expect(response).to.have.status(200);
           expect(response.body).to.be.an("object");
           expect(response.body.message).to.equal("Purged cache metadata returned successfully!");
-          expect(response.body.count).to.be.a("number");
+          expect(response.body.remainingCount).to.be.a("number");
           expect(response.body.timeLastCleared).to.be.a("number");
 
           return done();


### PR DESCRIPTION
Date: 27/11/2023

Developer Name: @sumitd94 

----

## Issue Ticket Number:- 
- https://github.com/Real-Dev-Squad/website-my/issues/530

## Description: 
the `count` key in the response was returning the total number of counts the user has used for purging the cache, but ideally it should be giving us the remaining count the user has left with in purging cache


Is Under Feature Flag 
- [x] Yes
- [ ] No

Database changes
- [ ] Yes
- [x] No

Breaking changes (If your feature is breaking/missing something please mention pending tickets)
- [ ] Yes
- [x] No

Is Development Tested?

- [x] Yes
- [ ] No

Tested in staging?

- [x] Yes
- [ ] No

### Add relevant Screenshot below ( e.g test coverage etc. )
<img width="850" alt="Screenshot 2023-11-27 at 5 48 17 PM" src="https://github.com/Real-Dev-Squad/website-backend/assets/29303618/58f1bb87-38a7-4068-9de4-4667638846da">

