### PR TITLE
Restricts what roles can be added to user discord profile

### DIFF
--- a/controllers/discordactions.js
+++ b/controllers/discordactions.js
@@ -115,12 +115,10 @@ const addGroupRoleToMember = async (req, res) => {
     const userDataPromise = fetchUser({ discordId: memberGroupRole.userid });
     const [{ roleExists }, userData] = await Promise.all([roleExistsPromise, userDataPromise]);
 
-    if (!roleExists) {
+    if (!roleExists || req.userData.id !== userData.user.id) {
       res.boom.forbidden("Permission denied. Cannot add the role.");
     }
-    if (req.userData.id !== userData.user.id) {
-      res.boom.forbidden("Permission denied. Cannot add the role.");
-    }
+
     const { roleData, wasSuccess } = await discordRolesModel.addGroupRoleToMember(memberGroupRole);
 
     if (!wasSuccess) {
@@ -164,10 +162,7 @@ const deleteRole = async (req, res) => {
     const userDataPromise = fetchUser({ discordId: userid });
     const [{ roleExists }, userData] = await Promise.all([roleExistsPromise, userDataPromise]);
 
-    if (!roleExists) {
-      res.boom.forbidden("Permission denied. Cannot delete the role.");
-    }
-    if (req.userData.id !== userData.user.id) {
+    if (!roleExists || req.userData.id !== userData.user.id) {
       res.boom.forbidden("Permission denied. Cannot delete the role.");
     }
 

--- a/controllers/discordactions.js
+++ b/controllers/discordactions.js
@@ -4,7 +4,7 @@ const config = require("config");
 const jwt = require("jsonwebtoken");
 const discordRolesModel = require("../models/discordactions");
 const discordServices = require("../services/discordService");
-const { fetchAllUsers } = require("../models/users");
+const { fetchAllUsers, fetchUser } = require("../models/users");
 const discordDeveloperRoleId = config.get("discordDeveloperRoleId");
 const discordMavenRoleId = config.get("discordMavenRoleId");
 
@@ -23,9 +23,9 @@ const createGroupRole = async (req, res) => {
   try {
     const rolename = `group-${req.body.rolename}`;
 
-    const { wasSuccess } = await discordRolesModel.isGroupRoleExists(rolename);
+    const { roleExists } = await discordRolesModel.isGroupRoleExists({ rolename });
 
-    if (!wasSuccess) {
+    if (roleExists) {
       return res.status(400).json({
         message: "Role already exists!",
       });
@@ -109,7 +109,18 @@ const addGroupRoleToMember = async (req, res) => {
       ...req.body,
       date: admin.firestore.Timestamp.fromDate(new Date()),
     };
+    const roleExistsPromise = discordRolesModel.isGroupRoleExists({
+      roleid: memberGroupRole.roleid,
+    });
+    const userDataPromise = fetchUser({ discordId: memberGroupRole.userid });
+    const [{ roleExists }, userData] = await Promise.all([roleExistsPromise, userDataPromise]);
 
+    if (!roleExists) {
+      res.boom.forbidden("Permission denied. Cannot add the role.");
+    }
+    if (req.userData.id !== userData.user.id) {
+      res.boom.forbidden("Permission denied. Cannot add the role.");
+    }
     const { roleData, wasSuccess } = await discordRolesModel.addGroupRoleToMember(memberGroupRole);
 
     if (!wasSuccess) {
@@ -146,6 +157,20 @@ const addGroupRoleToMember = async (req, res) => {
 const deleteRole = async (req, res) => {
   try {
     const { roleid, userid } = req.body;
+
+    const roleExistsPromise = discordRolesModel.isGroupRoleExists({
+      roleid,
+    });
+    const userDataPromise = fetchUser({ discordId: userid });
+    const [{ roleExists }, userData] = await Promise.all([roleExistsPromise, userDataPromise]);
+
+    if (!roleExists) {
+      res.boom.forbidden("Permission denied. Cannot delete the role.");
+    }
+    if (req.userData.id !== userData.user.id) {
+      res.boom.forbidden("Permission denied. Cannot delete the role.");
+    }
+
     const { wasSuccess } = await discordRolesModel.removeMemberGroup(roleid, userid);
     if (wasSuccess) {
       return res.status(200).json({ message: "Role deleted successfully" });

--- a/models/discordactions.js
+++ b/models/discordactions.js
@@ -124,19 +124,32 @@ const updateGroupRole = async (roleData, docId) => {
 };
 /**
  *
- * @param roleData { Object }: Data of the new role
+ * @param options { Object }: Data of the new role
+ * @param options.rolename String : name of the role
+ * @param options.roleId String : id of the role
  * @returns {Promise<discordRoleModel|Object>}
  */
 
-const isGroupRoleExists = async (rolename) => {
+const isGroupRoleExists = async (options = {}) => {
   try {
-    const alreadyIsRole = await discordRoleModel.where("rolename", "==", rolename).limit(1).get();
-    if (!alreadyIsRole.empty) {
-      const oldRole = [];
-      alreadyIsRole.forEach((role) => oldRole.push(role.data()));
-      return { wasSuccess: false };
+    const { rolename = null, roleid = null } = options;
+
+    let existingRoles;
+    if (rolename && roleid) {
+      existingRoles = await discordRoleModel
+        .where("rolename", "==", rolename)
+        .where("roleid", "==", roleid)
+        .limit(1)
+        .get();
+    } else if (rolename) {
+      existingRoles = await discordRoleModel.where("rolename", "==", rolename).limit(1).get();
+    } else if (roleid) {
+      existingRoles = await discordRoleModel.where("roleid", "==", roleid).limit(1).get();
+    } else {
+      throw Error("Either rolename or roleId is required");
     }
-    return { wasSuccess: true };
+
+    return { roleExists: !existingRoles.empty };
   } catch (err) {
     logger.error("Error in getting all group-roles", err);
     throw err;

--- a/test/fixtures/discordactions/discordactions.js
+++ b/test/fixtures/discordactions/discordactions.js
@@ -1,7 +1,7 @@
 const groupData = [
-  { rolename: "Group 1", roleid: 1 },
-  { rolename: "Group 2", roleid: 2 },
-  { rolename: "Group 3", roleid: 3 },
+  { rolename: "Group 1", roleid: "1" },
+  { rolename: "Group 2", roleid: "2" },
+  { rolename: "Group 3", roleid: "3" },
 ];
 
 const groupIdle7d = { rolename: "group-idle-7d+", roleid: 4, createdBy: "1dad23q23j131j" };

--- a/test/integration/discordactions.test.js
+++ b/test/integration/discordactions.test.js
@@ -290,24 +290,24 @@ describe("Discord actions", function () {
     it("should not allow unknown role to be deleted from user", async function () {
       const res = await chai
         .request(app)
-        .post("/discord-actions/roles")
+        .delete("/discord-actions/roles")
         .set("cookie", `${cookieName}=${jwt}`)
         .send({ roleid: "randomId", userid: "abc" });
 
       expect(res).to.have.status(403);
       expect(res.body).to.be.an("object");
-      expect(res.body.message).to.equal("Permission denied. Cannot add the role.");
+      expect(res.body.message).to.equal("Permission denied. Cannot delete the role.");
     });
     it("should not allow role to be deleted when userid does not belong to authenticated user", async function () {
       const res = await chai
         .request(app)
-        .post("/discord-actions/roles")
+        .delete("/discord-actions/roles")
         .set("cookie", `${cookieName}=${jwt}`)
         .send({ roleid, userid: "asdf" });
 
       expect(res).to.have.status(403);
       expect(res.body).to.be.an("object");
-      expect(res.body.message).to.equal("Permission denied. Cannot add the role.");
+      expect(res.body.message).to.equal("Permission denied. Cannot delete the role.");
     });
     it("should handle internal server error", function (done) {
       chai

--- a/test/unit/models/discordactions.test.js
+++ b/test/unit/models/discordactions.test.js
@@ -87,51 +87,59 @@ describe("discordactions", function () {
   });
 
   describe("isGroupRoleExists", function () {
-    let getStub;
+    let roleid;
+    let rolename;
+    beforeEach(async function () {
+      const discordRoleModelPromise = [discordRoleModel.add(groupData[0]), discordRoleModel.add(groupData[1])];
+      roleid = groupData[0].roleid;
+      rolename = groupData[0].rolename;
+      await Promise.all(discordRoleModelPromise);
+    });
 
-    beforeEach(function () {
-      getStub = sinon.stub(discordRoleModel, "where").returns({
-        limit: sinon.stub().resolves({
-          empty: true,
-          forEach: sinon.stub(),
-        }),
+    afterEach(async function () {
+      sinon.restore();
+      await cleanDb();
+    });
+
+    it("should return false if rolename doesn't exist in the database", async function () {
+      const rolename = "Test Role";
+      const result = await isGroupRoleExists({ rolename });
+      expect(result.roleExists).to.equal(false);
+    });
+    it("should return false if roleid doesn't exist in the database", async function () {
+      const roleid = "Test Role";
+      const result = await isGroupRoleExists({ roleid });
+      expect(result.roleExists).to.equal(false);
+    });
+    it("should return true if roleid exist in the database", async function () {
+      const result = await isGroupRoleExists({ roleid });
+      expect(result.roleExists).to.equal(true);
+    });
+    it("should return true if rolename exist in the database", async function () {
+      const result = await isGroupRoleExists({ rolename });
+      expect(result.roleExists).to.equal(true);
+    });
+    it("should return true if rolename and roleid exists in the database", async function () {
+      const result = await isGroupRoleExists({ rolename, roleid });
+      expect(result.roleExists).to.equal(true);
+    });
+    it("should return false if either rolename and roleid does not exist in the database", async function () {
+      const rolenameResult = await isGroupRoleExists({ rolename: "adf", roleid });
+      expect(rolenameResult.roleExists).to.equal(false);
+      const roleIdResult = await isGroupRoleExists({ rolename, roleid: "abc44" });
+      expect(roleIdResult.roleExists).to.equal(false);
+    });
+    it("should throw an error if rolename and roleid are not passed", async function () {
+      return isGroupRoleExists({}).catch((err) => {
+        expect(err).to.be.an.instanceOf(Error);
+        expect(err.message).to.equal("Either rolename or roleId is required");
       });
     });
-
-    afterEach(function () {
-      getStub.restore();
-    });
-
-    it("should return true if role doesn't exist in the database", async function () {
-      const result = await isGroupRoleExists("Test Role");
-      expect(result.wasSuccess).to.equal(true);
-      expect(getStub.calledOnceWith("rolename", "==", "Test Role")).to.equal(false);
-    });
-
-    it("should return false if role already exists in the database", async function () {
-      const existingRole = { rolename: "Test Role" };
-      const callbackFunction = (role) => {
-        const roleData = role.data();
-        existingRole.push(roleData);
-      };
-
-      getStub.returns({
-        limit: sinon.stub().resolves({
-          empty: false,
-          forEach: callbackFunction,
-        }),
-      });
-
-      const errorCallback = sinon.stub();
-      const result = await isGroupRoleExists("Test Role");
-      expect(result.wasSuccess).to.equal(true);
-      expect(getStub.calledOnceWith("rolename", "==", "Test Role")).to.equal(false);
-      expect(errorCallback.calledOnce).to.equal(false);
-    });
-
     it("should throw an error if getting group-roles fails", async function () {
-      getStub.rejects(new Error("Database error"));
-      return isGroupRoleExists("Test Role").catch((err) => {
+      sinon.stub(discordRoleModel, "where").rejects(new Error("Database error"));
+      const rolename = "Test Role";
+
+      return isGroupRoleExists({ rolename }).catch((err) => {
         expect(err).to.be.an.instanceOf(Error);
         expect(err.message).to.equal("Database error");
       });


### PR DESCRIPTION
Date: `30 November 2023`

Developer Name: @Ajeyakrishna-k 

----

## Description: 
Currently anyone can pass any discord role id and get privileges. This pr fixes that.

Is Under Feature Flag 
- [ ] Yes
- [x] No

Database changes
- [ ] Yes
- [x] No

Breaking changes (If your feature is breaking/missing something please mention pending tickets)
- [ ] Yes
- [x] No

Is Development Tested?

- [ ] Yes
- [x] No

Tested in staging?

- [ ] Yes
- [x] No

### Add relevant Screenshot below ( e.g test coverage etc. )
<img width="843" alt="Screenshot 2023-11-30 at 6 39 50 AM" src="https://github.com/Real-Dev-Squad/website-backend/assets/98796547/f36d337e-5865-49f7-9db8-bb1e03434804">

<img width="826" alt="Screenshot 2023-11-30 at 6 38 14 AM" src="https://github.com/Real-Dev-Squad/website-backend/assets/98796547/17fb5fed-14e6-4235-a98e-a1bc0b09cc72">
