### PR TITLE
Enhancement : Restrict Task Status Change to Available for Task assigned to Self

### DIFF
--- a/middlewares/validators/tasks.js
+++ b/middlewares/validators/tasks.js
@@ -137,10 +137,10 @@ const updateSelfTask = async (req, res, next) => {
     await schema.validateAsync(req.body);
     next();
   } catch (error) {
+    logger.error(`Error validating updateSelfTask payload : ${error}`);
     if (error instanceof BadRequest) {
       res.boom.badRequest(error.message);
     } else {
-      logger.error(`Error validating updateSelfTask payload : ${error}`);
       res.boom.badRequest(error.details[0].message);
     }
   }

--- a/test/integration/tasks.test.js
+++ b/test/integration/tasks.test.js
@@ -933,8 +933,8 @@ describe("Tasks", function () {
           }
           expect(res).to.have.status(400);
           expect(res.body).to.be.a("object");
-          expect(res.error).to.equal("Bad Request");
-          expect(res.message).to.equal("The value for the 'status' field is invalid.");
+          expect(res.body.error).to.equal("Bad Request");
+          expect(res.body.message).to.equal("The value for the 'status' field is invalid.");
           return done();
         });
     });

--- a/test/integration/tasks.test.js
+++ b/test/integration/tasks.test.js
@@ -921,7 +921,26 @@ describe("Tasks", function () {
       isNoteworthy: true,
     };
 
+    it("Should throw 400 Bad Request if the user tries to update the status of a task to AVAILABLE", function (done) {
+      chai
+        .request(app)
+        .patch(`/tasks/self/${taskId1}`)
+        .set("cookie", `${cookieName}=${jwt}`)
+        .send(taskStatusData)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+          expect(res).to.have.status(400);
+          expect(res.body).to.be.a("object");
+          expect(res.error).to.equal("Bad Request");
+          expect(res.message).to.equal("The value for the 'status' field is invalid.");
+          return done();
+        });
+    });
+
     it("Should update the task status for given self taskid", function (done) {
+      taskStatusData.status = "IN_PROGRESS";
       chai
         .request(app)
         .patch(`/tasks/self/${taskId1}`)
@@ -1002,6 +1021,7 @@ describe("Tasks", function () {
     });
 
     it("Should return 404 if task doesnt exist", function (done) {
+      taskStatusData.status = "IN_PROGRESS";
       chai
         .request(app)
         .patch("/tasks/self/wrongtaskId")
@@ -1043,6 +1063,7 @@ describe("Tasks", function () {
     });
 
     it("Should give 403 if status is already 'VERIFIED' ", async function () {
+      taskStatusData.status = "IN_PROGRESS";
       taskId = (await tasks.updateTask({ ...taskData, assignee: appOwner.username })).taskId;
       const res = await chai
         .request(app)

--- a/test/unit/middlewares/tasks-validator.test.js
+++ b/test/unit/middlewares/tasks-validator.test.js
@@ -2,6 +2,7 @@ const Sinon = require("sinon");
 const {
   getTasksValidator,
   createTask,
+  updateSelfTask,
   getUsersValidator,
   updateTask: updateTaskValidator,
 } = require("../../../middlewares/validators/tasks");
@@ -704,6 +705,24 @@ describe("getTasks validator", function () {
       await getUsersValidator(req, res, nextMiddlewareSpy);
       expect(nextMiddlewareSpy.callCount).to.be.equal(0);
       expect(res.boom.badRequest.callCount).to.be.equal(1);
+    });
+  });
+
+  describe("updateSelfTask Validator", function () {
+    it("should not pass the request when status is AVAILABLE", async function () {
+      const req = {
+        body: {
+          status: "AVAILABLE",
+        },
+      };
+      const res = {
+        boom: {
+          badRequest: Sinon.spy(),
+        },
+      };
+      const nextMiddlewareSpy = Sinon.spy();
+      await updateSelfTask(req, res, nextMiddlewareSpy);
+      expect(nextMiddlewareSpy.callCount).to.be.equal(0);
     });
   });
 });


### PR DESCRIPTION
Date: 14 Dec 2023

Developer Name: Randhir

----

## Issue Ticket Number:- 
- #1776

## Description: 

This pull request updates the PATCH request in the /tasks endpoint, After this update User will not be able to change their task status to AVAILABLE. Only a super user can change the status to available in that case the assignee will be removed and set to null.

Is Under Feature Flag 
- [ ] Yes
- [x] No

Database changes
- [ ] Yes
- [x] No

Breaking changes (If your feature is breaking/missing something please mention pending tickets)
- [ ] Yes
- [x] No

Is Development Tested?

- [x] Yes
- [ ] No

Tested in staging?

- [ ] Yes
- [x] No

### Add relevant Screenshot below ( e.g test coverage etc. )

Integration Tests
![image](https://github.com/Real-Dev-Squad/website-backend/assets/97341921/5b23927e-e80f-40ac-999b-b5826e043866)

Unit Tests
![image](https://github.com/Real-Dev-Squad/website-backend/assets/97341921/43da2129-3402-4fbd-ae82-769a64d9d018)

Code Coverage
![image](https://github.com/Real-Dev-Squad/website-backend/assets/97341921/35b09850-ddae-4827-b5ff-289886388a37)
