### PR TITLE
creating a post route for store document in log

### DIFF
--- a/controllers/logs.js
+++ b/controllers/logs.js
@@ -1,5 +1,6 @@
 const logsQuery = require("../models/logs");
 const { SOMETHING_WENT_WRONG } = require("../constants/errorMessages");
+const db = require("../utils/firestore");
 
 /**
  * Fetches logs
@@ -20,6 +21,22 @@ const fetchLogs = async (req, res) => {
   }
 };
 
+const createLogs=async (req, res) => {
+  try {
+    // Extract data from the request body
+    const logData = req.body;
+
+    // Save data to Firestore logs collection
+    const logsCollection = db.collection('logs');
+    await logsCollection.add(logData);
+
+    res.status(201).json({ message: 'Log saved successfully' });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}
 module.exports = {
   fetchLogs,
+  createLogs,
 };

--- a/routes/logs.js
+++ b/routes/logs.js
@@ -6,5 +6,6 @@ const authorizeRoles = require("../middlewares/authorizeRoles");
 const { SUPERUSER } = require("../constants/roles");
 
 router.get("/:type", authenticate, authorizeRoles([SUPERUSER]), logs.fetchLogs);
+router.post("/",logs.createLogs)
 
 module.exports = router;


### PR DESCRIPTION
Add pot route for storing document modification logs
----

## Issue Ticket Number:- 
#1784 

## Description: 
1. *Overview:*
   This pull request adds a new POST route to store document modification logs in the Firestore logs collection. This allows different services to log their document modifications easily.





