### PR TITLE
API to check if a user is a developer

### DIFF
--- a/controllers/users.js
+++ b/controllers/users.js
@@ -254,11 +254,11 @@ const isDeveloper = async (req, res) => {
       if (discordMember) {
         const { roles } = discordMember;
         if (roles) {
-          return res.status(200).json({ devRoleExistsOnUser: roles.includes(discordDeveloperRoleId) });
+          return res.status(200).json({ developerRoleExistsOnUser: roles.includes(discordDeveloperRoleId) });
         }
       }
     }
-    return res.status(200).json({ devRoleExistsOnUser: false });
+    return res.status(200).json({ developerRoleExistsOnUser: false });
   } catch (error) {
     logger.error(`Error while fetching developer tag: ${error}`);
     return res.boom.serverUnavailable(SOMETHING_WENT_WRONG);

--- a/routes/users.js
+++ b/routes/users.js
@@ -16,6 +16,7 @@ router.get("/userId/:userId", users.getUserById);
 router.patch("/self", authenticate, userValidator.updateUser, users.updateSelf);
 router.get("/", userValidator.getUsers, users.getUsers);
 router.get("/self", authenticate, users.getSelfDetails);
+router.get("/isDeveloper", authenticate, users.isDeveloper);
 router.get("/isUsernameAvailable/:username", authenticate, users.getUsernameAvailabilty);
 router.get("/username", authenticate, userValidator.validateGenerateUsernameQuery, users.generateUsername);
 router.get("/chaincode", authenticate, users.generateChaincode);

--- a/test/integration/users.test.js
+++ b/test/integration/users.test.js
@@ -65,6 +65,20 @@ describe("Users", function () {
   });
 
   describe("PATCH /users/self", function () {
+    beforeEach(function () {
+      fetchStub = Sinon.stub(global, "fetch");
+      fetchStub.returns(
+        Promise.resolve({
+          status: 200,
+          json: () => Promise.resolve(getDiscordMembers),
+        })
+      );
+    });
+
+    afterEach(function () {
+      Sinon.restore();
+    });
+
     it("Should update the user", function (done) {
       chai
         .request(app)

--- a/test/integration/users.test.js
+++ b/test/integration/users.test.js
@@ -15,6 +15,7 @@ const superUser = userData[4];
 const searchParamValues = require("../fixtures/user/search")();
 
 const config = require("config");
+const discordDeveloperRoleId = config.get("discordDeveloperRoleId");
 const { getDiscordMembers } = require("../fixtures/discordResponse/discord-response");
 const joinData = require("../fixtures/user/join");
 const {
@@ -2178,6 +2179,116 @@ describe("Users", function () {
           expect(res).to.have.status(500);
           const response = res.body;
           expect(response.message).to.be.equal("An internal server error occurred");
+          return done();
+        });
+    });
+  });
+
+  describe("GET /users/isDeveloper for developers not in_discord", function () {
+    beforeEach(function () {
+      fetchStub = Sinon.stub(global, "fetch");
+      fetchStub.returns(
+        Promise.resolve({
+          status: 200,
+          json: () => Promise.resolve(getDiscordMembers),
+        })
+      );
+    });
+
+    afterEach(function () {
+      Sinon.restore();
+    });
+
+    it("Should return false if user is a developer and not in discord", function (done) {
+      chai
+        .request(app)
+        .get("/users/isDeveloper")
+        .set("cookie", `${cookieName}=${jwt}`)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          expect(res).to.have.status(200);
+          expect(res.body.developerRoleExistsOnUser).to.equal(false);
+
+          return done();
+        });
+    });
+  });
+
+  describe("PATCH /users/self for developers", function () {
+    beforeEach(function () {
+      fetchStub = Sinon.stub(global, "fetch");
+      const discordMembers = [...getDiscordMembers];
+      discordMembers[0].user.id = "12345";
+      discordMembers[0].roles.push(discordDeveloperRoleId);
+      fetchStub.returns(
+        Promise.resolve({
+          status: 200,
+          json: () => Promise.resolve(discordMembers),
+        })
+      );
+    });
+
+    afterEach(function () {
+      Sinon.restore();
+    });
+
+    it("Should not update the user if user is a developer", function (done) {
+      chai
+        .request(app)
+        .patch("/users/self")
+        .set("cookie", `${cookieName}=${jwt}`)
+        .send({
+          first_name: "Test first_name",
+        })
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          expect(res).to.have.status(403);
+          expect(res.body.message).to.equal(
+            "Developers can't update their profile data. Use profile service for updating."
+          );
+
+          return done();
+        });
+    });
+  });
+
+  describe("GET /users/isDeveloper for developers", function () {
+    beforeEach(function () {
+      fetchStub = Sinon.stub(global, "fetch");
+      const discordMembers = [...getDiscordMembers];
+      discordMembers[0].user.id = "12345";
+      discordMembers[0].roles.push(discordDeveloperRoleId);
+      fetchStub.returns(
+        Promise.resolve({
+          status: 200,
+          json: () => Promise.resolve(discordMembers),
+        })
+      );
+    });
+
+    afterEach(function () {
+      Sinon.restore();
+    });
+
+    it("Should return true if user is a developer", function (done) {
+      chai
+        .request(app)
+        .get("/users/isDeveloper")
+        .set("cookie", `${cookieName}=${jwt}`)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          expect(res).to.have.status(200);
+          expect(res.body.developerRoleExistsOnUser).to.equal(true);
+
           return done();
         });
     });

--- a/test/unit/middlewares/contentTypeCheck.test.js
+++ b/test/unit/middlewares/contentTypeCheck.test.js
@@ -1,6 +1,8 @@
 const chai = require("chai");
 const { expect } = chai;
 const chaiHttp = require("chai-http");
+const { getDiscordMembers } = require("../../fixtures/discordResponse/discord-response");
+const sinon = require("sinon");
 
 const app = require("../../../server");
 const authService = require("../../../services/authService");
@@ -13,13 +15,23 @@ chai.use(chaiHttp);
 
 describe("contentTypeCheck", function () {
   let jwt;
+  let fetchStub;
 
   beforeEach(async function () {
     const userId = await addUser();
     jwt = authService.generateAuthToken({ userId });
+
+    fetchStub = sinon.stub(global, "fetch");
+    fetchStub.returns(
+      Promise.resolve({
+        status: 200,
+        json: () => Promise.resolve(getDiscordMembers),
+      })
+    );
   });
 
   afterEach(async function () {
+    sinon.restore();
     await cleanDb();
   });
 


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 14/02/2024
<!--Developer Name Here-->
Developer Name: @lakshayman 

---

## Issue Ticket Number
Closes #1909 

## Description
We want to disable developers from updating the data from the UI. So for that as a temporary solution, we have to add an API that calls discord slash commands get the member roles from discord, and return if a user is a developer or not. 

 If any developer likes to ensure that his/her data stays up-to-date in Real Dev Squad, they need to create a [profile service](https://github.com/Real-Dev-Squad/sample-profile-service/blob/main/README.md).

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [x] Yes
- [ ] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [ ] Yes
- [x] No
### Test Coverage
![65](https://github.com/Real-Dev-Squad/website-backend/assets/45519620/f41931df-d05a-42e1-aaef-e32d778b2a5b)
![56](https://github.com/Real-Dev-Squad/website-backend/assets/45519620/3bf4c119-33dc-4125-9926-f9e2b4df6091)

<!--Confirmation of local testing during development-->