### PR TITLE
update updated_at in user documents whenever user data is updated

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -80,7 +80,7 @@ const githubAuthCallback = (req, res, next) => {
         github_created_at: Number(new Date(user._json.created_at).getTime()),
         github_user_id: user.id,
         created_at: Date.now(),
-        updated_at: Date.now(),
+        updated_at: null,
       };
 
       const { userId, incompleteUserDetails, role } = await users.addOrUpdate(userData);

--- a/controllers/staging.js
+++ b/controllers/staging.js
@@ -15,6 +15,7 @@ const updateRoles = async (req, res) => {
           ...userData.roles,
           ...req.body,
         },
+        updated_at: Date.now(),
       },
       userId
     );
@@ -48,6 +49,7 @@ const removePrivileges = async (req, res) => {
               ...member.roles,
               member: false,
             },
+            updated_at: Date.now(),
           },
           member.id
         )
@@ -61,6 +63,7 @@ const removePrivileges = async (req, res) => {
               ...superUser.roles,
               super_user: false,
             },
+            updated_at: Date.now(),
           },
           superUser.id
         )

--- a/models/members.js
+++ b/models/members.js
@@ -54,6 +54,7 @@ const moveToMembers = async (userId) => {
     const roles = user.roles ? { ...user.roles, member: true } : { member: true };
     await userModel.doc(userId).update({
       roles,
+      updated_at: Date.now(),
     });
     return { isAlreadyMember: false, movedToMember: true };
   } catch (err) {
@@ -101,6 +102,7 @@ const addArchiveRoleToMembers = async (userId) => {
     const roles = { ...user.roles, [ROLES.ARCHIVED]: true };
     await userModel.doc(userId).update({
       roles,
+      updated_at: Date.now(),
     });
     return { isArchived: false };
   } catch (err) {

--- a/models/users.js
+++ b/models/users.js
@@ -61,7 +61,7 @@ const addOrUpdate = async (userData, userId = null) => {
       user = await userModel.where("github_id", "==", userData.github_id).limit(1).get();
     }
     if (user && !user.empty && user.docs !== null) {
-      await userModel.doc(user.docs[0].id).set(userData, { merge: true });
+      await userModel.doc(user.docs[0].id).set({ ...userData, updated_at: Date.now() }, { merge: true });
       const data = user.docs[0].data();
       return {
         isNewUser: false,
@@ -308,6 +308,7 @@ const setIncompleteUserDetails = async (userId) => {
   if (doc.exists) {
     return userRef.update({
       incompleteUserDetails: false,
+      updated_at: Date.now(),
     });
   }
   return {};
@@ -423,6 +424,7 @@ const updateUserPicture = async (image, userId) => {
     const userDoc = userModel.doc(userId);
     await userDoc.update({
       picture: image,
+      updated_at: Date.now(),
     });
   } catch (err) {
     logger.error("Error updating user picture data", err);
@@ -788,7 +790,7 @@ const updateUsersInBatch = async (usersData) => {
     usersData.forEach((user) => {
       const id = user.id;
       delete user.id;
-      bulkWriter.update(userModel.doc(id), user);
+      bulkWriter.update(userModel.doc(id), { ...user, updated_at: Date.now() });
     });
 
     await bulkWriter.close();
@@ -913,7 +915,7 @@ const addGithubUserId = async (page, size) => {
         })
         .then((data) => {
           const githubUserId = data.id;
-          batchWrite.update(userDoc.ref, { github_user_id: `${githubUserId}` });
+          batchWrite.update(userDoc.ref, { github_user_id: `${githubUserId}`, updated_at: Date.now() });
           countUserFound++;
         })
         .catch((error) => {

--- a/services/users.js
+++ b/services/users.js
@@ -19,6 +19,7 @@ const archiveUsers = async (usersData) => {
         ...user.roles,
         archived: true,
       },
+      updated_at: Date.now(),
     };
     batch.update(userModel.doc(id), updatedUserData);
     usersBatch.push({ id, firstName, lastName });


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 23/03/2024
<!--Developer Name Here-->
Developer Name: Mehul Chaudhari

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
#1929 
## Description

Some APIs which update the user documents now don't update the `updated_at` field in the user document which says when the document was updated latest. 

Not adding or updating tests, because we are just updating the `updated_at` field while updating the `user` document, and most of the API's do not return the `updated_at` field in the response.

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [x] Yes
- [ ] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [ ] Yes
- [x] No

<!--Confirmation of local testing during development-->


## Test Coverage
<summary>Screenshot 1</summary>
<img width="1109" alt="image" src="https://github.com/Real-Dev-Squad/website-backend/assets/55375534/f82b9452-9a3b-42cf-acb9-f6d39a1beba0">



<!-- Attach your screenshots here👇-->

</details>

<!--Attach Details on test coverage and outcomes-->

