### PR TITLE
2005 reimplement orphan tasks filteration logic

### DIFF
--- a/models/tasks.js
+++ b/models/tasks.js
@@ -9,8 +9,18 @@ const { chunks } = require("../utils/array");
 const { DOCUMENT_WRITE_SIZE } = require("../constants/constants");
 const { fromFirestoreData, toFirestoreData, buildTasks } = require("../utils/tasks");
 const { TASK_TYPE, TASK_STATUS, TASK_STATUS_OLD, TASK_SIZE } = require("../constants/tasks");
-const { IN_PROGRESS, NEEDS_REVIEW, IN_REVIEW, ASSIGNED, BLOCKED, SMOKE_TESTING, COMPLETED, SANITY_CHECK, BACKLOG } =
-  TASK_STATUS;
+const {
+  IN_PROGRESS,
+  NEEDS_REVIEW,
+  IN_REVIEW,
+  ASSIGNED,
+  BLOCKED,
+  SMOKE_TESTING,
+  COMPLETED,
+  SANITY_CHECK,
+  BACKLOG,
+  DONE,
+} = TASK_STATUS;
 const { OLD_ACTIVE, OLD_BLOCKED, OLD_PENDING, OLD_COMPLETED } = TASK_STATUS_OLD;
 const { INTERNAL_SERVER_ERROR } = require("../constants/errorMessages");
 
@@ -674,7 +684,7 @@ const markUnDoneTasksOfArchivedUsersBacklog = async (users) => {
     for (const user of users) {
       const tasksQuerySnapshot = await tasksModel
         .where("assigneeId", "==", user.id)
-        .where("status", "not-in", [COMPLETED, BACKLOG])
+        .where("status", "not-in", [COMPLETED, DONE, BACKLOG])
         .get();
       tasksQuerySnapshot.forEach(async (taskDoc) => {
         orphanTasksUpdatedCount++;

--- a/models/tasks.js
+++ b/models/tasks.js
@@ -667,6 +667,28 @@ const updateOrphanTasksStatus = async (lastOrphanTasksFilterationTimestamp) => {
   }
 };
 
+const markUnDoneTasksOfArchivedUsersBacklog = async (users) => {
+  try {
+    let orphanTasksUpdatedCount = 0;
+
+    for (const user of users) {
+      const tasksQuerySnapshot = await tasksModel
+        .where("assigneeId", "==", user.id)
+        .where("status", "not-in", [COMPLETED, BACKLOG])
+        .get();
+      tasksQuerySnapshot.forEach(async (taskDoc) => {
+        orphanTasksUpdatedCount++;
+        await tasksModel.doc(taskDoc.id).update({ status: BACKLOG, updated_at: Date.now() });
+      });
+    }
+
+    return orphanTasksUpdatedCount;
+  } catch (error) {
+    logger.error("Error marking tasks as backlog:", error);
+    throw error;
+  }
+};
+
 module.exports = {
   updateTask,
   fetchTasks,
@@ -685,4 +707,5 @@ module.exports = {
   getOverdueTasks,
   updateTaskStatus,
   updateOrphanTasksStatus,
+  markUnDoneTasksOfArchivedUsersBacklog,
 };

--- a/test/fixtures/discordResponse/discord-response.js
+++ b/test/fixtures/discordResponse/discord-response.js
@@ -135,6 +135,7 @@ const usersFromRds = [
       in_discord: false,
       archived: false,
     },
+    id: "nonArchivedAndNotInDiscord",
   },
 ];
 

--- a/test/integration/external-accounts.test.js
+++ b/test/integration/external-accounts.test.js
@@ -311,7 +311,6 @@ describe("External Accounts", function () {
       await userModel.add(usersFromRds[4]); // nonArchivedAndNotInDiscord
 
       const userId = usersFromRds[4].id;
-
       const task1 = {
         assigneeId: userId,
         status: "ACTIVE",

--- a/test/integration/external-accounts.test.js
+++ b/test/integration/external-accounts.test.js
@@ -15,6 +15,7 @@ const { INTERNAL_SERVER_ERROR } = require("../../constants/errorMessages");
 const firestore = require("../../utils/firestore");
 const userData = require("../fixtures/user/user")();
 const userModel = firestore.collection("users");
+const tasksModel = firestore.collection("tasks");
 const { EXTERNAL_ACCOUNTS_POST_ACTIONS } = require("../../constants/external-accounts");
 chai.use(chaiHttp);
 const cookieName = config.get("userToken.cookieName");
@@ -309,6 +310,22 @@ describe("External Accounts", function () {
     it("Should Archive Users With Archived as False and Not in RDS Discord Server", async function () {
       await userModel.add(usersFromRds[4]); // nonArchivedAndNotInDiscord
 
+      const userId = usersFromRds[4].id;
+
+      const task1 = {
+        assigneeId: userId,
+        status: "ACTIVE",
+      };
+      const task2 = {
+        assigneeId: userId,
+        status: "COMPLETED",
+      };
+      const task3 = {
+        assigneeId: userId,
+        status: "IN_PROGRESS",
+      };
+      await Promise.all([tasksModel.add(task1), tasksModel.add(task2), tasksModel.add(task3)]);
+
       fetchStub.returns(
         Promise.resolve({
           status: 200,
@@ -329,6 +346,7 @@ describe("External Accounts", function () {
         usersUnArchivedCount: 0,
         totalUsersProcessed: 2,
         rdsDiscordServerUsers: 3,
+        backlogTasksCount: 2,
       });
     });
 
@@ -354,6 +372,7 @@ describe("External Accounts", function () {
         usersUnArchivedCount: 0,
         totalUsersProcessed: 2,
         rdsDiscordServerUsers: 3,
+        backlogTasksCount: 0,
       });
     });
 
@@ -379,6 +398,7 @@ describe("External Accounts", function () {
         usersUnArchivedCount: 1,
         totalUsersProcessed: 2,
         rdsDiscordServerUsers: 3,
+        backlogTasksCount: 0,
       });
     });
 
@@ -404,6 +424,7 @@ describe("External Accounts", function () {
         usersUnArchivedCount: 0,
         totalUsersProcessed: 1,
         rdsDiscordServerUsers: 3,
+        backlogTasksCount: 0,
       });
     });
 


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 13/04/2024
<!--Developer Name Here-->
Developer Name: @MehulKChaudhari 

---

## Issue Ticket Number
- #2005 

## Description

Reimplement the logic to filter the orphan tasks, now we have a separate cron job and API to filter the orphan tasks but we should do it when we are marking user archived: true. 
we are reimplementing this so that we have data consistency, with the current implementation there might be a case where the user is archived earlier and their undone tasks are not marked BACKLOG till the next corn runs to filter the tasks. 

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [x] Yes
- [ ] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [ ] Yes
- [x] No

<!--Confirmation of local testing during development-->


<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<img width="1129" alt="image" src="https://github.com/Real-Dev-Squad/website-backend/assets/55375534/f40e2bb0-3a88-4876-a74a-fde3fc934314">

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

This is a re-implementation of - https://github.com/Real-Dev-Squad/website-backend/pull/1996
