### PR TITLE
Added middleware for extension request for /request route

### DIFF
--- a/constants/requests.ts
+++ b/constants/requests.ts
@@ -12,6 +12,7 @@ export const LOG_ACTION = {
 
 export const REQUEST_TYPE = {
   OOO: "OOO",
+  EXTENSION: "EXTENSION",
   ALL: "ALL",
 };
 

--- a/middlewares/validators/extensionRequestsv2.ts
+++ b/middlewares/validators/extensionRequestsv2.ts
@@ -1,0 +1,46 @@
+import joi from "joi";
+import { ExtensionRequestRequest, ExtensionRequestResponse } from "../../types/extensionRequests";
+import { NextFunction } from "express";
+import { REQUEST_TYPE,REQUEST_STATE } from "../../constants/requests";
+
+export const createExtensionRequestValidator = async (
+  req: ExtensionRequestRequest,
+  res: ExtensionRequestResponse,
+  next: NextFunction
+) => {
+
+  const schema = joi
+    .object()
+    .strict()
+    .keys({
+      taskId: joi.string().required().messages({
+        "string.empty": "taskId cannot be empty",
+        "any.required": "taskId is required",
+      }),
+      title: joi.string().required().messages({
+        "string.empty": "title cannot be empty",
+        "any.required": "title is required",
+      }),
+      oldEndsOn: joi.number().required().messages({
+        "number.base": "oldEndsOn must be a number",
+        "any.required": "oldEndsOn is required",
+      }),
+      newEndsOn: joi.number().required().min(joi.ref("oldEndsOn")).messages({
+        "number.base": "newEndsOn must be a number",
+        "any.required": "newEndsOn is required",
+      }),
+      message: joi.string().required().messages({
+        "string.empty": "message cannot be empty",
+      }),
+      state: joi.string().valid(REQUEST_STATE.PENDING).required().messages({
+        "string.empty": "state cannot be empty",
+        "any.required": "state is required",
+      }),
+      type: joi.string().valid(REQUEST_TYPE.EXTENSION).required().messages({
+        "string.empty": "type cannot be empty",
+        "any.required": "type is required",
+      }),
+    });
+
+  await schema.validateAsync(req.body, { abortEarly: false });
+};

--- a/middlewares/validators/requests.ts
+++ b/middlewares/validators/requests.ts
@@ -3,10 +3,13 @@ import { NextFunction } from "express";
 import { REQUEST_STATE, REQUEST_TYPE } from "../../constants/requests";
 import { OooRequestCreateRequest, OooRequestResponse, OooRequestUpdateRequest } from "../../types/oooRequest";
 import { createOooStatusRequestValidator, updateOooStatusRequestValidator } from "./oooRequests";
+import { createExtensionRequestValidator } from "./extensionRequestsv2";
+import { ExtensionRequestRequest, ExtensionRequestResponse } from "../../types/extensionRequests";
+import { CustomResponse } from "../../typeDefinitions/global";
 
 export const createRequestsMiddleware = async (
-  req: OooRequestCreateRequest,
-  res: OooRequestResponse,
+  req: OooRequestCreateRequest|ExtensionRequestRequest,
+  res: CustomResponse,
   next: NextFunction
 ) => {
   const type = req.body.type;
@@ -20,13 +23,16 @@ export const createRequestsMiddleware = async (
       case REQUEST_TYPE.OOO:
         await createOooStatusRequestValidator(req as OooRequestCreateRequest, res as OooRequestResponse, next);
         break;
+      case REQUEST_TYPE.EXTENSION:
+        await createExtensionRequestValidator(req as ExtensionRequestRequest, res as ExtensionRequestResponse, next);
+        break;
       default:
         res.boom.badRequest(`Invalid request type: ${type}`);
     }
 
     next();
   } catch (error) {
-    const errorMessages = error.details.map((detail) => detail.message);
+    const errorMessages = error.details.map((detail:any) => detail.message);
     logger.error(`Error while validating request payload : ${errorMessages}`);
     res.boom.badRequest(errorMessages);
   }

--- a/test/fixtures/extension-requests/extensionRequests.ts
+++ b/test/fixtures/extension-requests/extensionRequests.ts
@@ -1,0 +1,11 @@
+import { REQUEST_STATE, REQUEST_TYPE } from "../../../constants/requests";
+
+export const extensionCreateObject = {
+  taskId: "4XlEQ64H8puuLTrwIi93",
+  title: "Extension Request",
+  oldEndsOn: 1708674980000,
+  newEndsOn: 1709674980000,
+  message: "request message",
+  type: REQUEST_TYPE.EXTENSION,
+  state: REQUEST_STATE.PENDING,
+};

--- a/test/unit/middlewares/extensionRequests.test.ts
+++ b/test/unit/middlewares/extensionRequests.test.ts
@@ -1,0 +1,71 @@
+import chai from "chai";
+import sinon from "sinon";
+const { expect } = chai;
+
+import { createExtensionRequestValidator } from "../../../middlewares/validators/extensionRequestsv2";
+import { extensionCreateObject } from "../../fixtures/extension-requests/extensionRequests";
+import { REQUEST_STATE } from "../../../constants/requests";
+
+describe("Extension Request Validators", function () {
+    let req: any;
+    let res: any;
+    let nextSpy: any;
+
+    beforeEach(function () {
+        res = {
+            boom: {
+                badRequest: sinon.spy(),
+            },
+        };
+        nextSpy = sinon.spy();
+    });
+
+    describe("createExtensionRequestValidator", function () {
+        it("should validate for a valid create extension request", async function () {
+            req = {
+                body: extensionCreateObject,
+            };
+            res = {};
+            console.log("req", req);
+            const response = await createExtensionRequestValidator(req as any, res as any, nextSpy);
+            console.log("response", response);
+            expect(nextSpy.calledOnce);
+        });
+
+        it("should not validate for an invalid extension request on wrong type", async function () {
+            req = {
+                body: { ...extensionCreateObject, type: "ACTIVE" },
+            };
+            try {
+                await createExtensionRequestValidator(req as any, res as any, nextSpy);
+            } catch (error) {
+                expect(error).to.be.an.instanceOf(Error);
+                expect(error.details[0].message).to.equal(`"type" must be [EXTENSION]`);
+            }
+        });
+
+        it("should not validate for an invalid extension request on wrong status", async function () {
+            req = {
+                body: { ...extensionCreateObject, state: REQUEST_STATE.APPROVED },
+            };
+            try {
+                await createExtensionRequestValidator(req as any, res as any, nextSpy);
+            } catch (error) {
+                expect(error).to.be.an.instanceOf(Error);
+                expect(error.details[0].message).to.equal(`"state" must be [PENDING]`);
+            }
+        });
+
+        it("should not validate for an invalid extension request on missing taskId", async function () {
+            req = {
+                body: { ...extensionCreateObject, taskId: "" },
+            };
+            try {
+                await createExtensionRequestValidator(req as any, res as any, nextSpy);
+            } catch (error) {
+                expect(error).to.be.an.instanceOf(Error);
+                expect(error.details[0].message).to.equal(`"taskId cannot be empty`);
+            }
+        });
+    });
+});

--- a/test/unit/middlewares/extensionRequests.test.ts
+++ b/test/unit/middlewares/extensionRequests.test.ts
@@ -5,39 +5,28 @@ const { expect } = chai;
 import { createExtensionRequestValidator } from "../../../middlewares/validators/extensionRequestsv2";
 import { extensionCreateObject } from "../../fixtures/extension-requests/extensionRequests";
 import { REQUEST_STATE } from "../../../constants/requests";
+import { ExtensionRequestRequest, ExtensionRequestResponse } from "../../../types/extensionRequests";
 
 describe("Extension Request Validators", function () {
-    let req: any;
-    let res: any;
-    let nextSpy: any;
-
-    beforeEach(function () {
-        res = {
-            boom: {
-                badRequest: sinon.spy(),
-            },
-        };
-        nextSpy = sinon.spy();
-    });
-
     describe("createExtensionRequestValidator", function () {
         it("should validate for a valid create extension request", async function () {
-            req = {
+            const req = {
                 body: extensionCreateObject,
             };
-            res = {};
-            console.log("req", req);
-            const response = await createExtensionRequestValidator(req as any, res as any, nextSpy);
-            console.log("response", response);
+            const res = {};
+            const nextSpy = sinon.spy();
+            const response = await createExtensionRequestValidator(req as ExtensionRequestRequest, res as ExtensionRequestResponse, nextSpy);
             expect(nextSpy.calledOnce);
         });
 
         it("should not validate for an invalid extension request on wrong type", async function () {
-            req = {
+            const req = {
                 body: { ...extensionCreateObject, type: "ACTIVE" },
             };
+            const res = {};
+            const nextSpy = sinon.spy();
             try {
-                await createExtensionRequestValidator(req as any, res as any, nextSpy);
+                await createExtensionRequestValidator(req as ExtensionRequestRequest, res as ExtensionRequestResponse, nextSpy);
             } catch (error) {
                 expect(error).to.be.an.instanceOf(Error);
                 expect(error.details[0].message).to.equal(`"type" must be [EXTENSION]`);
@@ -45,11 +34,13 @@ describe("Extension Request Validators", function () {
         });
 
         it("should not validate for an invalid extension request on wrong status", async function () {
-            req = {
+            const req = {
                 body: { ...extensionCreateObject, state: REQUEST_STATE.APPROVED },
             };
+            const res = {};
+            const nextSpy = sinon.spy();
             try {
-                await createExtensionRequestValidator(req as any, res as any, nextSpy);
+                await createExtensionRequestValidator(req as ExtensionRequestRequest, res as ExtensionRequestResponse, nextSpy);
             } catch (error) {
                 expect(error).to.be.an.instanceOf(Error);
                 expect(error.details[0].message).to.equal(`"state" must be [PENDING]`);
@@ -57,11 +48,13 @@ describe("Extension Request Validators", function () {
         });
 
         it("should not validate for an invalid extension request on missing taskId", async function () {
-            req = {
+            const req = {
                 body: { ...extensionCreateObject, taskId: "" },
             };
+            const res = {};
+            const nextSpy = sinon.spy();
             try {
-                await createExtensionRequestValidator(req as any, res as any, nextSpy);
+                await createExtensionRequestValidator(req as ExtensionRequestRequest, res as ExtensionRequestResponse, nextSpy);
             } catch (error) {
                 expect(error).to.be.an.instanceOf(Error);
                 expect(error.details[0].message).to.equal(`taskId cannot be empty`);

--- a/test/unit/middlewares/extensionRequests.test.ts
+++ b/test/unit/middlewares/extensionRequests.test.ts
@@ -64,7 +64,7 @@ describe("Extension Request Validators", function () {
                 await createExtensionRequestValidator(req as any, res as any, nextSpy);
             } catch (error) {
                 expect(error).to.be.an.instanceOf(Error);
-                expect(error.details[0].message).to.equal(`"taskId cannot be empty`);
+                expect(error.details[0].message).to.equal(`taskId cannot be empty`);
             }
         });
     });

--- a/typeDefinitions/global.d.ts
+++ b/typeDefinitions/global.d.ts
@@ -9,6 +9,7 @@ export type UserData = {
     archived: boolean;
     in_discord: boolean;
     member: boolean;
+    super_user: boolean;
   };
   profileStatus: string;
   created_at: number;

--- a/types/extensionRequests.d.ts
+++ b/types/extensionRequests.d.ts
@@ -1,0 +1,65 @@
+import { Request, Response } from "express";
+import { Boom } from "express-boom";
+import { REQUEST_STATE, REQUEST_TYPE } from "../constants/requests";
+
+export type ExtensionRequest = {
+    id: string;
+    type: REQUEST_TYPE.EXTENSION;
+    taskId: string;
+    title: string;
+    oldEndsOn: number;
+    newEndsOn: number;
+    message?: string;
+    requestedBy?: string;
+    state?: REQUEST_STATE;
+    lastModifiedBy?: string;
+    reason?: string;
+    createdAt?: Timestamp;
+    updatedAt?: Timestamp;
+    requestNumber?: number;
+};
+
+export type ExtensionRequestCreateBody = {
+    type: REQUEST_TYPE.EXTENSION;
+    taskId: string;
+    title: string;
+    message?: string;
+    requestedBy?: string;
+    oldEndsOn: number;
+    newEndsOn: number;
+    state: REQUEST_STATE.PENDING;
+    requestNumber?: number;
+    assignee?: string;
+};
+
+export type ExtensionRequestUpdateBody = {
+    lastModifiedBy?: string;
+    type?: REQUEST_TYPE.EXTENSION;
+    id?: string;
+    reason?: string;
+    state: REQUEST_STATE.APPROVED | REQUEST_STATE.REJECTED;
+};
+
+export type userData = {
+    id: string;
+};
+
+export type RequestQuery = {
+    dev?: string;
+    type?: string;
+    requestedBy?: string;
+    state?: REQUEST_STATE.APPROVED | REQUEST_STATE.PENDING | REQUEST_STATE.REJECTED;
+    id?: string;
+    prev?: string;
+    next?: string;
+    page?: number;
+    size?: number;
+};
+
+export type ExtensionRequestResponse = Response & { Boom: Boom };
+export type ExtensionRequestRequest = Request & {
+    ExtensionRequestCreateBody: ExtensionRequestCreateBody;
+    userData: userData;
+    query: RequestQuery;
+    Boom: Boom;
+};


### PR DESCRIPTION
## Issue Ticket Number

- #2019

## Description

In the PR, a new middleware was added to create extension requests through the request router. This middleware will facilitate the creation of extension requests for the user.

### Documentation Updated?

- [ ] Yes
- [x] No

### Under Feature Flag

- [x] Yes
- [ ] No

### Database Changes

- [ ] Yes
- [x] No

### Breaking Changes

- [ ] Yes
- [x] No

### Development Tested?

- [x] Yes
- [ ] No

## Screenshots
<details>
<summary>Screenshot 1</summary>

![image](https://github.com/Real-Dev-Squad/website-backend/assets/70854507/9e3036f7-7bb0-4a0d-9c83-9acdf7bbbf30)

![image](https://github.com/Real-Dev-Squad/website-backend/assets/70854507/8bb5cedd-45b1-4922-99f0-5be4da4a7251)


</details>

## Test Coverage

| File                        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s |
|-----------------------------|---------|----------|---------|---------|-------------------|
| extensionRequestsv2.ts      |   100   |   100    |   100   |   100   |                   |
| requests.ts                 | 87.75   | 44.44    |   100   | 85.71   | 18,27-30,50,59    |

## Additional Notes

In the next PR, a controller will be added to handle the extension request creation.
