### PR TITLE
add: one-time script to filter unfinished tasks from archived users.

### DIFF
--- a/controllers/tasks.js
+++ b/controllers/tasks.js
@@ -491,9 +491,7 @@ const updateStatus = async (req, res) => {
 
 const orphanTasks = async (req, res) => {
   try {
-    const { lastOrphanTasksFilterationTimestamp = 0 } = req.body;
-
-    const updatedTasksData = await tasks.updateOrphanTasksStatus(lastOrphanTasksFilterationTimestamp);
+    const updatedTasksData = await tasks.updateOrphanTasksStatus();
 
     return res.status(200).json({ message: "Orphan tasks filtered successfully", updatedTasksData });
   } catch (error) {

--- a/routes/tasks.js
+++ b/routes/tasks.js
@@ -8,7 +8,6 @@ const {
   updateSelfTask,
   getTasksValidator,
   getUsersValidator,
-  filterOrphanTasksValidator,
 } = require("../middlewares/validators/tasks");
 const authorizeRoles = require("../middlewares/authorizeRoles");
 const { authorizeAndAuthenticate } = require("../middlewares/authorizeUsersAndService");
@@ -68,6 +67,6 @@ router.patch("/assign/self", authenticate, invalidateCache({ invalidationKeys: [
 router.get("/users/discord", verifyCronJob, getUsersValidator, tasks.getUsersHandler);
 
 router.post("/migration", authenticate, authorizeRoles([SUPERUSER]), tasks.updateStatus);
-router.post("/orphanTasks", verifyCronJob, filterOrphanTasksValidator, tasks.orphanTasks);
+router.post("/orphanTasks", authenticate, authorizeRoles([SUPERUSER]), tasks.orphanTasks);
 
 module.exports = router;

--- a/test/integration/tasks.test.js
+++ b/test/integration/tasks.test.js
@@ -1541,41 +1541,41 @@ describe("Tasks", function () {
   });
 
   describe("POST /tasks/orphanTasks", function () {
-    let jwtToken;
-
     beforeEach(async function () {
+      const superUserId = await addUser(superUser);
+      superUserJwt = authService.generateAuthToken({ userId: superUserId });
       const user1 = userData[6];
       user1.roles.in_discord = false;
       user1.updated_at = 1712053284000;
       const user2 = userData[18];
-      user2.updated_at = 1712064084000;
+      user2.roles.in_discord = false;
       const [{ id: userId }, { id: userId2 }] = await Promise.all([userDBModel.add(user1), userDBModel.add(user2)]);
 
       const task1 = {
-        assigneeId: userId,
+        assignee: userId,
         status: "ACTIVE",
       };
       const task2 = {
-        assigneeId: userId2,
+        assignee: userId2,
         status: "COMPLETED",
       };
       const task3 = {
-        assigneeId: userId2,
+        assignee: userId2,
         status: "IN_PROGRESS",
       };
-      await Promise.all([tasksModel.add(task1), tasksModel.add(task2), tasksModel.add(task3)]);
-
-      jwtToken = generateCronJobToken({ name: CRON_JOB_HANDLER });
+      const task4 = {
+        assignee: userId,
+        status: "DONE",
+      };
+      await Promise.all([tasksModel.add(task1), tasksModel.add(task2), tasksModel.add(task3), tasksModel.add(task4)]);
     });
 
     afterEach(async function () {
       await cleanDb();
     });
-    it("Should update status of orphan tasks to BACKLOG", async function () {
-      const res = await chai.request(app).post("/tasks/orphanTasks").set("Authorization", `Bearer ${jwtToken}`).send({
-        lastOrphanTasksFilterationTimestamp: 1712040715000,
-      });
 
+    it("Should update status of orphan tasks to BACKLOG", async function () {
+      const res = await chai.request(app).post("/tasks/orphanTasks").set("cookie", `${cookieName}=${superUserJwt}`);
       expect(res).to.have.status(200);
       expect(res.body).to.deep.equal({
         message: "Orphan tasks filtered successfully",
@@ -1583,24 +1583,18 @@ describe("Tasks", function () {
           orphanTasksUpdatedCount: 2,
         },
       });
-    }).timeout(10000);
+    });
 
-    it("Should return 400 if not cron worker", async function () {
+    it("Should return 400 if not super user", async function () {
       const nonSuperUserId = await addUser(appOwner);
       const nonSuperUserJwt = authService.generateAuthToken({ userId: nonSuperUserId });
-      const res = await chai
-        .request(app)
-        .post("/tasks/orphanTasks")
-        .set("Authorization", `Bearer ${nonSuperUserJwt}`)
-        .send({
-          lastOrphanTasksFilterationTimestamp: 1712040715000,
-        });
+      const res = await chai.request(app).post("/tasks/orphanTasks").set("Authorization", `Bearer ${nonSuperUserJwt}`);
 
-      expect(res).to.have.status(400);
+      expect(res).to.have.status(401);
       expect(res.body).to.deep.equal({
-        statusCode: 400,
-        error: "Bad Request",
-        message: "Unauthorized Cron Worker",
+        statusCode: 401,
+        error: "Unauthorized",
+        message: "You are not authorized for this action.",
       });
     });
   });


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 13/may/2024
<!--Developer Name Here-->
Developer Name: @MehulKChaudhari 

---

## Issue Ticket Number
- https://github.com/Real-Dev-Squad/todo-action-items/issues/215

## Description
We run a cron job every 6 hours to filter the orphan tasks and mark them `BACKLOG` but we don't have tasks filtered from users who left before this cron job was developed, So we need to run this script once to filter tasks from these users. 

### Documentation Updated?

- [ ] Yes
- [ ] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [ ] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [ ] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [ ] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [ ] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Test Coverage
<img width="1244" alt="image" src="https://github.com/Real-Dev-Squad/website-backend/assets/55375534/f8addf92-cb62-4abb-865c-a42e945bc3f8">



<!--Attach Details on test coverage and outcomes-->

## Additional Notes

I have edited the old implementation of orphan tasks filtration to make a one time script. Later on will raise a PR to remove it completely 
