### PR TITLE
add roles query param in /users api to get all members

### DIFF
--- a/controllers/users.js
+++ b/controllers/users.js
@@ -111,6 +111,22 @@ const getUsers = async (req, res) => {
         user,
       });
     }
+
+    /**
+     * !!NOTE: At the time of writing we are only supporting the member role
+     * this will be fixed in the new onboarding flow, contact @tejaskh3 for more info
+     *
+     * if you're making changes to this code remove the role === 'member' check from middleware/validators/user.js
+     */
+    if (req.query.roles === "member") {
+      const data = await dataAccess.retrieveUsers({ query: req.query });
+
+      return res.json({
+        message: "members returned successfully!",
+        users: data.users,
+      });
+    }
+
     if (!transformedQuery?.days && transformedQuery?.filterBy === "unmerged_prs") {
       return res.boom.badRequest(`Days is required for filterBy ${transformedQuery?.filterBy}`);
     }
@@ -919,6 +935,16 @@ async function usersPatchHandler(req, res) {
   }
 }
 
+async function addMembersRole(params) {
+  try {
+    const data = await userQuery.batchUpdateAllUsersRoles();
+    return data;
+  } catch (error) {
+    logger.error(`Error while updating all users roles: ${error}`);
+    throw Error(INTERNAL_SERVER_ERROR);
+  }
+}
+
 module.exports = {
   verifyUser,
   generateChaincode,
@@ -949,4 +975,5 @@ module.exports = {
   archiveUserIfNotInDiscord,
   usersPatchHandler,
   isDeveloper,
+  addMembersRole,
 };

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -112,21 +112,6 @@ const getUsers = async (req, res) => {
       });
     }
 
-    /**
-     * !!NOTE: At the time of writing we are only supporting the member role
-     * this will be fixed in the new onboarding flow, contact @tejaskh3 for more info
-     *
-     * if you're making changes to this code remove the role === 'member' check from middleware/validators/user.js
-     */
-    if (req.query.roles === "member") {
-      const data = await dataAccess.retrieveUsers({ query: req.query });
-
-      return res.json({
-        message: "members returned successfully!",
-        users: data.users,
-      });
-    }
-
     if (!transformedQuery?.days && transformedQuery?.filterBy === "unmerged_prs") {
       return res.boom.badRequest(`Days is required for filterBy ${transformedQuery?.filterBy}`);
     }

--- a/middlewares/validators/user.js
+++ b/middlewares/validators/user.js
@@ -190,6 +190,13 @@ async function getUsers(req, res, next) {
       filterBy: joi.string().optional(),
       days: joi.string().optional(),
       dev: joi.string().optional(),
+      roles: joi.optional().custom((value, helpers) => {
+        if (value !== "member") {
+          return helpers.message("only member role is supported");
+        }
+
+        return value;
+      }),
     });
   try {
     await schema.validateAsync(req.query);

--- a/models/users.js
+++ b/models/users.js
@@ -169,7 +169,19 @@ const fetchPaginatedUsers = async (query) => {
     const size = parseInt(query.size) || 100;
     const doc = (query.next || query.prev) && (await userModel.doc(query.next || query.prev).get());
 
-    let dbQuery = userModel.where("roles.archived", "==", false).orderBy("username");
+    let dbQuery;
+    /**
+     * !!NOTE : At the time of writing we only support member in the role query
+     * this will get fixed with the new onboarding flow, contact @tejaskh3 for more info
+     *
+     * if you're making changes to this code remove the archived check in the role query, example: role=archived,member
+     */
+    if (query.roles === "member") {
+      dbQuery = userModel.where("roles.archived", "==", false).where("roles.member", "==", true);
+    } else {
+      dbQuery = userModel.where("roles.archived", "==", false).orderBy("username");
+    }
+
     let compositeQuery = [dbQuery];
     if (isDevMode) {
       const usernameQuery = userModel.where("roles.archived", "==", false).orderBy("username");


### PR DESCRIPTION
### Date: 17th August 2024
### Developer Name: Yash Raj

## Issue Ticket Number
- https://github.com/Real-Dev-Squad/members-site/issues/152

## Description
- Add the `roles` query parameter to the `/users` API to filter users data.
    - currently, the roles query param only accepts the `members` role, it will be fixed with the new onboarding flow that @tejaskh3 is working on. 

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [x] Yes
- [ ] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No