### PR TITLE
Fix/allow users to view their own application status data

### DIFF
--- a/controllers/users.js
+++ b/controllers/users.js
@@ -720,7 +720,7 @@ const addUserIntro = async (req, res) => {
   }
 };
 
-const getUserIntro = async (req, res) => {
+/* const getUserIntro = async (req, res) => {
   try {
     const data = await userQuery.getJoinData(req.params.userId);
     if (data.length) {
@@ -728,6 +728,33 @@ const getUserIntro = async (req, res) => {
         message: "User data returned",
         data: data,
       });
+    } else {
+      return res.status(404).json({
+        message: "Data Not Found",
+      });
+    }
+  } catch (err) {
+    logger.error("Could Not Get User Data", err);
+    return res.boom.badImplementation(INTERNAL_SERVER_ERROR);
+  }
+}; */
+const getUserIntro = async (req, res) => {
+  try {
+    const { userId } = req.params;
+    const loggedInUserId = req.userData.id;
+    const data = await userQuery.getJoinData(userId);
+
+    if (data.length) {
+      if (userId === loggedInUserId || req.userData.roles.super_user) {
+        return res.json({
+          message: "User data returned",
+          data: data,
+        });
+      } else {
+        return res.status(403).json({
+          message: "You're not authorized to view this page",
+        });
+      }
     } else {
       return res.status(404).json({
         message: "Data Not Found",

--- a/routes/users.js
+++ b/routes/users.js
@@ -33,7 +33,7 @@ router.patch(
   users.updateDiscordUserNickname
 );
 router.get("/:username", users.getUser);
-router.get("/:userId/intro", authenticate, authorizeRoles([SUPERUSER]), users.getUserIntro);
+router.get("/:userId/intro", authenticate, users.getUserIntro);
 router.put("/self/intro", authenticate, userValidator.validateJoinData, users.addUserIntro);
 router.get("/:id/skills", users.getUserSkills);
 router.get("/:id/badges", getUserBadges);


### PR DESCRIPTION


<!-- Date Here in dd mmm yyyy-->
Date: `19th August, 2024`
<!--Developer Name Here-->
Developer Name: @Achintya-Chatterjee 

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->

## Description
This PR updates the backend authorization logic for accessing user intro data
-  Users can now view their own application status without requiring superuser privileges.
- Superusers can still access the intro data of any user.
- Proper handling of unauthorized access with a 403 status code.
- Maintains the existing 404 response if no data is found.
<!--Description of the changes made in this PR-->

### Documentation Updated?

- [ ] Yes
- [ ] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [ ] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [ ] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [ ] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [ ] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
