### PR TITLE
fixed getUserApplications to-fetch-latest-application

### DIFF
--- a/models/applications.ts
+++ b/models/applications.ts
@@ -141,7 +141,9 @@ const getApplicationsBasedOnStatus = async (status: string, limit: number, lastD
 const getUserApplications = async (userId: string) => {
   try {
     const applicationsResult = [];
-    const applications = await ApplicationsModel.where("userId", "==", userId).get();
+    const applications = await ApplicationsModel.where("userId", "==", userId)
+    .orderBy("createdAt", "desc")
+    .get();
 
     applications.forEach((application) => {
       applicationsResult.push({
@@ -149,7 +151,7 @@ const getUserApplications = async (userId: string) => {
         ...application.data(),
       });
     });
-    return applicationsResult;
+    return applicationsResult[0];
   } catch (err) {
     logger.log("error in getting user intro", err);
     throw err;

--- a/models/applications.ts
+++ b/models/applications.ts
@@ -143,6 +143,7 @@ const getUserApplications = async (userId: string) => {
     const applicationsResult = [];
     const applications = await ApplicationsModel.where("userId", "==", userId)
     .orderBy("createdAt", "desc")
+    .limit(1)
     .get();
 
     applications.forEach((application) => {
@@ -151,7 +152,8 @@ const getUserApplications = async (userId: string) => {
         ...application.data(),
       });
     });
-    return applicationsResult[0];
+    
+    return applicationsResult;
   } catch (err) {
     logger.log("error in getting user intro", err);
     throw err;

--- a/test/unit/models/application.test.ts
+++ b/test/unit/models/application.test.ts
@@ -48,7 +48,7 @@ describe("applications", function () {
   });
 
   describe("getUserApplications", function () {
-    it("should return all the user applications", async function () {
+    it("should return users most recent application", async function () {
       const applications = await ApplicationModel.getUserApplications("kfasdjfkdlfjkasdjflsdjfk");
       expect(applications).to.be.a("array");
       expect(applications.length).to.be.equal(1);


### PR DESCRIPTION
Date: `23rd August, 2024`
Developer Name:  @Favourokerri 
---

## Issue Ticket Number
- Closes #2093
<!--Issue ticket this PR closes-->

## Description
This pull request enhances the getUserApplications query by sorting the user's applications in descending order based on their creation date (createdAt). The query now ensures that the most recently created application appears first in the list. Additionally, only the first application in the sorted array is returned, making it easier to display the user's most recent application

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

![image](https://github.com/user-attachments/assets/19052f33-1eed-41e6-a001-1dcbeb3fbf89)
![image](https://github.com/user-attachments/assets/43c69211-3e78-4fd3-ae6c-ff1fae3ea3c3)

Only the first and most recent application is returned
</details>

## Test Coverage
<details>
<summary>Screenshot 2</summary>

![Test Coverage Screenshot](https://github.com/user-attachments/assets/5ab7d9ad-5391-4a8d-98a1-a77a87736f6c)

</details>
</details>
