### PR TITLE
Hotfix to extend date to generate discord link

### DIFF
--- a/middlewares/checkCanGenerateDiscordLink.ts
+++ b/middlewares/checkCanGenerateDiscordLink.ts
@@ -34,7 +34,7 @@ const checkCanGenerateDiscordLink = async (req: CustomRequest, res: CustomRespon
       return res.boom.forbidden("Only users with an approved application can generate a Discord invite link.");
     }
 
-    // return next();
+    return next();
   } catch (error) {
     return res.boom.badImplementation("An error occurred while checking user applications.");
   }

--- a/middlewares/checkCanGenerateDiscordLink.ts
+++ b/middlewares/checkCanGenerateDiscordLink.ts
@@ -7,11 +7,11 @@ const checkCanGenerateDiscordLink = async (req: CustomRequest, res: CustomRespon
   const isSuperUser = roles.super_user;
   const userIdInQuery = req.query.userId;
   const currentTime = Date.now();
-  const cutoffTime = 1724630399000;  // Epoch time for 25 August 2024
+  const cutoffTime = 1725147849000;  // Todo will remove this Hotfix time for 31 August 2024
 
-  if (isSuperUser) {
-    return next();
-  }
+  // if (isSuperUser) {
+  //   return next();
+  // }
 
   if (userIdInQuery && userIdInQuery !== userId && !isSuperUser) {
     return res.boom.forbidden("User should be super user to generate link for other users");
@@ -34,7 +34,7 @@ const checkCanGenerateDiscordLink = async (req: CustomRequest, res: CustomRespon
       return res.boom.forbidden("Only users with an approved application can generate a Discord invite link.");
     }
 
-    return next();
+    // return next();
   } catch (error) {
     return res.boom.badImplementation("An error occurred while checking user applications.");
   }

--- a/middlewares/checkCanGenerateDiscordLink.ts
+++ b/middlewares/checkCanGenerateDiscordLink.ts
@@ -9,9 +9,9 @@ const checkCanGenerateDiscordLink = async (req: CustomRequest, res: CustomRespon
   const currentTime = Date.now();
   const cutoffTime = 1725147849000;  // Todo will remove this Hotfix time for 31 August 2024
 
-  // if (isSuperUser) {
-  //   return next();
-  // }
+  if (isSuperUser) {
+    return next();
+  }
 
   if (userIdInQuery && userIdInQuery !== userId && !isSuperUser) {
     return res.boom.forbidden("User should be super user to generate link for other users");

--- a/test/integration/discordactions.test.js
+++ b/test/integration/discordactions.test.js
@@ -784,7 +784,7 @@ describe("Discord actions", function () {
     let clock;
 
     beforeEach(function () {
-      clock = sinon.useFakeTimers(new Date("2024-08-24").getTime());
+      clock = sinon.useFakeTimers(new Date("2024-08-31").getTime());
     });
 
     afterEach(function () {
@@ -904,7 +904,7 @@ describe("Discord actions", function () {
     });
 
     it("should return 403 if current date is after 25 August 2024", async function () {
-      clock.tick(2 * 24 * 60 * 60 * 1000); // Move time forward to after 25 August 2024
+      clock.tick(2 * 24 * 60 * 60 * 1000); // Move time forward to after 31 August 2024
       sinon.stub(ApplicationModel, "getUserApplications").resolves([{ status: "accepted" }]);
 
       const res = await chai


### PR DESCRIPTION
## Issue Ticket Number
- closes #2102 

## Description

Make a change for discord verification middleware to allow to generate link till 31 August 2024.

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
![Screenshot_92](https://github.com/user-attachments/assets/72e76d0a-8e2e-49e1-9b15-15779a531a78)

