### PR TITLE
[Feat] Extends Toggle privilege feature allowing other roles to be Toggled off

### DIFF
--- a/controllers/users.js
+++ b/controllers/users.js
@@ -411,20 +411,25 @@ const updateSelf = async (req, res) => {
     }
 
     if (req.body.disabled_roles) {
-      let roles = [...req.body.disabled_roles];
+      let rolesToDisable;
+      const data = req.body.disabled_roles;
+
       if (user.disabled_roles !== undefined) {
-        roles = [...user.disabled_roles];
-        req.body.disabled_roles.forEach((role) => {
-          if (user.disabled_roles.includes(role)) {
-            const index = roles.indexOf(role);
-            roles.splice(index, 1);
+        rolesToDisable = user.disabled_roles;
+
+        data.forEach((role) => {
+          const roleIndex = rolesToDisable.indexOf(role);
+          if (roleIndex !== -1) {
+            rolesToDisable.splice(roleIndex, 1);
           } else {
-            roles.push(role);
+            rolesToDisable.push(role);
           }
         });
+      } else {
+        rolesToDisable = data;
       }
 
-      const updatedUser = await userQuery.addOrUpdate({ disabled_roles: roles }, userId);
+      const updatedUser = await userQuery.addOrUpdate({ disabled_roles: rolesToDisable }, userId);
       if (updatedUser) {
         return res.status(200).send({ message: "Privilege modified successfully!" });
       }

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -410,10 +410,10 @@ const updateSelf = async (req, res) => {
       }
     }
 
-    if (req.body.revoked_roles) {
+    if (req.body.disabled_roles) {
       // filter roles which are 'true'
-      const revokableRoles = req.body.revoked_roles.filter((role) => user.roles[`${role}`] === true);
-      const updatedUser = await userQuery.addOrUpdate({ revoked_roles: revokableRoles }, userId);
+      const toggleableRoles = req.body.disabled_roles.filter((role) => user.roles[`${role}`] === true);
+      const updatedUser = await userQuery.addOrUpdate({ disabled_roles: toggleableRoles }, userId);
       if (updatedUser) {
         return res.status(200).send({ message: "Privilege modified successfully!" });
       }

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -415,7 +415,7 @@ const updateSelf = async (req, res) => {
       const revokableRoles = req.body.revoked_roles.filter((role) => user.roles[`${role}`] === true);
       const updatedUser = await userQuery.addOrUpdate({ revoked_roles: revokableRoles }, userId);
       if (updatedUser) {
-        return res.status(200).send({ message: "privilege modified successfully!", revoked_roles: revokableRoles });
+        return res.status(200).send({ message: "Privilege modified successfully!" });
       }
     }
 

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -411,9 +411,20 @@ const updateSelf = async (req, res) => {
     }
 
     if (req.body.disabled_roles) {
-      // filter roles which are 'true'
-      const toggleableRoles = req.body.disabled_roles.filter((role) => user.roles[`${role}`] === true);
-      const updatedUser = await userQuery.addOrUpdate({ disabled_roles: toggleableRoles }, userId);
+      let roles = [...req.body.disabled_roles];
+      if (user.disabled_roles !== undefined) {
+        roles = [...user.disabled_roles];
+        req.body.disabled_roles.forEach((role) => {
+          if (user.disabled_roles.includes(role)) {
+            const index = roles.indexOf(role);
+            roles.splice(index, 1);
+          } else {
+            roles.push(role);
+          }
+        });
+      }
+
+      const updatedUser = await userQuery.addOrUpdate({ disabled_roles: roles }, userId);
       if (updatedUser) {
         return res.status(200).send({ message: "Privilege modified successfully!" });
       }

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -410,6 +410,15 @@ const updateSelf = async (req, res) => {
       }
     }
 
+    if (req.body.revoked_roles) {
+      // filter roles which are 'true'
+      const revokableRoles = req.body.revoked_roles.filter((role) => user.roles[`${role}`] === true);
+      const updatedUser = await userQuery.addOrUpdate({ revoked_roles: revokableRoles }, userId);
+      if (updatedUser) {
+        return res.status(200).send({ message: "privilege modified successfully!", revoked_roles: revokableRoles });
+      }
+    }
+
     if (userRoles.in_discord && !user.incompleteUserDetails) {
       const membersInDiscord = await getDiscordMembers();
       const discordMember = membersInDiscord.find((member) => member.user.id === discordId);

--- a/middlewares/validators/user.js
+++ b/middlewares/validators/user.js
@@ -51,7 +51,7 @@ const updateUser = async (req, res, next) => {
         .valid(...Object.values(USER_STATUS))
         .optional(),
       discordId: joi.string().optional(),
-      revoked_roles: joi.array().items(joi.string().valid("super_user", "member")).optional(),
+      disabled_roles: joi.array().items(joi.string().valid("super_user", "member")).optional(),
       roles: joi.object().keys({
         designer: joi.boolean().optional(),
         maven: joi.boolean().optional(),

--- a/middlewares/validators/user.js
+++ b/middlewares/validators/user.js
@@ -51,7 +51,7 @@ const updateUser = async (req, res, next) => {
         .valid(...Object.values(USER_STATUS))
         .optional(),
       discordId: joi.string().optional(),
-      revoked_roles: joi.array().items(joi.string().valid("super_user", "members")).optional(),
+      revoked_roles: joi.array().items(joi.string().valid("super_user", "member")).optional(),
       roles: joi.object().keys({
         designer: joi.boolean().optional(),
         maven: joi.boolean().optional(),

--- a/middlewares/validators/user.js
+++ b/middlewares/validators/user.js
@@ -51,7 +51,7 @@ const updateUser = async (req, res, next) => {
         .valid(...Object.values(USER_STATUS))
         .optional(),
       discordId: joi.string().optional(),
-      disabled_roles: joi.array().items(joi.string().valid("super_user", "member")).optional(),
+      disabledRoles: joi.array().items(joi.string().valid("super_user", "member")).optional(),
       roles: joi.object().keys({
         designer: joi.boolean().optional(),
         maven: joi.boolean().optional(),

--- a/middlewares/validators/user.js
+++ b/middlewares/validators/user.js
@@ -51,6 +51,7 @@ const updateUser = async (req, res, next) => {
         .valid(...Object.values(USER_STATUS))
         .optional(),
       discordId: joi.string().optional(),
+      revoked_roles: joi.array().items(joi.string().valid("super_user", "members")).optional(),
       roles: joi.object().keys({
         designer: joi.boolean().optional(),
         maven: joi.boolean().optional(),

--- a/models/users.js
+++ b/models/users.js
@@ -319,12 +319,10 @@ const fetchUser = async ({ userId = null, username = null, githubUsername = null
     }
 
     if (userData && userData.disabled_roles !== undefined) {
-      const updatedRoles = userData.roles;
-      if (userData.disabled_roles.length > 0) {
+      if (userData.disabled_roles.length > 0 && userData.roles !== undefined) {
         for (const role of userData.disabled_roles) {
-          updatedRoles[`${role}`] = false;
+          userData.roles[`${role}`] = false;
         }
-        userData.roles = updatedRoles;
       }
     }
     return {

--- a/models/users.js
+++ b/models/users.js
@@ -317,6 +317,16 @@ const fetchUser = async ({ userId = null, username = null, githubUsername = null
         userData = doc.data();
       });
     }
+
+    if (userData && userData.revoked_roles !== undefined) {
+      const updatedRoles = { ...userData.roles };
+      if (userData.revoked_roles.length > 0) {
+        for (const role of userData.revoked_roles) {
+          updatedRoles[`${role}`] = false;
+        }
+        userData.roles = updatedRoles;
+      }
+    }
     return {
       userExists: !!userData,
       user: {

--- a/models/users.js
+++ b/models/users.js
@@ -319,7 +319,7 @@ const fetchUser = async ({ userId = null, username = null, githubUsername = null
     }
 
     if (userData && userData.disabled_roles !== undefined) {
-      const updatedRoles = { ...userData.roles };
+      const updatedRoles = userData.roles;
       if (userData.disabled_roles.length > 0) {
         for (const role of userData.disabled_roles) {
           updatedRoles[`${role}`] = false;

--- a/models/users.js
+++ b/models/users.js
@@ -318,10 +318,10 @@ const fetchUser = async ({ userId = null, username = null, githubUsername = null
       });
     }
 
-    if (userData && userData.revoked_roles !== undefined) {
+    if (userData && userData.disabled_roles !== undefined) {
       const updatedRoles = { ...userData.roles };
-      if (userData.revoked_roles.length > 0) {
-        for (const role of userData.revoked_roles) {
+      if (userData.disabled_roles.length > 0) {
+        for (const role of userData.disabled_roles) {
           updatedRoles[`${role}`] = false;
         }
         userData.roles = updatedRoles;

--- a/test/integration/users.test.js
+++ b/test/integration/users.test.js
@@ -488,13 +488,13 @@ describe("Users", function () {
         });
     });
 
-    it("Should return 200 when revoked_roles is being set to [super_user] in userObject ", function (done) {
+    it("Should return 200 when disabled_roles is being set to [super_user] in userObject ", function (done) {
       chai
         .request(app)
         .patch("/users/self")
         .set("cookie", `${cookieName}=${jwt}`)
         .send({
-          revoked_roles: ["super_user"],
+          disabled_roles: ["super_user"],
         })
         .end((err, res) => {
           if (err) {
@@ -511,13 +511,13 @@ describe("Users", function () {
         });
     });
 
-    it("Should return 200 when revoked_roles is being set to [super_user, member] in userObject", function (done) {
+    it("Should return 200 when disabled_roles is being set to [super_user, member] in userObject", function (done) {
       chai
         .request(app)
         .patch("/users/self")
         .set("cookie", `${cookieName}=${jwt}`)
         .send({
-          revoked_roles: ["super_user", "member"],
+          disabled_roles: ["super_user", "member"],
         })
         .end((err, res) => {
           if (err) {
@@ -534,13 +534,13 @@ describe("Users", function () {
         });
     });
 
-    it("Should return 200 when revoked_roles is being set to [], member in userObject", function (done) {
+    it("Should return 200 when disabled_roles is being set to [], member in userObject", function (done) {
       chai
         .request(app)
         .patch("/users/self")
         .set("cookie", `${cookieName}=${jwt}`)
         .send({
-          revoked_roles: [],
+          disabled_roles: [],
         })
         .end((err, res) => {
           if (err) {
@@ -557,13 +557,13 @@ describe("Users", function () {
         });
     });
 
-    it("Should return 400 when revoked_roles is being set to ['admin'], member in userObject", function (done) {
+    it("Should return 400 when disabled_roles is being set to ['admin'], member in userObject", function (done) {
       chai
         .request(app)
         .patch("/users/self")
         .set("cookie", `${cookieName}=${jwt}`)
         .send({
-          revoked_roles: ["admin"],
+          disabled_roles: ["admin"],
         })
         .end((err, res) => {
           if (err) {
@@ -575,7 +575,7 @@ describe("Users", function () {
           expect(res.body).to.eql({
             statusCode: 400,
             error: "Bad Request",
-            message: '"revoked_roles[0]" must be one of [super_user, member]',
+            message: '"disabled_roles[0]" must be one of [super_user, member]',
           });
 
           return done();

--- a/test/integration/users.test.js
+++ b/test/integration/users.test.js
@@ -487,6 +487,100 @@ describe("Users", function () {
           return done();
         });
     });
+
+    it("Should return 200 when revoked_roles is being set to [super_user] in userObject ", function (done) {
+      chai
+        .request(app)
+        .patch("/users/self")
+        .set("cookie", `${cookieName}=${jwt}`)
+        .send({
+          revoked_roles: ["super_user"],
+        })
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          expect(res).to.have.status(200);
+          expect(res.body).to.be.an("object");
+          expect(res.body).to.eql({
+            message: "Privilege modified successfully!",
+          });
+
+          return done();
+        });
+    });
+
+    it("Should return 200 when revoked_roles is being set to [super_user, member] in userObject", function (done) {
+      chai
+        .request(app)
+        .patch("/users/self")
+        .set("cookie", `${cookieName}=${jwt}`)
+        .send({
+          revoked_roles: ["super_user", "member"],
+        })
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          expect(res).to.have.status(200);
+          expect(res.body).to.be.an("object");
+          expect(res.body).to.eql({
+            message: "Privilege modified successfully!",
+          });
+
+          return done();
+        });
+    });
+
+    it("Should return 200 when revoked_roles is being set to [], member in userObject", function (done) {
+      chai
+        .request(app)
+        .patch("/users/self")
+        .set("cookie", `${cookieName}=${jwt}`)
+        .send({
+          revoked_roles: [],
+        })
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          expect(res).to.have.status(200);
+          expect(res.body).to.be.an("object");
+          expect(res.body).to.eql({
+            message: "Privilege modified successfully!",
+          });
+
+          return done();
+        });
+    });
+
+    it("Should return 400 when revoked_roles is being set to ['admin'], member in userObject", function (done) {
+      chai
+        .request(app)
+        .patch("/users/self")
+        .set("cookie", `${cookieName}=${jwt}`)
+        .send({
+          revoked_roles: ["admin"],
+        })
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          expect(res).to.have.status(400);
+          expect(res.body).to.be.an("object");
+          expect(res.body).to.eql({
+            statusCode: 400,
+            error: "Bad Request",
+            message: '"revoked_roles[0]" must be one of [super_user, member]',
+          });
+
+          return done();
+        });
+    });
   });
 
   describe("GET /users", function () {

--- a/test/unit/middlewares/user-validator.test.js
+++ b/test/unit/middlewares/user-validator.test.js
@@ -309,52 +309,67 @@ describe("Middleware | Validators | User", function () {
   });
 
   describe("Test the update Self Validator for disabled_roles property", function () {
-    it("Allows the request to pass with disabled_roles property", async function () {
-      const req = {
+    let req, res, nextSpy;
+
+    beforeEach(function () {
+      res = {
+        boom: {
+          badRequest: sinon.stub(), // Stub the badRequest method
+        },
+      };
+
+      nextSpy = sinon.spy(); // Spy on the next function
+    });
+
+    it("Allows the request to pass with disabled_roles property []", async function () {
+      req = {
         body: {
           disabledRoles: [],
         },
       };
-      const res = {};
-      const nextSpy = sinon.spy();
       await updateUser(req, res, nextSpy);
       expect(nextSpy.callCount).to.be.equal(1);
     });
 
     it("Allows the request to pass with disabled_roles property with roles `super_user` & `member'", async function () {
-      const req = {
+      req = {
         body: {
           disabledRoles: ["super_user", "member"],
         },
       };
-      const res = {};
-      const nextSpy = sinon.spy();
       await updateUser(req, res, nextSpy);
-      expect(nextSpy.notCalled).to.be.equal(false);
+      expect(nextSpy.callCount).to.be.equal(1);
     });
 
     it("Allows the request to pass with disabled_roles property with role `member'", async function () {
-      const req = {
+      req = {
         body: {
           disabledRoles: ["member"],
         },
       };
-      const res = {};
-      const nextSpy = sinon.spy();
+
       await updateUser(req, res, nextSpy);
       expect(nextSpy.callCount).to.be.equal(1);
     });
 
     it("Allows the request to pass with disabled_roles property with role `super_user` ", async function () {
-      const req = {
+      req = {
         body: {
           disabledRoles: ["super_user"],
         },
       };
-      const res = {};
-      const nextSpy = sinon.spy();
       await updateUser(req, res, nextSpy);
       expect(nextSpy.callCount).to.be.equal(1);
+    });
+
+    it("shouldn't allow the request to pass with disabled_roles property with role `admin` ", async function () {
+      req = {
+        body: {
+          disabledRoles: ["admin"],
+        },
+      };
+      await updateUser(req, res, nextSpy);
+      expect(res.boom.badRequest.calledOnce).to.be.equal(true);
     });
   });
 

--- a/test/unit/middlewares/user-validator.test.js
+++ b/test/unit/middlewares/user-validator.test.js
@@ -308,11 +308,11 @@ describe("Middleware | Validators | User", function () {
     });
   });
 
-  describe("Test the update Self Validator for revoked_roles property", function () {
-    it("Allows the request to pass with revoked_roles property", async function () {
+  describe("Test the update Self Validator for disabled_roles property", function () {
+    it("Allows the request to pass with disabled_roles property", async function () {
       const req = {
         body: {
-          revoked_roles: [],
+          disabled_roles: [],
         },
       };
       const res = {};
@@ -321,10 +321,10 @@ describe("Middleware | Validators | User", function () {
       expect(nextSpy.callCount).to.be.equal(1);
     });
 
-    it("Allows the request to pass with revoked_roles property with roles `super_user` & `member'", async function () {
+    it("Allows the request to pass with disabled_roles property with roles `super_user` & `member'", async function () {
       const req = {
         body: {
-          revoked_roles: ["super_user", "member"],
+          disabled_roles: ["super_user", "member"],
         },
       };
       const res = {};
@@ -333,10 +333,10 @@ describe("Middleware | Validators | User", function () {
       expect(nextSpy.notCalled).to.be.equal(false);
     });
 
-    it("Allows the request to pass with revoked_roles property with role `member'", async function () {
+    it("Allows the request to pass with disabled_roles property with role `member'", async function () {
       const req = {
         body: {
-          revoked_roles: ["member"],
+          disabled_roles: ["member"],
         },
       };
       const res = {};
@@ -345,10 +345,10 @@ describe("Middleware | Validators | User", function () {
       expect(nextSpy.callCount).to.be.equal(1);
     });
 
-    it("Allows the request to pass with revoked_roles property with role `super_user` ", async function () {
+    it("Allows the request to pass with disabled_roles property with role `super_user` ", async function () {
       const req = {
         body: {
-          revoked_roles: ["super_user"],
+          disabled_roles: ["super_user"],
         },
       };
       const res = {};

--- a/test/unit/middlewares/user-validator.test.js
+++ b/test/unit/middlewares/user-validator.test.js
@@ -308,6 +308,56 @@ describe("Middleware | Validators | User", function () {
     });
   });
 
+  describe("Test the update Self Validator for revoked_roles property", function () {
+    it("Allows the request to pass with revoked_roles property", async function () {
+      const req = {
+        body: {
+          revoked_roles: [],
+        },
+      };
+      const res = {};
+      const nextSpy = sinon.spy();
+      await updateUser(req, res, nextSpy);
+      expect(nextSpy.callCount).to.be.equal(1);
+    });
+
+    it("Allows the request to pass with revoked_roles property with roles `super_user` & `member'", async function () {
+      const req = {
+        body: {
+          revoked_roles: ["super_user", "member"],
+        },
+      };
+      const res = {};
+      const nextSpy = sinon.spy();
+      await updateUser(req, res, nextSpy);
+      expect(nextSpy.notCalled).to.be.equal(false);
+    });
+
+    it("Allows the request to pass with revoked_roles property with role `member'", async function () {
+      const req = {
+        body: {
+          revoked_roles: ["member"],
+        },
+      };
+      const res = {};
+      const nextSpy = sinon.spy();
+      await updateUser(req, res, nextSpy);
+      expect(nextSpy.callCount).to.be.equal(1);
+    });
+
+    it("Allows the request to pass with revoked_roles property with role `super_user` ", async function () {
+      const req = {
+        body: {
+          revoked_roles: ["super_user"],
+        },
+      };
+      const res = {};
+      const nextSpy = sinon.spy();
+      await updateUser(req, res, nextSpy);
+      expect(nextSpy.callCount).to.be.equal(1);
+    });
+  });
+
   describe("Create user validator for getUsers", function () {
     it("lets the request pass to next", async function () {
       const req = {

--- a/test/unit/middlewares/user-validator.test.js
+++ b/test/unit/middlewares/user-validator.test.js
@@ -312,7 +312,7 @@ describe("Middleware | Validators | User", function () {
     it("Allows the request to pass with disabled_roles property", async function () {
       const req = {
         body: {
-          disabled_roles: [],
+          disabledRoles: [],
         },
       };
       const res = {};
@@ -324,7 +324,7 @@ describe("Middleware | Validators | User", function () {
     it("Allows the request to pass with disabled_roles property with roles `super_user` & `member'", async function () {
       const req = {
         body: {
-          disabled_roles: ["super_user", "member"],
+          disabledRoles: ["super_user", "member"],
         },
       };
       const res = {};
@@ -336,7 +336,7 @@ describe("Middleware | Validators | User", function () {
     it("Allows the request to pass with disabled_roles property with role `member'", async function () {
       const req = {
         body: {
-          disabled_roles: ["member"],
+          disabledRoles: ["member"],
         },
       };
       const res = {};
@@ -348,7 +348,7 @@ describe("Middleware | Validators | User", function () {
     it("Allows the request to pass with disabled_roles property with role `super_user` ", async function () {
       const req = {
         body: {
-          disabled_roles: ["super_user"],
+          disabledRoles: ["super_user"],
         },
       };
       const res = {};

--- a/test/unit/models/users.test.js
+++ b/test/unit/models/users.test.js
@@ -489,35 +489,35 @@ describe("users", function () {
     });
   });
 
-  describe("fetchUser with revoked rples", function () {
+  describe("fetchUser with disabled roles", function () {
     afterEach(async function () {
       await cleanDb();
     });
 
     it("should fetch users with modified roles : []", async function () {
-      const superUser = { ...userData()[4], revoked_roles: [] };
+      const superUser = { ...userData()[4], disabled_roles: [] };
       const userId = await addUser(superUser);
 
       const userDoc = await users.fetchUser({ userId });
-      expect(userDoc.user.revoked_roles.length).to.be.equal(0);
+      expect(userDoc.user.disabled_roles.length).to.be.equal(0);
       expect(userDoc.user.roles.super_user).to.be.equal(true);
     });
 
     it("should fetch users with modified roles : super_user", async function () {
-      const superUser = { ...userData()[4], revoked_roles: ["super_user"] };
+      const superUser = { ...userData()[4], disabled_roles: ["super_user"] };
       const userId = await addUser(superUser);
 
       const userDoc = await users.fetchUser({ userId });
-      expect(userDoc.user.revoked_roles.length).to.be.equal(1);
+      expect(userDoc.user.disabled_roles.length).to.be.equal(1);
       expect(userDoc.user.roles.super_user).to.be.equal(false);
     });
 
     it("should fetch users with modified roles : member", async function () {
-      const memberUser = { ...userData()[6], revoked_roles: ["member"] };
+      const memberUser = { ...userData()[6], disabled_roles: ["member"] };
       const userId = await addUser(memberUser);
 
       const userDoc = await users.fetchUser({ userId });
-      expect(userDoc.user.revoked_roles.length).to.be.equal(1);
+      expect(userDoc.user.disabled_roles.length).to.be.equal(1);
       expect(userDoc.user.roles.member).to.be.equal(false);
     });
 
@@ -525,14 +525,14 @@ describe("users", function () {
       // super_user & member
       const userWithBothRoles = {
         ...userData()[4],
-        revoked_roles: ["super_user", "member"],
+        disabled_roles: ["super_user", "member"],
         roles: { ...userData()[4].roles, member: true },
       };
 
       const userId = await addUser(userWithBothRoles);
 
       const userDoc = await users.fetchUser({ userId });
-      expect(userDoc.user.revoked_roles.length).to.be.equal(2);
+      expect(userDoc.user.disabled_roles.length).to.be.equal(2);
       expect(userDoc.user.roles.member).to.be.equal(false);
       expect(userDoc.user.roles.super_user).to.be.equal(false);
     });

--- a/test/unit/models/users.test.js
+++ b/test/unit/models/users.test.js
@@ -522,7 +522,6 @@ describe("users", function () {
     });
 
     it("should fetch users with modified roles : super_user & member", async function () {
-      // super_user & member
       const userWithBothRoles = {
         ...userData()[4],
         disabled_roles: ["super_user", "member"],

--- a/test/unit/models/users.test.js
+++ b/test/unit/models/users.test.js
@@ -488,4 +488,53 @@ describe("users", function () {
       expect(userListResult[0].discordId).to.be.deep.equal(userDataArray[0].discordId);
     });
   });
+
+  describe("fetchUser with revoked rples", function () {
+    afterEach(async function () {
+      await cleanDb();
+    });
+
+    it("should fetch users with modified roles : []", async function () {
+      const superUser = { ...userData()[4], revoked_roles: [] };
+      const userId = await addUser(superUser);
+
+      const userDoc = await users.fetchUser({ userId });
+      expect(userDoc.user.revoked_roles.length).to.be.equal(0);
+      expect(userDoc.user.roles.super_user).to.be.equal(true);
+    });
+
+    it("should fetch users with modified roles : super_user", async function () {
+      const superUser = { ...userData()[4], revoked_roles: ["super_user"] };
+      const userId = await addUser(superUser);
+
+      const userDoc = await users.fetchUser({ userId });
+      expect(userDoc.user.revoked_roles.length).to.be.equal(1);
+      expect(userDoc.user.roles.super_user).to.be.equal(false);
+    });
+
+    it("should fetch users with modified roles : member", async function () {
+      const memberUser = { ...userData()[6], revoked_roles: ["member"] };
+      const userId = await addUser(memberUser);
+
+      const userDoc = await users.fetchUser({ userId });
+      expect(userDoc.user.revoked_roles.length).to.be.equal(1);
+      expect(userDoc.user.roles.member).to.be.equal(false);
+    });
+
+    it("should fetch users with modified roles : super_user & member", async function () {
+      // super_user & member
+      const userWithBothRoles = {
+        ...userData()[4],
+        revoked_roles: ["super_user", "member"],
+        roles: { ...userData()[4].roles, member: true },
+      };
+
+      const userId = await addUser(userWithBothRoles);
+
+      const userDoc = await users.fetchUser({ userId });
+      expect(userDoc.user.revoked_roles.length).to.be.equal(2);
+      expect(userDoc.user.roles.member).to.be.equal(false);
+      expect(userDoc.user.roles.super_user).to.be.equal(false);
+    });
+  });
 });


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 09-09-2024
<!--Developer Name Here-->
Developer Name: Shubham Raj

---

## Issue Ticket Number
#2110
<!--Issue ticket this PR closes-->

## Description
The PR add a new property `disabled_roles` in the users object with an array of string value; these string value will an enum value for now  but the list can be extended to more roles as well. 
For now these value are these, which are basically the the property name of the roles
`[ “super_user”, “members”];`

An Empty Array `[ ]` : means that no roles have been toggled off / privileges are downgraded.

`[‘super_user’]`: means that the `super_user` role has been restricted.

`[ “super_user”, “members”]`: means that both `super_user` as well as `member` roles have been restricted.

In the Data Access Layer we mutate the user Object, to be very specific about the function, in the `fetchUser` function, this way all the instances where we would be calling/fetching users we will get the same user object with the updated roles.

If the property name is found in the `disabled_roles` array, we set the value of those properties in the userData to false.

If the `disabled_roles` array is empty, we do nothing, users can use the services without any restriction on the privileges.
 
For adding this property I'm using the `PATCH \users\self`

If we go with this solution, the only place we need to put this function of setting user roles to false, based on the `disabled_roles` property, inside the data Access Layer services only. 

We won’t need to modify any other routes.



<!--Description of the changes made in this PR-->

### Documentation Updated?

- [x] Yes
- [] No

Update PR raised

<!--Additional notes about documentation update if applicable-->
### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [x] Yes
- [ ] No

<!--Notes on any database changes-->
Added an another attribute in the user Object in database
### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screen Cast</summary>

<!-- Attach your screenshots here👇-->
[Screencast from 10-09-24 12:31:35 AM IST.webm](https://github.com/user-attachments/assets/d0ff1906-42c9-4ffe-89e5-10a1534a74bc)

</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Unit Test Coverage</summary>

<!-- Attach your screenshots here👇-->
![image](https://github.com/user-attachments/assets/e74b4565-c295-4839-ae49-f0544b819574)

</details>
<details>
<summary>Integration Test Coverage</summary>

<!-- Attach your screenshots here👇-->
![image](https://github.com/user-attachments/assets/21b70dda-4e9d-47ce-84bd-1751bdbdaa34)



</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes
For additional detailed explanation refer this [**design doc**](https://docs.google.com/document/d/17khsviClkNVNYH4Xy5Pkk98Xvrid1jH1jL9QtfGp7aw/edit?usp=sharing) 

<!--Any additional notes, considerations or explanations for reviewers-->
flow of the updateSelf()
![image](https://github.com/user-attachments/assets/3119bfa7-67a3-4c33-a498-123f5d9a2270)
