### PR TITLE
Remove dev feature flag for GET /requests API

### DIFF
--- a/controllers/requests.ts
+++ b/controllers/requests.ts
@@ -57,7 +57,7 @@ export const getRequestsController = async (req: any, res: any) => {
     }
 
     if (page) {
-      const pageLink = `/requests?page=${page}&dev=${query.dev}`;
+      const pageLink = `/requests?page=${page}`;
       return res.status(200).json({
         message: REQUEST_FETCHED_SUCCESSFULLY,
         data: allRequests,

--- a/middlewares/validators/requests.ts
+++ b/middlewares/validators/requests.ts
@@ -83,7 +83,7 @@ export const updateRequestsMiddleware = async (
 
 export const getRequestsMiddleware = async (req: OooRequestCreateRequest, res: OooRequestResponse, next: NextFunction) => {
   const schema = joi.object().keys({
-    dev: joi.bool().sensitive(),  // TODO: Remove this validator once feature is tested and ready to be used
+    dev: joi.bool().sensitive().optional(), // TODO: Remove this validator once feature is tested and ready to be used
     id: joi.string().optional(),
     type: joi
       .string()

--- a/test/integration/requests.test.ts
+++ b/test/integration/requests.test.ts
@@ -288,7 +288,7 @@ describe("/requests OOO", function () {
     it("should return all requests", function (done) {
       chai
         .request(app)
-        .get("/requests?dev=true")
+        .get("/requests")
         .end(function (err, res) {
           expect(res).to.have.status(200);
           expect(res.body.data).to.have.lengthOf(2);
@@ -304,7 +304,7 @@ describe("/requests OOO", function () {
     it("should return all requests by specific user", function (done) {
       chai
         .request(app)
-        .get(`/requests?dev=true&requestedBy=${userData[16].username}`)
+        .get(`/requests?requestedBy=${userData[16].username}`)
         .end(function (err, res) {
           expect(res).to.have.status(200);
           expect(res.body.data.every((request: any) => request.requestedBy === testUserId));
@@ -315,7 +315,7 @@ describe("/requests OOO", function () {
     it("should return all requests by specific user and state", function (done) {
       chai
         .request(app)
-        .get(`/requests?dev=true&state=APPROVED&requestedBy=${userData[16].username}`)
+        .get(`/requests?state=APPROVED&requestedBy=${userData[16].username}`)
         .end(function (err, res) {
           expect(res).to.have.status(200);
           expect(res.body.data.every((e: any) => e.state === "APPROVED"));
@@ -327,7 +327,7 @@ describe("/requests OOO", function () {
     it("should return request of type OOO", function (done) {
       chai
         .request(app)
-        .get("/requests?dev=true&type=OOO")
+        .get("/requests?type=OOO")
         .end(function (err, res) {
           expect(res).to.have.status(200);
           expect(res.body.data.every((e: any) => e.type === "OOO"));
@@ -338,7 +338,7 @@ describe("/requests OOO", function () {
     it("should return empty array is no data is found, for specific state and user", function (done) {
       chai
         .request(app)
-        .get("/requests?dev=true&requestedBy=testUser2&state=APPROVED")
+        .get("/requests?requestedBy=testUser2&state=APPROVED")
         .end(function (err, res) {
           expect(res).to.have.status(204);
           done();
@@ -348,7 +348,7 @@ describe("/requests OOO", function () {
     it("should return empty array is no data is found", function (done) {
       chai
         .request(app)
-        .get("/requests?dev=true&requestedBy=testUserRandom")
+        .get("/requests?requestedBy=testUserRandom")
         .end(function (err, res) {
           expect(res).to.have.status(204);
           done();
@@ -358,7 +358,7 @@ describe("/requests OOO", function () {
     it("should throw error if request id doesn't match", function (done) {
       chai
         .request(app)
-        .get("/requests?dev=true&id=ramdonId1")
+        .get("/requests?id=ramdonId1")
         .end(function (err, res) {
           expect(res).to.have.status(204);
           done();
@@ -368,7 +368,7 @@ describe("/requests OOO", function () {
     it("should return error if not a valid state is passed", function (done) {
       chai
         .request(app)
-        .get("/requests?dev=true&state=ACTIVE")
+        .get("/requests?state=ACTIVE")
         .end(function (err, res) {
           expect(res).to.have.status(400);
           expect(res.body.error).to.equal("Bad Request");
@@ -380,7 +380,7 @@ describe("/requests OOO", function () {
     it("should return error if not a valid type is passed", function (done) {
       chai
         .request(app)
-        .get("/requests?dev=true&type=RANDOM")
+        .get("/requests?type=RANDOM")
         .end(function (err, res) {
           expect(res).to.have.status(400);
           expect(res.body.error).to.equal("Bad Request");

--- a/test/unit/middlewares/requests.test.ts
+++ b/test/unit/middlewares/requests.test.ts
@@ -93,9 +93,7 @@ describe("Create Request Validators", function () {
   describe("Get Request Validator", function () {
     it("Should pass validation for a valid get request", async function () {
       req = {
-        query: {
-          dev: "true",
-        },
+        query: {},
       };
       res = {};
       await getRequestsMiddleware(req as any, res as any, nextSpy);
@@ -105,7 +103,6 @@ describe("Create Request Validators", function () {
     it("Should throw an error for an invalid get request", async function () {
       req = {
         query: {
-          dev: "true",
           type: "RANDOM",
           state: "RANDOM",
         },

--- a/test/unit/middlewares/requests.test.ts
+++ b/test/unit/middlewares/requests.test.ts
@@ -92,9 +92,7 @@ describe("Create Request Validators", function () {
 
   describe("Get Request Validator", function () {
     it("Should pass validation for a valid get request", async function () {
-      req = {
-        query: {},
-      };
+      req = {};
       res = {};
       await getRequestsMiddleware(req as any, res as any, nextSpy);
       expect(nextSpy.calledOnce).to.equal(true);


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 13 Sep 2024
<!--Developer Name Here-->
Developer Name: Samarpan Harit

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
Closes #2139 
## Description
1. Remove `dev` query param from the next page link being set in the response
2. Make the `dev` query param optional in the request validator
3. Update integration tests
<!--Description of the changes made in this PR-->

### Documentation Updated?

- [ ] Yes
- [ ] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [X] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [X] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [X] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [X] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Get requests with `dev` FF</summary>

<!-- Attach your screenshots here👇-->
![Screenshot from 2024-09-21 01-47-07](https://github.com/user-attachments/assets/893edd57-3412-4dc2-9c46-99af014503dd)
</details>

<details>
<summary>Get requests without `dev` FF</summary>

<!-- Attach your screenshots here👇-->
![Screenshot from 2024-09-21 01-47-28](https://github.com/user-attachments/assets/121f6484-4f28-482b-b345-e335f6645028)
</details>


## Test Coverage
NA

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
