### PR TITLE
Flag PATCH users/self route as Deprecated

### DIFF
--- a/controllers/users.js
+++ b/controllers/users.js
@@ -390,6 +390,9 @@ const getSelfDetails = async (req, res) => {
  * Update the user
  * @deprecated [SCHEDULED] This Controller will be removed in the near Future, New controller TBD.
  *
+ * @todo vikas would be working on this as a sub part of his task issue #2126
+ * https://github.com/vikasosmium
+ *
  * @param req {Object} - Express request object
  * @param req.body {Object} - User object
  * @param res {Object} - Express response object

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -388,6 +388,7 @@ const getSelfDetails = async (req, res) => {
 
 /**
  * Update the user
+ * @deprecated [SCHEDULED] This Controller will be removed in the near Future, New controller TBD.
  *
  * @param req {Object} - Express request object
  * @param req.body {Object} - User object

--- a/routes/users.js
+++ b/routes/users.js
@@ -17,22 +17,7 @@ router.post("/update-in-discord", authenticate, authorizeRoles([SUPERUSER]), use
 router.post("/verify", authenticate, users.verifyUser);
 router.get("/userId/:userId", users.getUserById);
 /**
- * Route handler for updating the authenticated user's own profile
- * @deprecated [SCHEDULED] This endpoint will be deprecated in the next major version. Use `/api/v2/users/profile` instead.
- *
- * @route PATCH /self
- * @middleware {Function} authenticate - Verifies user authentication
- * @middleware {Function} userValidator.updateUser - Validates update payload
- * @function users.updateSelf - Handles the user update logic
- *
- * @example
- * // Example request
- * PATCH /self
- * Authorization: Bearer <token>
- * {
- *   "name": "John Doe",
- *   "email": "john@example.com"
- * }
+ * @deprecated [SCHEDULED] This endpoint will be deprecated in the near future. New EndPoint TBD.
  */
 router.patch("/self", authenticate, userValidator.updateUser, users.updateSelf);
 router.get("/", userValidator.getUsers, users.getUsers);

--- a/routes/users.js
+++ b/routes/users.js
@@ -18,6 +18,8 @@ router.post("/verify", authenticate, users.verifyUser);
 router.get("/userId/:userId", users.getUserById);
 /**
  * @deprecated [SCHEDULED] This endpoint will be deprecated in the near future. New EndPoint TBD.
+ * @todo vikas would be working on this as a sub part of his task issue #2126
+ * https://github.com/vikasosmium
  */
 router.patch("/self", authenticate, userValidator.updateUser, users.updateSelf);
 router.get("/", userValidator.getUsers, users.getUsers);

--- a/routes/users.js
+++ b/routes/users.js
@@ -16,6 +16,24 @@ router.post("/", authorizeAndAuthenticate([ROLES.SUPERUSER], [Services.CRON_JOB_
 router.post("/update-in-discord", authenticate, authorizeRoles([SUPERUSER]), users.setInDiscordScript);
 router.post("/verify", authenticate, users.verifyUser);
 router.get("/userId/:userId", users.getUserById);
+/**
+ * Route handler for updating the authenticated user's own profile
+ * @deprecated [SCHEDULED] This endpoint will be deprecated in the next major version. Use `/api/v2/users/profile` instead.
+ *
+ * @route PATCH /self
+ * @middleware {Function} authenticate - Verifies user authentication
+ * @middleware {Function} userValidator.updateUser - Validates update payload
+ * @function users.updateSelf - Handles the user update logic
+ *
+ * @example
+ * // Example request
+ * PATCH /self
+ * Authorization: Bearer <token>
+ * {
+ *   "name": "John Doe",
+ *   "email": "john@example.com"
+ * }
+ */
 router.patch("/self", authenticate, userValidator.updateUser, users.updateSelf);
 router.get("/", userValidator.getUsers, users.getUsers);
 router.get("/self", authenticate, users.getSelfDetails);


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 06/10/2024
<!--Developer Name Here-->
Developer Name: Shubham Raj

---

## Issue Ticket Number
Closes #2155 


<!--Description of the changes made in this PR-->
The above mentioned issue was related to improving the overall performance of the patch users/self, thought we are either way going to deprecate all the `users/self` route in accordance with issue #2126, So there is no point wasting effort on something that we are going to deprecate, 

I'm adding comments, above the controller and the endpoint, as well as update the api contracts documentation

## TODO
- [ ] Implementing the new route replacing the current PATCH "/user/self" route as well as it's controller
- #2126 
- **[vikas](https://github.com/vikasosmium)**  is working on the issue. 


### Documentation Updated?

[This PR updates the API Contracts](https://github.com/Real-Dev-Squad/website-api-contracts/pull/193)
**Note:**
- [x] Documentation merged
-------

- [ ] No
- [x] Yes

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [x] Yes
- [ ] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

Adds an handy warning in the IDE

![image](https://github.com/user-attachments/assets/3b818ea6-c3aa-46b5-a9ec-1373c00220b2)


- [x] Yes
- [ ] No


## Test Coverage
Didn't add any test coverage only modified the previously written one and they all are passing

## Additional Notes:
changes done in accordance with solution 3
https://docs.google.com/document/d/1ub9ryFs4qq9m9m5jdOxFAx9VvBPMpOn4-_jDTBaNkJY/edit?tab=t.0
