### PR TITLE
Fix: Obfuscate email and phone in profileDiff response

### DIFF
--- a/models/profileDiffs.js
+++ b/models/profileDiffs.js
@@ -111,7 +111,17 @@ const fetchProfileDiffsWithPagination = async (status, order, size, username, cu
 const fetchProfileDiff = async (profileDiffId) => {
   try {
     const profileDiff = await profileDiffsModel.doc(profileDiffId).get();
-    return { id: profileDiff.id, profileDiffExists: profileDiff.exists, ...profileDiff.data() };
+    const profileDiffData = profileDiff.data();
+    const emailRedacted = profileDiffData.email ? obfuscate.obfuscateMail(profileDiffData.email) : "";
+    const phoneRedacted = profileDiffData.phone ? obfuscate.obfuscatePhone(profileDiffData.phone) : "";
+
+    return {
+      id: profileDiff.id,
+      profileDiffExists: profileDiff.exists,
+      ...profileDiff.data(),
+      email: emailRedacted,
+      phone: phoneRedacted,
+    };
   } catch (err) {
     logger.error("Error retrieving profile Diff", err);
     throw err;

--- a/models/profileDiffs.js
+++ b/models/profileDiffs.js
@@ -123,7 +123,7 @@ const fetchProfileDiff = async (profileDiffId) => {
     return {
       id: profileDiff.id,
       profileDiffExists: true,
-      ...profileDiff.data(),
+      ...profileDiffData,
       email: emailRedacted,
       phone: phoneRedacted,
     };

--- a/models/profileDiffs.js
+++ b/models/profileDiffs.js
@@ -111,13 +111,18 @@ const fetchProfileDiffsWithPagination = async (status, order, size, username, cu
 const fetchProfileDiff = async (profileDiffId) => {
   try {
     const profileDiff = await profileDiffsModel.doc(profileDiffId).get();
+
+    if (!profileDiff.exists) {
+      return { profileDiffExists: false };
+    }
+
     const profileDiffData = profileDiff.data();
     const emailRedacted = profileDiffData.email ? obfuscate.obfuscateMail(profileDiffData.email) : "";
     const phoneRedacted = profileDiffData.phone ? obfuscate.obfuscatePhone(profileDiffData.phone) : "";
 
     return {
       id: profileDiff.id,
-      profileDiffExists: profileDiff.exists,
+      profileDiffExists: true,
       ...profileDiff.data(),
       email: emailRedacted,
       phone: phoneRedacted,


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 08 Oct 2024
<!--Developer Name Here-->
Developer Name: @lakshayman 

---

## Issue Ticket Number
#2204 

## Description

This PR addresses an issue where the email and phone fields were not being obfuscated in the `profileDiff` response. It adds checks to obfuscate the email and phone fields before sending the response back to the client. This ensures that sensitive user data is protected.

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->
No documentation updates were needed as this was an internal bug fix related to obfuscation.

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->
This fix is applied globally and is not gated by a feature flag.

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->
No database changes were required for this fix.

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->
There are no breaking changes associated with this update.

### Development Tested?

- [ ] Yes
- [x] No

<!--Description of tests conducted-->
This fix has been tested locally.



![image](https://github.com/user-attachments/assets/85feb2a7-48e3-472e-a50a-958a741187e6)

