### PR TITLE
[HOT FIX] change phoneNumber to phone to hide it from APIs

### DIFF
--- a/controllers/subscription.ts
+++ b/controllers/subscription.ts
@@ -7,9 +7,9 @@ const emailServiceConfig = config.get("emailServiceConfig");
 
 export const subscribe = async (req: CustomRequest, res: CustomResponse) => {
     const { email } = req.body;
-    const phoneNumber = req.body.phoneNumber || null;
+    const phone = req.body.phone || null;
     const userId = req.userData.id;
-    const data = { email, isSubscribed: true, phoneNumber };
+    const data = { email, isSubscribed: true, phone };
     const userAlreadySubscribed = req.userData.isSubscribed;
   try {
     if (userAlreadySubscribed) {

--- a/middlewares/validators/subscription.ts
+++ b/middlewares/validators/subscription.ts
@@ -8,11 +8,11 @@ export const validateSubscribe = (req: CustomRequest, res: CustomResponse, next:
     if(req.body.email){
       req.body.email = req.body.email.trim();
     }
-     if (req.body.phoneNumber) {
-       req.body.phoneNumber = req.body.phoneNumber.trim();
+     if (req.body.phone) {
+       req.body.phone = req.body.phone.trim();
      }
   const subscribeSchema = Joi.object({
-    phoneNumber: Joi.string().allow('').optional().regex(phoneNumberRegex), 
+    phone: Joi.string().allow('').optional().regex(phoneNumberRegex), 
     email: Joi.string().required().regex(emailRegex)
   });
   const { error } = subscribeSchema.validate(req.body);

--- a/test/fixtures/subscription/subscription.ts
+++ b/test/fixtures/subscription/subscription.ts
@@ -1,7 +1,7 @@
 export const subscribedMessage = "User subscribed successfully";
 export const unSubscribedMessage = "User unsubscribed successfully";
 export const subscriptionData = {
-  phoneNumber: "+911234567890",
+  phone: "+911234567890",
   email: "example@gmail.com",
 };
 

--- a/test/unit/middlewares/subscription-validator.test.js
+++ b/test/unit/middlewares/subscription-validator.test.js
@@ -16,7 +16,7 @@ describe("Middleware | Validators | Subscription", function () {
 
   it("should call next function when a valid request body is passed", async function () {
     req.body = {
-      phoneNumber: "+911234567890",
+      phone: "+911234567890",
       email: "test@example.com",
     };
 
@@ -27,7 +27,7 @@ describe("Middleware | Validators | Subscription", function () {
     expect(res.json.called).to.be.equal(false);
   });
 
-  it("should not return an error when phoneNumber is missing", async function () {
+  it("should not return an error when phone is missing", async function () {
     req.body = {
       email: "test@example.com",
     };
@@ -40,7 +40,7 @@ describe("Middleware | Validators | Subscription", function () {
 
   it("should return a 400 error when email is missing", async function () {
     req.body = {
-      phoneNumber: "+911234567890",
+      phone: "+911234567890",
     };
 
     validateSubscribe(req, res, nextSpy);
@@ -51,7 +51,7 @@ describe("Middleware | Validators | Subscription", function () {
     expect(res.json.firstCall.args[0]).to.have.property("error").that.includes('"email" is required');
   });
 
-  it("should return a 400 error when both phoneNumber and email are missing", async function () {
+  it("should return a 400 error when both phone and email are missing", async function () {
     req.body = {};
 
     validateSubscribe(req, res, nextSpy);
@@ -63,7 +63,7 @@ describe("Middleware | Validators | Subscription", function () {
 
   it("should return a 400 error when email is not in correct format", async function () {
     req.body = {
-      phoneNumber: "+911234567890",
+      phone: "+911234567890",
       email: "invalid-email",
     };
 
@@ -77,9 +77,9 @@ describe("Middleware | Validators | Subscription", function () {
       .that.includes('"email" with value "invalid-email" fails to match the required pattern');
   });
 
-  it("should not return an error when phoneNumber is in correct format", async function () {
+  it("should not return an error when phone is in correct format", async function () {
     req.body = {
-      phoneNumber: "+911234567890",
+      phone: "+911234567890",
       email: "test@example.com",
     };
 
@@ -89,9 +89,9 @@ describe("Middleware | Validators | Subscription", function () {
     expect(res.json.called).to.be.equal(false);
   });
 
-  it("should trim and validate phoneNumber if it contains leading or trailing spaces", async function () {
+  it("should trim and validate phone if it contains leading or trailing spaces", async function () {
     req.body = {
-      phoneNumber: "   +911234567890   ",
+      phone: "   +911234567890   ",
       email: "test@example.com",
     };
 
@@ -100,12 +100,12 @@ describe("Middleware | Validators | Subscription", function () {
     expect(nextSpy.calledOnce).to.be.equal(true);
     expect(res.status.called).to.be.equal(false);
     expect(res.json.called).to.be.equal(false);
-    expect(req.body.phoneNumber).to.equal("+911234567890");
+    expect(req.body.phone).to.equal("+911234567890");
   });
 
-  it("should return a 400 error when phoneNumber is in incorrect format", async function () {
+  it("should return a 400 error when phone is in incorrect format", async function () {
     req.body = {
-      phoneNumber: "invalid-number",
+      phone: "invalid-number",
       email: "test@example.com",
     };
 
@@ -116,6 +116,6 @@ describe("Middleware | Validators | Subscription", function () {
     expect(res.json.calledOnce).to.be.equal(true);
     expect(res.json.firstCall.args[0])
       .to.have.property("error")
-      .that.includes('"phoneNumber" with value "invalid-number" fails to match the required pattern');
+      .that.includes('"phone" with value "invalid-number" fails to match the required pattern');
   });
 });

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -37,7 +37,7 @@ export type userData = {
   username: string;
   updated_at: number;
   isSubscribed: boolean;
-  phoneNumber: string | null;
+  phone: string | null;
   email: string;
 };
 


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 24 oct, 2024
<!--Developer Name Here-->
Developer Name: @tejaskh3 

---

## Issue Ticket Number 
closes https://github.com/Real-Dev-Squad/website-backend/issues/2228

## Description
The issue is we were using phone in "KEYS_NOT_ALLOWED" but while taking user phone inputs we took phoneNumber as field, which exposed phone number publicly. So, in this PR we are fixing the issue motioned above.
<!--Description of the changes made in this PR-->

### Documentation Updated?

- [x] Yes
- [ ] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [x] Yes
- [ ] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
![image](https://github.com/user-attachments/assets/cbc31ead-7108-472f-807c-4f77cc2ddab2)


## Test Coverage
![image](https://github.com/user-attachments/assets/f46060b0-73c9-4ca7-b8f6-f241c504b3e4)

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes
This is just an fix in which we changed  name of a field in test cases as well.