### PR TITLE
Feat: Super users can delete discord group roles

### DIFF
--- a/controllers/discordactions.js
+++ b/controllers/discordactions.js
@@ -86,6 +86,8 @@ const deleteGroupRole = async (req, res) => {
 
     const roleData = existingRoles.docs[0].data();
 
+    // To be implemented later after availability of Discord API
+
     // const discordDeletionSuccess = await discordServices.deleteGroupRoleFromDiscord(roleid);
 
     // if (!discordDeletionSuccess) {

--- a/controllers/discordactions.js
+++ b/controllers/discordactions.js
@@ -93,7 +93,7 @@ const deleteGroupRole = async (req, res) => {
 
     if (!isSuccess) {
       logger.error(`Role deleted from Discord but failed to delete from database for groupId: ${groupId}`);
-      return res.boom.badRequest("Group role deletion failed");
+      return res.boom.badImplementation("Group role deletion failed");
     }
 
     const groupDeletionLog = {

--- a/controllers/discordactions.js
+++ b/controllers/discordactions.js
@@ -77,7 +77,18 @@ const deleteGroupRole = async (req, res) => {
   if (isDevMode) {
     try {
       const { groupId } = req.params;
-      const { roleid } = req.body;
+
+      const getRoleId = async (groupId) => {
+        try {
+          const roleDoc = await admin.firestore().collection("discord-roles").doc(groupId).get();
+          return roleDoc.data().roleid;
+        } catch (error) {
+          logger.error("Error fetching roleId by groupId", error);
+          throw error;
+        }
+      };
+
+      const roleid = await getRoleId(groupId);
 
       const { roleExists, existingRoles } = await discordRolesModel.isGroupRoleExists({ roleid });
 
@@ -94,7 +105,6 @@ const deleteGroupRole = async (req, res) => {
       // const discordDeletionSuccess = await discordServices.deleteGroupRoleFromDiscord(roleid);
 
       // if (!discordDeletionSuccess) {
-      //   console.log(`Failed to delete role from Discord with ID: ${roleid}`);
       //   return res.status(500).json({
       //     error: "Failed to delete role from Discord server",
       //   });

--- a/controllers/discordactions.js
+++ b/controllers/discordactions.js
@@ -75,25 +75,16 @@ const deleteGroupRole = async (req, res) => {
   try {
     const { groupId } = req.params;
     const { roleid } = req.body;
-    console.log(`Attempting to delete group role with ID: ${groupId}`);
-
-    console.log(roleid);
 
     const { roleExists, existingRoles } = await discordRolesModel.isGroupRoleExists({ roleid });
 
     if (!roleExists) {
-      console.log(`Role with ID ${groupId} does not exist in the database.`);
       return res.status(404).json({
         error: "Group role not found",
       });
     }
 
     const roleData = existingRoles.docs[0].data();
-    console.log(roleData);
-
-    console.log(`Deleting role from Discord with ID: ${roleid}`);
-
-    console.log(roleid);
 
     // const discordDeletionSuccess = await discordServices.deleteGroupRoleFromDiscord(roleid);
 
@@ -107,7 +98,6 @@ const deleteGroupRole = async (req, res) => {
     const { isSuccess } = await discordRolesModel.deleteGroupRole(groupId, req.userData.id);
 
     if (isSuccess) {
-      console.log("deletion log reached");
       const groupDeletionLog = {
         type: "group-role-deletion",
         meta: {
@@ -121,7 +111,6 @@ const deleteGroupRole = async (req, res) => {
         },
       };
       await addLog(groupDeletionLog.type, groupDeletionLog.meta, groupDeletionLog.body);
-      console.log("deletion log end before messge");
       return res.status(200).json({
         message: "Group role deleted succesfully",
       });

--- a/models/discordactions.js
+++ b/models/discordactions.js
@@ -46,6 +46,31 @@ const createNewRole = async (roleData) => {
   }
 };
 
+/**
+ * Soft deletes a group role by marking it as deleted in the database.
+ * This function updates the role document in Firestore, setting isDeleted to true
+ * and recording who deleted it and when.
+ *
+ * @param {string} groupId - The ID of the group role to be deleted
+ * @param {string} deletedBy - The ID of the user performing the deletion for logging purpose
+ * @returns {Promise<Object>} An object indicating whether the operation was successful
+ */
+const deleteGroupRole = async (groupId, deletedBy) => {
+  try {
+    const roleRef = admin.firestore().collection("discord-roles").doc(groupId);
+    await roleRef.update({
+      isDeleted: true,
+      deletedAt: admin.firestore.Timestamp.fromDate(new Date()),
+      deletedBy: deletedBy,
+    });
+
+    return { isSuccess: true };
+  } catch (error) {
+    logger.error(`Error in deleteGroupRole: ${error}`);
+    return { isSuccess: false };
+  }
+};
+
 const removeMemberGroup = async (roleId, discordId) => {
   try {
     const backendResponse = await deleteRoleFromDatabase(roleId, discordId);
@@ -1075,4 +1100,5 @@ module.exports = {
   getUserDiscordInvite,
   addInviteToInviteModel,
   groupUpdateLastJoinDate,
+  deleteGroupRole,
 };

--- a/models/discordactions.js
+++ b/models/discordactions.js
@@ -164,7 +164,7 @@ const updateGroupRole = async (roleData, docId) => {
 
 const isGroupRoleExists = async (options = {}) => {
   try {
-    const { groupId, rolename = null, roleid = null } = options;
+    const { groupId = null, rolename = null, roleid = null } = options;
 
     let existingRoles;
     if (groupId) {
@@ -183,7 +183,6 @@ const isGroupRoleExists = async (options = {}) => {
     } else {
       throw Error("Either rolename, roleId, or groupId is required");
     }
-
     return { roleExists: !existingRoles.empty, existingRoles };
   } catch (err) {
     logger.error("Error in getting all group-roles", err);

--- a/models/discordactions.js
+++ b/models/discordactions.js
@@ -164,10 +164,13 @@ const updateGroupRole = async (roleData, docId) => {
 
 const isGroupRoleExists = async (options = {}) => {
   try {
-    const { rolename = null, roleid = null } = options;
+    const { groupId, rolename = null, roleid = null } = options;
 
     let existingRoles;
-    if (rolename && roleid) {
+    if (groupId) {
+      existingRoles = await discordRoleModel.doc(groupId).get();
+      return { roleExists: existingRoles.exists, existingRoles };
+    } else if (rolename && roleid) {
       existingRoles = await discordRoleModel
         .where("rolename", "==", rolename)
         .where("roleid", "==", roleid)
@@ -178,7 +181,7 @@ const isGroupRoleExists = async (options = {}) => {
     } else if (roleid) {
       existingRoles = await discordRoleModel.where("roleid", "==", roleid).limit(1).get();
     } else {
-      throw Error("Either rolename or roleId is required");
+      throw Error("Either rolename, roleId, or groupId is required");
     }
 
     return { roleExists: !existingRoles.empty, existingRoles };

--- a/routes/discordactions.js
+++ b/routes/discordactions.js
@@ -15,6 +15,7 @@ const {
   updateUsersNicknameStatus,
   syncDiscordGroupRolesInFirestore,
   setRoleToUsersWith31DaysPlusOnboarding,
+  deleteGroupRole,
 } = require("../controllers/discordactions");
 const {
   validateGroupRoleBody,
@@ -29,11 +30,11 @@ const ROLES = require("../constants/roles");
 const { Services } = require("../constants/bot");
 const { verifyCronJob } = require("../middlewares/authorizeBot");
 const { authorizeAndAuthenticate } = require("../middlewares/authorizeUsersAndService");
-
 const router = express.Router();
 
 router.post("/groups", authenticate, checkIsVerifiedDiscord, validateGroupRoleBody, createGroupRole);
 router.get("/groups", authenticate, checkIsVerifiedDiscord, getAllGroupRoles);
+router.delete("/groups/:groupId", authenticate, checkIsVerifiedDiscord, authorizeRoles([SUPERUSER]), deleteGroupRole);
 router.post("/roles", authenticate, checkIsVerifiedDiscord, validateMemberRoleBody, addGroupRoleToMember);
 router.get("/invite", authenticate, getUserDiscordInvite);
 router.post("/invite", authenticate, checkCanGenerateDiscordLink, generateInviteForUser);

--- a/routes/discordactions.js
+++ b/routes/discordactions.js
@@ -30,11 +30,19 @@ const ROLES = require("../constants/roles");
 const { Services } = require("../constants/bot");
 const { verifyCronJob } = require("../middlewares/authorizeBot");
 const { authorizeAndAuthenticate } = require("../middlewares/authorizeUsersAndService");
+const { devFlagMiddleware } = require("../middlewares/devFlag");
 const router = express.Router();
 
 router.post("/groups", authenticate, checkIsVerifiedDiscord, validateGroupRoleBody, createGroupRole);
 router.get("/groups", authenticate, checkIsVerifiedDiscord, getAllGroupRoles);
-router.delete("/groups/:groupId", authenticate, checkIsVerifiedDiscord, authorizeRoles([SUPERUSER]), deleteGroupRole);
+router.delete(
+  "/groups/:groupId",
+  authenticate,
+  checkIsVerifiedDiscord,
+  authorizeRoles([SUPERUSER]),
+  devFlagMiddleware,
+  deleteGroupRole
+);
 router.post("/roles", authenticate, checkIsVerifiedDiscord, validateMemberRoleBody, addGroupRoleToMember);
 router.get("/invite", authenticate, getUserDiscordInvite);
 router.post("/invite", authenticate, checkCanGenerateDiscordLink, generateInviteForUser);

--- a/services/discordService.js
+++ b/services/discordService.js
@@ -118,36 +118,29 @@ const setUserDiscordNickname = async (userName, discordId) => {
  * @throws {Error} If the deletion fails or there's a network error
  */
 
-const deleteGroupRoleFromDiscord = async (roleId) => {
-  try {
-    const authToken = generateAuthTokenForCloudflare();
-    // console.log(`Attempting to delete role with ID: ${roleId}`);
-    const response = await fetch(`${DISCORD_BASE_URL}/roles/${roleId}`, {
-      method: "DELETE",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${authToken}`,
-      },
-    });
+// To be implemented later after availability of Discord API
 
-    if (!response.ok) {
-      // const errorResponse = await response.json();
+// const deleteGroupRoleFromDiscord = async (roleId) => {
+//   try {
+//     const authToken = generateAuthTokenForCloudflare();
+//     const response = await fetch(`URL`, {
+//       method: "DELETE",
+//       headers: {
+//         "Content-Type": "application/json",
+//         Authorization: `Bearer ${authToken}`,
+//       },
+//     });
 
-      // console.error(`Response status: ${response.status}`);
-      // console.error(`Response body: ${JSON.stringify(errorResponse)}`);
-      throw new Error(`Failed to delete role from discord`);
-    }
-
-    const result = await response.json();
-    // console.log(`Successfully deleted role: ${JSON.stringify(result)}`);
-
-    return result;
-  } catch (err) {
-    logger.error(`Error deleting role from Discord: ${err.message}`);
-    // console.error(`Full error: ${err}`);
-    throw new Error(err);
-  }
-};
+//     if (!response.ok) {
+//       throw new Error(`Failed to delete role from discord`);
+//     }
+//     const result = await response.json();
+//     return result;
+//   } catch (err) {
+//     logger.error(`Error deleting role from Discord: ${err.message}`);
+//     throw new Error(err);
+//   }
+// };
 
 module.exports = {
   getDiscordMembers,
@@ -156,5 +149,5 @@ module.exports = {
   addRoleToUser,
   removeRoleFromUser,
   setUserDiscordNickname,
-  deleteGroupRoleFromDiscord,
+  // deleteGroupRoleFromDiscord,
 };

--- a/services/discordService.js
+++ b/services/discordService.js
@@ -121,7 +121,7 @@ const setUserDiscordNickname = async (userName, discordId) => {
 const deleteGroupRoleFromDiscord = async (roleId) => {
   try {
     const authToken = generateAuthTokenForCloudflare();
-    console.log(`Attempting to delete role with ID: ${roleId}`);
+    // console.log(`Attempting to delete role with ID: ${roleId}`);
     const response = await fetch(`${DISCORD_BASE_URL}/roles/${roleId}`, {
       method: "DELETE",
       headers: {
@@ -131,20 +131,20 @@ const deleteGroupRoleFromDiscord = async (roleId) => {
     });
 
     if (!response.ok) {
-      const errorResponse = await response.json();
+      // const errorResponse = await response.json();
 
-      console.error(`Response status: ${response.status}`);
-      console.error(`Response body: ${JSON.stringify(errorResponse)}`);
+      // console.error(`Response status: ${response.status}`);
+      // console.error(`Response body: ${JSON.stringify(errorResponse)}`);
       throw new Error(`Failed to delete role from discord`);
     }
 
     const result = await response.json();
-    console.log(`Successfully deleted role: ${JSON.stringify(result)}`);
+    // console.log(`Successfully deleted role: ${JSON.stringify(result)}`);
 
     return result;
   } catch (err) {
     logger.error(`Error deleting role from Discord: ${err.message}`);
-    console.error(`Full error: ${err}`);
+    // console.error(`Full error: ${err}`);
     throw new Error(err);
   }
 };

--- a/services/discordService.js
+++ b/services/discordService.js
@@ -103,7 +103,49 @@ const setUserDiscordNickname = async (userName, discordId) => {
     };
   } catch (err) {
     logger.error("Error in updating discord Nickname", err);
-    throw err;
+    throw new Error(err);
+  }
+};
+
+/**
+ * Deletes a group role from the Discord server.
+ * This function sends a DELETE request to the Discord API to remove the role.
+ * It's part of the soft delete process, where we remove the role from Discord
+ * but keep a record of it in our database.
+ *
+ * @param {string} roleId - The Discord ID of the role to be deleted
+ * @returns {Promise<Object>} The response from the Discord API
+ * @throws {Error} If the deletion fails or there's a network error
+ */
+
+const deleteGroupRoleFromDiscord = async (roleId) => {
+  try {
+    const authToken = generateAuthTokenForCloudflare();
+    console.log(`Attempting to delete role with ID: ${roleId}`);
+    const response = await fetch(`${DISCORD_BASE_URL}/roles/${roleId}`, {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${authToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      const errorResponse = await response.json();
+
+      console.error(`Response status: ${response.status}`);
+      console.error(`Response body: ${JSON.stringify(errorResponse)}`);
+      throw new Error(`Failed to delete role from discord`);
+    }
+
+    const result = await response.json();
+    console.log(`Successfully deleted role: ${JSON.stringify(result)}`);
+
+    return result;
+  } catch (err) {
+    logger.error(`Error deleting role from Discord: ${err.message}`);
+    console.error(`Full error: ${err}`);
+    throw new Error(err);
   }
 };
 
@@ -114,4 +156,5 @@ module.exports = {
   addRoleToUser,
   removeRoleFromUser,
   setUserDiscordNickname,
+  deleteGroupRoleFromDiscord,
 };

--- a/services/discordService.js
+++ b/services/discordService.js
@@ -129,14 +129,11 @@ const deleteGroupRoleFromDiscord = async (roleId) => {
       },
     });
 
-    if (!response.ok) {
-      return { success: false, message: "Failed to delete role from discord" };
-    }
     if (response.status === 204) {
       return { success: true, message: "Role deleted successfully" };
     }
-    const data = await response.json();
-    return data;
+
+    return { success: false, message: "Failed to delete role from discord" };
   } catch (err) {
     logger.error("Error deleting role from Discord", err);
     return { success: false, message: "Internal server error" };

--- a/services/discordService.js
+++ b/services/discordService.js
@@ -118,29 +118,30 @@ const setUserDiscordNickname = async (userName, discordId) => {
  * @throws {Error} If the deletion fails or there's a network error
  */
 
-// To be implemented later after availability of Discord API
+const deleteGroupRoleFromDiscord = async (roleId) => {
+  try {
+    const authToken = generateAuthTokenForCloudflare();
+    const response = await fetch(`${DISCORD_BASE_URL}/roles/${roleId}?dev=true`, {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${authToken}`,
+      },
+    });
 
-// const deleteGroupRoleFromDiscord = async (roleId) => {
-//   try {
-//     const authToken = generateAuthTokenForCloudflare();
-//     const response = await fetch(`URL`, {
-//       method: "DELETE",
-//       headers: {
-//         "Content-Type": "application/json",
-//         Authorization: `Bearer ${authToken}`,
-//       },
-//     });
-
-//     if (!response.ok) {
-//       throw new Error(`Failed to delete role from discord`);
-//     }
-//     const result = await response.json();
-//     return result;
-//   } catch (err) {
-//     logger.error(`Error deleting role from Discord: ${err.message}`);
-//     throw new Error(err);
-//   }
-// };
+    if (!response.ok) {
+      return { success: false, message: "Failed to delete role from discord" };
+    }
+    if (response.status === 204) {
+      return { success: true, message: "Role deleted successfully" };
+    }
+    const data = await response.json();
+    return data;
+  } catch (err) {
+    logger.error("Error deleting role from Discord", err);
+    return { success: false, message: "Internal server error" };
+  }
+};
 
 module.exports = {
   getDiscordMembers,
@@ -149,5 +150,5 @@ module.exports = {
   addRoleToUser,
   removeRoleFromUser,
   setUserDiscordNickname,
-  // deleteGroupRoleFromDiscord,
+  deleteGroupRoleFromDiscord,
 };

--- a/test/integration/discordactions.test.js
+++ b/test/integration/discordactions.test.js
@@ -233,14 +233,14 @@ describe("Discord actions", function () {
       await cleanDb();
     });
 
-    it("should return 403 when not in dev mode", function (done) {
+    it("should return 404 when not in dev mode", function (done) {
       chai
         .request(app)
         .delete(`/discord-actions/groups/${groupId}`)
         .set("cookie", `${cookieName}=${superUserAuthToken}`)
         .end((err, res) => {
-          expect(res).to.have.status(403);
-          expect(res.body.error).to.equal("Feature not available in production mode.");
+          expect(res).to.have.status(404);
+          expect(res.body.error).to.equal("Not Found");
           done(err);
         });
     });
@@ -257,12 +257,12 @@ describe("Discord actions", function () {
         .set("cookie", `${cookieName}=${superUserAuthToken}`)
         .end((err, res) => {
           expect(res).to.have.status(404);
-          expect(res.body.error).to.equal("Group role not found");
+          expect(res.body.error).to.equal("Not Found");
           done(err);
         });
     });
 
-    it("should succesfully delete the group role from discord server", function (done) {
+    it("should successfully delete the group role from discord server", function (done) {
       sinon.stub(discordRolesModel, "isGroupRoleExists").resolves({
         roleExists: true,
         existingRoles: { data: () => ({ ...roleData, roleid: roleData.roleid }) },
@@ -279,7 +279,7 @@ describe("Discord actions", function () {
         .set("cookie", `${cookieName}=${superUserAuthToken}`)
         .end((err, res) => {
           expect(res).to.have.status(200);
-          expect(res.body.message).to.equal("Group role deleted succesfully");
+          expect(res.body.message).to.equal("Group role deleted successfully");
           done(err);
         });
     });
@@ -301,7 +301,7 @@ describe("Discord actions", function () {
         .set("cookie", `${cookieName}=${superUserAuthToken}`)
         .end((err, res) => {
           expect(res).to.have.status(500);
-          expect(res.body.error).to.equal("Failed to delete role from Discord");
+          expect(res.body.error).to.equal("Internal Server Error");
           done(err);
         });
     });
@@ -323,7 +323,7 @@ describe("Discord actions", function () {
         .set("cookie", `${cookieName}=${superUserAuthToken}`)
         .end((err, res) => {
           expect(res).to.have.status(500);
-          expect(res.body.error).to.equal("Internal server error");
+          expect(res.body.error).to.equal("Internal Server Error");
           done(err);
         });
     });
@@ -345,7 +345,7 @@ describe("Discord actions", function () {
         .set("cookie", `${cookieName}=${superUserAuthToken}`)
         .end((err, res) => {
           expect(res).to.have.status(200);
-          expect(res.body.message).to.equal("Group role deleted succesfully");
+          expect(res.body.message).to.equal("Group role deleted successfully");
           done(err);
         });
     });
@@ -369,7 +369,7 @@ describe("Discord actions", function () {
         .set("cookie", `${cookieName}=${superUserAuthToken}`)
         .end((err, res) => {
           expect(res).to.have.status(400);
-          expect(res.body.error).to.equal("Group role deletion failed");
+          expect(res.body.error).to.equal("Bad Request");
           done(err);
         });
     });
@@ -383,7 +383,7 @@ describe("Discord actions", function () {
         .set("cookie", `${cookieName}=${superUserAuthToken}`)
         .end((err, res) => {
           expect(res).to.have.status(500);
-          expect(res.body.error).to.equal("Internal server error");
+          expect(res.body.error).to.equal("Internal Server Error");
           done(err);
         });
     });

--- a/test/integration/discordactions.test.js
+++ b/test/integration/discordactions.test.js
@@ -350,7 +350,7 @@ describe("Discord actions", function () {
         });
     });
 
-    it("should return 400 when deletion fails", function (done) {
+    it("should return 500 when deletion fails", function (done) {
       sinon.restore();
       sinon.stub(discordRolesModel, "isGroupRoleExists").resolves({
         roleExists: true,
@@ -368,8 +368,8 @@ describe("Discord actions", function () {
         .delete(`/discord-actions/groups/${groupId}?dev=true`)
         .set("cookie", `${cookieName}=${superUserAuthToken}`)
         .end((err, res) => {
-          expect(res).to.have.status(400);
-          expect(res.body.error).to.equal("Bad Request");
+          expect(res).to.have.status(500);
+          expect(res.body.error).to.equal("Internal Server Error");
           done(err);
         });
     });

--- a/test/unit/models/discordactions.test.js
+++ b/test/unit/models/discordactions.test.js
@@ -173,7 +173,7 @@ describe("discordactions", function () {
     it("should throw an error if rolename and roleid are not passed", async function () {
       return isGroupRoleExists({}).catch((err) => {
         expect(err).to.be.an.instanceOf(Error);
-        expect(err.message).to.equal("Either rolename or roleId is required");
+        expect(err.message).to.equal("Either rolename, roleId, or groupId is required");
       });
     });
 

--- a/test/unit/models/discordactions.test.js
+++ b/test/unit/models/discordactions.test.js
@@ -281,7 +281,7 @@ describe("discordactions", function () {
           }),
         }),
       };
-      // Replacing firestore implementation with our mock
+
       Object.defineProperty(admin, "firestore", {
         configurable: true,
         get: () => () => mockFirestore,
@@ -292,7 +292,6 @@ describe("discordactions", function () {
     });
 
     afterEach(async function () {
-      // Restoring original firestore implementation
       Object.defineProperty(admin, "firestore", {
         configurable: true,
         value: firestoreOriginal,

--- a/test/unit/services/discordService.test.js
+++ b/test/unit/services/discordService.test.js
@@ -6,12 +6,14 @@ const {
   getDiscordMembers,
   removeRoleFromUser,
   setUserDiscordNickname,
+  deleteGroupRoleFromDiscord,
 } = require("../../../services/discordService");
 const { fetchAllUsers } = require("../../../models/users");
 const Sinon = require("sinon");
 const userModel = firestore.collection("users");
 const userDataArray = require("../../fixtures/user/user")();
 const discordMembersArray = require("../../fixtures/discordResponse/discord-response");
+// const { func } = require("joi");
 let fetchStub;
 describe("Discord services", function () {
   describe("setInDiscordFalseScript", function () {
@@ -155,6 +157,57 @@ describe("Discord services", function () {
       setUserDiscordNickname("Kotesh", "aMYlI7sxQ4JMPwiqLQlp").catch((err) => {
         expect(err).to.be.an.instanceOf(Error);
         expect(err.message).to.equal("Error in updating discord Nickname");
+      });
+    });
+  });
+
+  describe("delete group role from Discord", function () {
+    beforeEach(function () {
+      fetchStub = Sinon.stub(global, "fetch");
+    });
+
+    afterEach(function () {
+      fetchStub.restore();
+    });
+
+    it("should successfully delete role from discord and return success for 204 response", async function () {
+      fetchStub.returns(
+        Promise.resolve({
+          ok: true,
+          status: 204,
+        })
+      );
+
+      const response = await deleteGroupRoleFromDiscord("123456789");
+      expect(response).to.deep.equal({
+        success: true,
+        message: "Role deleted successfully",
+      });
+      expect(fetchStub.calledOnce).to.be.equal(true);
+    });
+
+    it("should return failure for non-ok response", async function () {
+      fetchStub.returns(
+        Promise.resolve({
+          ok: false,
+          status: 400,
+        })
+      );
+
+      const response = await deleteGroupRoleFromDiscord("123456789");
+      expect(response).to.deep.equal({
+        success: false,
+        message: "Failed to delete role from discord",
+      });
+    });
+
+    it("should handle unexpected errors", async function () {
+      fetchStub.rejects(new Error("Network error"));
+
+      const response = await deleteGroupRoleFromDiscord("123456789");
+      expect(response).to.deep.equal({
+        success: false,
+        message: "Internal server error",
       });
     });
   });


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 04 Nov 2024
<!--Developer Name Here-->
Developer Name: @VaibhavSingh8

---

## Issue Ticket Number
<!--Issue ticket this PR closes--> 
- Closes #2191 

## Description

<!--Description of the changes made in this PR-->
This PR implements the ability for super users to delete Discord groups through the `/groups` endpoint on the dashboard site. This feature allows for better group management.

  - Added the `deleteGroupRole` model function to handle the soft deletion of group roles in the Firestore database.
  - The deletion is implemented as a soft delete, setting `isDeleted: true` along with deletion metadata.
  - Implemented controller logic to handle deletion requests, verify role existence, log deletion events for audit, and manage responses with appropriate status codes.
  - Added comprehensive test coverage for both success and error scenarios.
  
### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [x] Yes
- [ ] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [x] Yes
- [ ] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->


https://github.com/user-attachments/assets/5c6c85d0-bed8-4481-af0c-78a898f40922

https://github.com/user-attachments/assets/7037cc1d-1ee5-4e62-b868-b2b9d2aef603

</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

<img width="1470" alt="Screenshot 2024-11-20 at 2 46 54 AM" src="https://github.com/user-attachments/assets/a930b684-a9ce-456c-9e4c-cd9e199dcaf5">

<img width="1308" alt="Screenshot 2024-11-20 at 2 48 24 AM" src="https://github.com/user-attachments/assets/2c88409f-09b0-4546-975a-e074afc36a87">

<img width="1181" alt="Screenshot 2024-11-20 at 2 48 48 AM" src="https://github.com/user-attachments/assets/89e549c5-ee1e-4d1f-9ab5-24c3fbee7796">

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->