### PR TITLE
feat: lazy load discord groups page 

### DIFF
--- a/middlewares/validators/discordactions.js
+++ b/middlewares/validators/discordactions.js
@@ -39,12 +39,17 @@ const validateUpdateUsersNicknameStatusBody = async (req, res, next) => {
     res.boom.badRequest(error);
   }
 };
-
+/**
+ * Middleware: Validates lazy loading parameters in the request.
+ *
+ * @param {Object} req - Express request object.
+ * @param {Object} res - Express response object.
+ * @param {Function} next - Express next middleware function.
+ */
 const validateLazyLoadingParams = async (req, res, next) => {
   const schema = Joi.object({
     page: Joi.number().integer().min(0).optional(),
     size: Joi.number().integer().min(1).max(100).optional(),
-    cursor: Joi.string().optional(),
     dev: Joi.string().valid("true").optional(),
   });
 
@@ -59,6 +64,6 @@ const validateLazyLoadingParams = async (req, res, next) => {
 module.exports = {
   validateGroupRoleBody,
   validateMemberRoleBody,
-  validateUpdateUsersNicknameStatusBody,
   validateLazyLoadingParams,
+  validateUpdateUsersNicknameStatusBody,
 };

--- a/middlewares/validators/discordactions.js
+++ b/middlewares/validators/discordactions.js
@@ -45,6 +45,7 @@ const validateLazyLoadingParams = async (req, res, next) => {
     page: Joi.number().integer().min(0).optional(),
     size: Joi.number().integer().min(1).max(100).optional(),
     cursor: Joi.string().optional(),
+    dev: Joi.string().valid("true").optional(),
   });
 
   try {

--- a/middlewares/validators/discordactions.js
+++ b/middlewares/validators/discordactions.js
@@ -40,8 +40,24 @@ const validateUpdateUsersNicknameStatusBody = async (req, res, next) => {
   }
 };
 
+const validateLazyLoadingParams = async (req, res, next) => {
+  const schema = Joi.object({
+    page: Joi.number().integer().min(0).optional(),
+    size: Joi.number().integer().min(1).max(100).optional(),
+    cursor: Joi.string().optional(),
+  });
+
+  try {
+    req.query = await schema.validateAsync(req.query);
+    next();
+  } catch (error) {
+    res.boom.badRequest(error.message);
+  }
+};
+
 module.exports = {
   validateGroupRoleBody,
   validateMemberRoleBody,
   validateUpdateUsersNicknameStatusBody,
+  validateLazyLoadingParams,
 };

--- a/models/discordactions.js
+++ b/models/discordactions.js
@@ -107,6 +107,7 @@ const deleteRoleFromDatabase = async (roleId, discordId) => {
  * @param roleData { Object }: Data of the new role
  * @returns {Promise<discordRoleModel|Object>}
  */
+
 const getAllGroupRoles = async () => {
   try {
     const data = await discordRoleModel.get();
@@ -119,6 +120,28 @@ const getAllGroupRoles = async () => {
       groups.push(group);
     });
     return { groups };
+  } catch (err) {
+    logger.error("Error in getting all group-roles", err);
+    throw err;
+  }
+};
+
+const getPaginatedGroupRoles = async (latestDoc) => {
+  try {
+    const data = await discordRoleModel
+      .orderBy("roleid")
+      .startAfter(latestDoc || 0)
+      .limit(18)
+      .get();
+    const groups = [];
+    data.forEach((doc) => {
+      const group = {
+        id: doc.id,
+        ...doc.data(),
+      };
+      groups.push(group);
+    });
+    return { groups, newLatestDoc: data.docs[data.docs.length - 1]?.data().roleid };
   } catch (err) {
     logger.error("Error in getting all group-roles", err);
     throw err;
@@ -1086,6 +1109,7 @@ module.exports = {
   removeMemberGroup,
   getGroupRolesForUser,
   getAllGroupRoles,
+  getPaginatedGroupRoles,
   getGroupRoleByName,
   updateGroupRole,
   addGroupRoleToMember,

--- a/models/discordactions.js
+++ b/models/discordactions.js
@@ -140,9 +140,12 @@ const getPaginatedGroupRoles = async ({ cursor, limit }) => {
     let query = discordRoleModel.orderBy("roleid").limit(limit + 1); // Fetch one extra for `hasMore`
 
     if (cursor) {
+      if (typeof cursor !== "string" || !cursor.trim()) {
+        throw new Error("Invalid cursor: Cursor must be a non-empty string");
+      }
       const cursorDoc = await discordRoleModel.doc(cursor).get();
       if (!cursorDoc.exists) {
-        throw new Error("Invalid cursor.");
+        throw new Error("Invalid cursor: Document does not exist");
       }
       query = query.startAfter(cursorDoc);
     }
@@ -160,8 +163,8 @@ const getPaginatedGroupRoles = async ({ cursor, limit }) => {
       hasMore: !!nextCursor,
     };
   } catch (err) {
-    logger.error(`Error in getPaginatedGroupRoles: ${err}`);
-    throw err;
+    logger.error(`Error in getPaginatedGroupRoles: ${err.message}`);
+    throw new Error("Database error");
   }
 };
 

--- a/routes/discordactions.js
+++ b/routes/discordactions.js
@@ -3,7 +3,7 @@ const authenticate = require("../middlewares/authenticate");
 const {
   createGroupRole,
   getGroupsRoleId,
-  getAllGroupRoles,
+  getPaginatedGroupRoles,
   addGroupRoleToMember,
   deleteRole,
   updateDiscordImageForVerification,
@@ -33,7 +33,7 @@ const { authorizeAndAuthenticate } = require("../middlewares/authorizeUsersAndSe
 const router = express.Router();
 
 router.post("/groups", authenticate, checkIsVerifiedDiscord, validateGroupRoleBody, createGroupRole);
-router.get("/groups", authenticate, checkIsVerifiedDiscord, getAllGroupRoles);
+router.get("/groups", authenticate, checkIsVerifiedDiscord, getPaginatedGroupRoles);
 router.delete("/groups/:groupId", authenticate, checkIsVerifiedDiscord, authorizeRoles([SUPERUSER]), deleteGroupRole);
 router.post("/roles", authenticate, checkIsVerifiedDiscord, validateMemberRoleBody, addGroupRoleToMember);
 router.get("/invite", authenticate, getUserDiscordInvite);

--- a/routes/discordactions.js
+++ b/routes/discordactions.js
@@ -3,7 +3,7 @@ const authenticate = require("../middlewares/authenticate");
 const {
   createGroupRole,
   getGroupsRoleId,
-  getPaginatedGroupRoles,
+  getPaginatedAllGroupRoles,
   addGroupRoleToMember,
   deleteRole,
   updateDiscordImageForVerification,
@@ -21,6 +21,7 @@ const {
   validateGroupRoleBody,
   validateMemberRoleBody,
   validateUpdateUsersNicknameStatusBody,
+  validateLazyLoadingParams,
 } = require("../middlewares/validators/discordactions");
 const checkIsVerifiedDiscord = require("../middlewares/verifydiscord");
 const checkCanGenerateDiscordLink = require("../middlewares/checkCanGenerateDiscordLink");
@@ -33,7 +34,7 @@ const { authorizeAndAuthenticate } = require("../middlewares/authorizeUsersAndSe
 const router = express.Router();
 
 router.post("/groups", authenticate, checkIsVerifiedDiscord, validateGroupRoleBody, createGroupRole);
-router.get("/groups", authenticate, checkIsVerifiedDiscord, getPaginatedGroupRoles);
+router.get("/groups", authenticate, checkIsVerifiedDiscord, validateLazyLoadingParams, getPaginatedAllGroupRoles);
 router.delete("/groups/:groupId", authenticate, checkIsVerifiedDiscord, authorizeRoles([SUPERUSER]), deleteGroupRole);
 router.post("/roles", authenticate, checkIsVerifiedDiscord, validateMemberRoleBody, addGroupRoleToMember);
 router.get("/invite", authenticate, getUserDiscordInvite);

--- a/routes/discordactions.js
+++ b/routes/discordactions.js
@@ -3,7 +3,6 @@ const authenticate = require("../middlewares/authenticate");
 const {
   createGroupRole,
   getGroupsRoleId,
-  getPaginatedAllGroupRoles,
   addGroupRoleToMember,
   deleteRole,
   updateDiscordImageForVerification,
@@ -16,6 +15,7 @@ const {
   syncDiscordGroupRolesInFirestore,
   setRoleToUsersWith31DaysPlusOnboarding,
   deleteGroupRole,
+  getPaginatedAllGroupRoles,
 } = require("../controllers/discordactions");
 const {
   validateGroupRoleBody,

--- a/test/unit/models/discordactions.test.js
+++ b/test/unit/models/discordactions.test.js
@@ -120,15 +120,28 @@ describe("discordactions", function () {
     });
 
     it("should return paginated group-roles from the database", async function () {
-      const result = await getPaginatedGroupRoles();
+      const result = await getPaginatedGroupRoles({ cursor: groupData, limit: 2 });
+
       expect(result).to.have.property("groups").that.is.an("array");
-      expect(result).to.have.property("newLatestDoc");
-      expect(result.groups.length).to.be.at.most(18);
+      expect(result.groups).to.have.lengthOf(2); // Verify the limit works
+      expect(result).to.have.property("newLatestDoc").that.is.a("string");
+      expect(result).to.have.property("hasMore").that.is.a("boolean");
+    });
+
+    it("should handle pagination without a cursor", async function () {
+      const result = await getPaginatedGroupRoles({ limit: 2 });
+
+      // eslint-disable-next-line no-undef
+      assert(orderByStub.calledOnce);
+      // eslint-disable-next-line no-undef
+      assert(startAfterStub.notCalled);
+      expect(result.groups).to.have.lengthOf(2);
     });
 
     it("should throw an error if getting group-roles fails", async function () {
       getStub.rejects(new Error("Database error"));
-      return getPaginatedGroupRoles().catch((err) => {
+
+      await getPaginatedGroupRoles({ cursor: groupData, limit: 2 }).catch((err) => {
         expect(err).to.be.an.instanceOf(Error);
         expect(err.message).to.equal("Database error");
       });

--- a/test/unit/models/discordactions.test.js
+++ b/test/unit/models/discordactions.test.js
@@ -120,10 +120,18 @@ describe("discordactions", function () {
     });
 
     it("should return paginated group-roles from the database", async function () {
-      const result = await getPaginatedGroupRoles({ cursor: groupData, limit: 2 });
+      const cursor = "validCursorDocId";
+      getStub.resolves({
+        docs: groupData.map((group) => ({
+          id: group.id,
+          data: () => group,
+        })),
+      });
+
+      const result = await getPaginatedGroupRoles({ cursor, limit: 2 });
 
       expect(result).to.have.property("groups").that.is.an("array");
-      expect(result.groups).to.have.lengthOf(2); // Verify the limit works
+      expect(result.groups).to.have.lengthOf(2);
       expect(result).to.have.property("newLatestDoc").that.is.a("string");
       expect(result).to.have.property("hasMore").that.is.a("boolean");
     });
@@ -131,17 +139,17 @@ describe("discordactions", function () {
     it("should handle pagination without a cursor", async function () {
       const result = await getPaginatedGroupRoles({ limit: 2 });
 
-      // eslint-disable-next-line no-undef
-      assert(orderByStub.calledOnce);
-      // eslint-disable-next-line no-undef
-      assert(startAfterStub.notCalled);
+      // eslint-disable-next-line no-unused-expressions
+      expect(orderByStub).to.have.been.calledOnce;
+      // eslint-disable-next-line no-unused-expressions
+      expect(startAfterStub).not.to.have.been.called; // No cursor means no startAfter
       expect(result.groups).to.have.lengthOf(2);
     });
 
     it("should throw an error if getting group-roles fails", async function () {
       getStub.rejects(new Error("Database error"));
 
-      await getPaginatedGroupRoles({ cursor: groupData, limit: 2 }).catch((err) => {
+      await getPaginatedGroupRoles({ cursor: "invalidCursor", limit: 2 }).catch((err) => {
         expect(err).to.be.an.instanceOf(Error);
         expect(err.message).to.equal("Database error");
       });

--- a/test/unit/models/discordactions.test.js
+++ b/test/unit/models/discordactions.test.js
@@ -19,7 +19,7 @@ const tasksModel = firestore.collection("tasks");
 
 const {
   createNewRole,
-  getAllGroupRoles,
+  getPaginatedGroupRoles,
   isGroupRoleExists,
   addGroupRoleToMember,
   deleteRoleFromDatabase,
@@ -93,27 +93,42 @@ describe("discordactions", function () {
     });
   });
 
-  describe("getAllGroupRoles", function () {
-    let getStub;
+  describe("getPaginatedGroupRoles", function () {
+    let orderByStub, startAfterStub, limitStub, getStub;
 
     beforeEach(function () {
-      getStub = sinon.stub(discordRoleModel, "get").resolves({
-        forEach: (callback) => groupData.forEach(callback),
+      orderByStub = sinon.stub();
+      startAfterStub = sinon.stub();
+      limitStub = sinon.stub();
+      getStub = sinon.stub();
+
+      orderByStub.returns({ startAfter: startAfterStub });
+      startAfterStub.returns({ limit: limitStub });
+      limitStub.returns({ get: getStub });
+      getStub.resolves({
+        docs: groupData.map((group) => ({
+          id: group.id,
+          data: () => group,
+        })),
       });
+
+      sinon.stub(discordRoleModel, "orderBy").returns(orderByStub);
     });
 
     afterEach(function () {
-      getStub.restore();
+      sinon.restore();
     });
 
-    it("should return all group-roles from the database", async function () {
-      const result = await getAllGroupRoles();
-      expect(result.groups).to.be.an("array");
+    it("should return paginated group-roles from the database", async function () {
+      const result = await getPaginatedGroupRoles();
+      expect(result).to.have.property("groups").that.is.an("array");
+      expect(result).to.have.property("newLatestDoc");
+      expect(result.groups.length).to.be.at.most(18);
     });
 
     it("should throw an error if getting group-roles fails", async function () {
       getStub.rejects(new Error("Database error"));
-      return getAllGroupRoles().catch((err) => {
+      return getPaginatedGroupRoles().catch((err) => {
         expect(err).to.be.an.instanceOf(Error);
         expect(err.message).to.equal("Database error");
       });


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: `8th December, 2024`
<!--Developer Name Here-->
Developer Name: @Achintya-Chatterjee 

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
- Closes #2129 
## Description
Added pagination, where only a subset of groups is loaded initially. Additional groups should load dynamically as the user scrolls or interacts with the page, ensuring smooth performance. The page would remain responsive and efficient, regardless of the total number of groups.
<!--Description of the changes made in this PR-->

### Documentation Updated?

- [x] Yes
- [ ] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [x] Yes
- [ ] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

- `Without dev=true`

https://github.com/user-attachments/assets/d10d8817-9072-46b1-8408-9fe76d1aabb7

- `with dev=true`

https://github.com/user-attachments/assets/d0c44400-8302-4aa9-8f35-195a3d800b75

- `with prev and next page`


https://github.com/user-attachments/assets/1b04084d-e6ed-45f0-befd-fd19b76765be


</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->
<img width="1156" alt="Screenshot 2024-12-21 at 23 01 34" src="https://github.com/user-attachments/assets/e0d8aa15-4bfd-4cbd-9c0f-1cb84181f928" />
<img width="1156" alt="Screenshot 2024-12-21 at 23 02 15" src="https://github.com/user-attachments/assets/b714eb78-6fc1-461e-921b-4cbd276a14a0" />

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

- **This PR follows a stack PR approach, so first the test [PR](https://github.com/Real-Dev-Squad/website-backend/pull/2310) will be merged into this feature branch, and then we can merge this to develop.**
<!--Any additional notes, considerations or explanations for reviewers-->
