### PR TITLE
Storing userData in place of userId in progresses to minimize additional API calls from the frontend.

### DIFF
--- a/controllers/progresses.js
+++ b/controllers/progresses.js
@@ -48,8 +48,14 @@ const createProgress = async (req, res) => {
   const {
     body: { type, completed, planned, blockers, taskId },
   } = req;
+  const isDevFeatureEnabled = req.query.dev === "true";
+
   try {
-    const { data, taskTitle } = await createProgressDocument({ ...req.body, userId: req.userData.id });
+    const { data, taskTitle } = await createProgressDocument({
+      ...req.body,
+      [isDevFeatureEnabled ? "userData" : "userId"]: isDevFeatureEnabled ? req.userData : req.userData.id,
+    });
+
     await sendTaskUpdate(completed, blockers, planned, req.userData.username, taskId, taskTitle);
     return res.status(201).json({
       data,
@@ -217,7 +223,7 @@ const getProgressRangeData = async (req, res) => {
 
 const getProgressBydDateController = async (req, res) => {
   try {
-    const data = await getProgressByDate(req.params);
+    const data = await getProgressByDate(req.params, req.query);
     return res.json({
       message: PROGRESS_DOCUMENT_RETRIEVAL_SUCCEEDED,
       data,

--- a/middlewares/validators/progresses.js
+++ b/middlewares/validators/progresses.js
@@ -70,6 +70,9 @@ const validateGetProgressRecordsQuery = async (req, res, next) => {
         .messages({
           "string.base": "orderBy must be a string",
         }),
+      dev: joi.boolean().optional().messages({
+        "boolean.base": "dev must be a boolean",
+      }),
     })
     .xor("type", "userId", "taskId")
     .messages({
@@ -92,6 +95,7 @@ const validateGetRangeProgressRecordsParams = async (req, res, next) => {
       taskId: joi.string().optional(),
       startDate: joi.date().iso().required(),
       endDate: joi.date().iso().min(joi.ref("startDate")).required(),
+      dev: joi.boolean().optional(),
     })
     .xor("userId", "taskId")
     .messages({

--- a/models/progresses.js
+++ b/models/progresses.js
@@ -29,7 +29,7 @@ const createProgressDocument = async (progressData) => {
   if (taskId) {
     taskTitle = await assertTaskExists(taskId);
   }
-  const query = buildQueryForPostingProgress(progressData);
+  const query = await buildQueryForPostingProgress(progressData);
   const existingDocumentSnapshot = await query.where("date", "==", progressDateTimestamp).get();
   if (!existingDocumentSnapshot.empty) {
     throw new Conflict(`${type.charAt(0).toUpperCase() + type.slice(1)} ${PROGRESS_ALREADY_CREATED}`);
@@ -77,10 +77,11 @@ const getRangeProgressData = async (queryParams) => {
  * @returns {Promise<object>} A Promise that resolves with the progress records of the queried user or task.
  * @throws {Error} If the userId or taskId is invalid or does not exist.
  **/
-async function getProgressByDate(pathParams) {
+async function getProgressByDate(pathParams, queryParams) {
   const { type, typeId, date } = pathParams;
+  const { dev } = queryParams;
   await assertUserOrTaskExists({ [TYPE_MAP[type]]: typeId });
-  const query = buildQueryToSearchProgressByDay({ [TYPE_MAP[type]]: typeId, date });
+  const query = buildQueryToSearchProgressByDay({ [TYPE_MAP[type]]: typeId, date, dev });
   const result = await query.get();
   if (!result.size) {
     throw new NotFound(PROGRESS_DOCUMENT_NOT_FOUND);

--- a/test/fixtures/progress/progresses.js
+++ b/test/fixtures/progress/progresses.js
@@ -52,6 +52,18 @@ const stubbedModelProgressData = (userId, createdAt, date) => {
   };
 };
 
+const stubbedModelProgressDataForDev = (userData, createdAt, date) => {
+  return {
+    userData,
+    createdAt,
+    date,
+    type: "user",
+    completed: "Implemented caching mechanism for frequent API requests",
+    planned: "Refactor code to follow coding best practices",
+    blockers: "Waiting for feedback from the code review",
+  };
+};
+
 const taskProgressDay1 = (taskId) => {
   return {
     taskId,
@@ -122,6 +134,18 @@ const stubbedModelTaskProgressData = (userId, taskId, createdAt, date) => {
     blockers: "Waiting for feedback from the code review",
   };
 };
+const stubbedModelTaskProgressDataForDev = (userData, taskId, createdAt, date) => {
+  return {
+    userData,
+    taskId,
+    createdAt,
+    date,
+    type: "task",
+    completed: "Implemented caching mechanism for frequent API requests",
+    planned: "Refactor code to follow coding best practices",
+    blockers: "Waiting for feedback from the code review",
+  };
+};
 
 module.exports = {
   standupProgressDay1,
@@ -130,4 +154,6 @@ module.exports = {
   taskProgressDay1,
   incompleteTaskProgress,
   stubbedModelTaskProgressData,
+  stubbedModelProgressDataForDev,
+  stubbedModelTaskProgressDataForDev,
 };

--- a/test/utils/addUser.js
+++ b/test/utils/addUser.js
@@ -8,7 +8,7 @@ const userData = require("../fixtures/user/user")();
  *
  * @return {Promise<string>} userId - userId for the added user
  */
-module.exports = async (user) => {
+module.exports = async (user, requireData = false) => {
   const isValid = user && Object.keys(user).length !== 0 && user.constructor === Object;
   // Use the user data sent as arguments, else use data from fixtures
   user = isValid ? user : userData[0];
@@ -28,5 +28,10 @@ module.exports = async (user) => {
     const rolesToBeUpdated = { ...existingRoles, ...rolesToBeAdded };
     await users.addOrUpdate({ roles: rolesToBeUpdated }, userId);
   }
-  return userId;
+  const userInfo = { ...user, id: userId };
+  if (requireData) {
+    return userInfo;
+  } else {
+    return userId;
+  }
 };


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 20 Dec 2024
<!--Developer Name Here-->
Developer Name: Anuj Chhikara

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
#2294 
## Description
In this PR, we have updated the logic for storing user-related information when a progress is created. Previously, only the `userId` was stored, but now we are storing the complete `userData` object. This change ensures that more comprehensive user details are available directly within the progress data, reducing the need for additional API calls to fetch user information from the frontend.

<!--Description of the changes made in this PR-->

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [x] Yes
- [ ] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->
## Post Request working fine 
- Without dev flag
<div>
<img src="https://github.com/user-attachments/assets/f815d2fb-013a-4f56-8bc6-aff962912cf5" alt="Postman Image 1" width=380px />
<img src="https://github.com/user-attachments/assets/4c502efc-9502-4d44-91f3-71754c1d857b" alt="Postman Image 2" width=380px />
</div>

- With dev flag
  userData field getting add in place of userId
 <div>
<img src="https://github.com/user-attachments/assets/f8b9db05-6efa-49d9-b9ee-af15f1fa049f" alt="Postman Image 1" width=380px />
<img src="https://github.com/user-attachments/assets/9cf36252-0405-466d-ad87-b3ddfdf9d253" alt="Postman Image 2" width=380px />
</div>
</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->
![image](https://github.com/user-attachments/assets/58e84289-5bd4-4b50-a610-616eddcc32d3)
![image](https://github.com/user-attachments/assets/b617c4b8-b704-4a2d-bdc1-aea8678e5161)
![image](https://github.com/user-attachments/assets/7a740178-ebdf-4a99-a0c4-57a00b074b25)

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes
- Updated addUser Function:
 The addUser function in the utils previously only returned userId. To support storing userData in progresses, I added a second argument (defaulted to false). When set to true, the function now returns userData, which we use in tests to store the full user data in the progress documents.
<!--Any additional notes, considerations or explanations for reviewers-->
