### PR TITLE
Fix: skip users having approved onboarding extension when applying groupOnboarding31d+ role

### DIFF
--- a/test/unit/models/discordactions.test.js
+++ b/test/unit/models/discordactions.test.js
@@ -40,6 +40,7 @@ const {
   removeMemberGroup,
   getGroupRoleByName,
   getGroupRolesForUser,
+  skipOnboardingUsersHavingApprovedExtensionRequest,
 } = require("../../../models/discordactions");
 const {
   groupData,
@@ -63,6 +64,8 @@ const { stubbedModelTaskProgressData } = require("../../fixtures/progress/progre
 const { convertDaysToMilliseconds } = require("../../../utils/time");
 const { generateUserStatusData } = require("../../fixtures/userStatus/userStatus");
 const { userState } = require("../../../constants/userStatus");
+const { REQUEST_TYPE, REQUEST_STATE } = require("../../../constants/requests");
+const { createRequest } = require("../../../models/requests");
 
 chai.should();
 
@@ -1064,6 +1067,7 @@ describe("discordactions", function () {
 
   describe("updateUsersWith31DaysPlusOnboarding", function () {
     let fetchStub;
+    let userId0;
 
     beforeEach(async function () {
       fetchStub = sinon.stub(global, "fetch");
@@ -1087,7 +1091,7 @@ describe("discordactions", function () {
         roles: { archived: false, in_discord: true },
       };
 
-      const userId0 = await addUser(userData[0]);
+      userId0 = await addUser(userData[0]);
       const userId1 = await addUser(userData[1]);
       const userId2 = await addUser(userData[2]);
 
@@ -1131,6 +1135,48 @@ describe("discordactions", function () {
     afterEach(async function () {
       sinon.restore();
       await cleanDb();
+    });
+
+    it("should add grouponboarding31D when user has an approved extension request but dealine has been passed", async function () {
+      await createRequest({
+        type: REQUEST_TYPE.ONBOARDING,
+        state: REQUEST_STATE.APPROVED,
+        newEndsOn: Date.now() - convertDaysToMilliseconds(2),
+        userId: userId0,
+      });
+
+      const res = await updateUsersWith31DaysPlusOnboarding();
+      expect(res.totalOnboardingUsers31DaysCompleted.count).to.equal(2);
+      expect(res.totalOnboarding31dPlusRoleApplied.count).to.equal(1);
+      expect(res.totalOnboarding31dPlusRoleRemoved.count).to.equal(1);
+    });
+
+    it("should add grouponboarding31D when user does not have approved extension request", async function () {
+      await createRequest({
+        type: REQUEST_TYPE.ONBOARDING,
+        state: REQUEST_STATE.PENDING,
+        newEndsOn: Date.now() + convertDaysToMilliseconds(2),
+        userId: userId0,
+      });
+
+      const res = await updateUsersWith31DaysPlusOnboarding();
+      expect(res.totalOnboardingUsers31DaysCompleted.count).to.equal(2);
+      expect(res.totalOnboarding31dPlusRoleApplied.count).to.equal(1);
+      expect(res.totalOnboarding31dPlusRoleRemoved.count).to.equal(1);
+    });
+
+    it("should not add grouponboarding31D when user has approved extension request", async function () {
+      await createRequest({
+        type: REQUEST_TYPE.ONBOARDING,
+        state: REQUEST_STATE.APPROVED,
+        newEndsOn: Date.now() + convertDaysToMilliseconds(2),
+        userId: userId0,
+      });
+
+      const res = await updateUsersWith31DaysPlusOnboarding();
+      expect(res.totalOnboardingUsers31DaysCompleted.count).to.equal(1);
+      expect(res.totalOnboarding31dPlusRoleApplied.count).to.equal(1);
+      expect(res.totalOnboarding31dPlusRoleRemoved.count).to.equal(1);
     });
 
     it("apply, or remove grouponboarding31D", async function () {
@@ -1341,6 +1387,35 @@ describe("discordactions", function () {
         expect(err).to.be.instanceOf(Error);
         expect(err.message).to.equal("Database error while paginating group roles");
       }
+    });
+  });
+
+  describe("skipOnboardingUsersHavingApprovedExtensionRequest", function () {
+    const userId0 = "11111";
+    const userId1 = "12345";
+
+    afterEach(async function () {
+      sinon.restore();
+      await cleanDb();
+    });
+
+    it("should return filtered users", async function () {
+      await createRequest({
+        state: REQUEST_STATE.APPROVED,
+        type: REQUEST_TYPE.ONBOARDING,
+        newEndsOn: Date.now() + convertDaysToMilliseconds(2),
+        userId: userId0,
+      });
+      const users = await skipOnboardingUsersHavingApprovedExtensionRequest([{ id: userId0 }, { id: userId1 }]);
+      expect(users.length).to.equal(1);
+      expect(users[0].id).to.equal(userId1);
+    });
+
+    it("should not return filtered users", async function () {
+      const users = await skipOnboardingUsersHavingApprovedExtensionRequest([{ id: userId0 }, { id: userId1 }]);
+      expect(users.length).to.equal(2);
+      expect(users[0].id).to.equal(userId0);
+      expect(users[1].id).to.equal(userId1);
     });
   });
 });


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 2 Jan, 2025
<!--Developer Name Here-->
Developer Name: @pankajjs 

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
- Closes #2187 
## Description
 - The PR contains the fix and tests both. 
 - This PR filters onboarding users and skip who have a valid approved extension request and then apply the `groupOnboarding31d+` role.
<!--Description of the changes made in this PR-->
### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag
 - The changes are not behind feature flag as the `/discord-actions/group-onboarding-31d-plus` api is invoked by cron job after every 30 minutes. I have not made the changes behind feature flag because there is not any user's control over feature flag to enable or disable it.
- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Working Videos</summary>

- Example when cron job run and apply `groupOnboarding31d+` role.

https://github.com/user-attachments/assets/3d6570f7-87b6-4848-9998-9f20638aa7ec

- Example when cron job run and skip the user who has valid approved extension request.

https://github.com/user-attachments/assets/acce53b6-5148-4431-8e5f-589fc081c6d4




<!-- Attach your screenshots here👇-->

</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshots
</summary>

<img width="884" alt="Screenshot 2025-01-02 at 1 02 36 PM" src="https://github.com/user-attachments/assets/cc347dfe-8c5a-4711-a53a-3a75f59a4bef" />
<img width="867" alt="Screenshot 2025-01-02 at 1 03 57 PM" src="https://github.com/user-attachments/assets/2580a46f-241c-4c28-a007-4c8e9ff724bb" />
<img width="1418" alt="Screenshot 2025-01-02 at 1 05 11 PM" src="https://github.com/user-attachments/assets/d1e564f7-528d-42f7-8eb2-809b9a81b848" />
<img width="1445" alt="Screenshot 2025-01-02 at 1 05 58 PM" src="https://github.com/user-attachments/assets/2564d406-789f-4cea-af9a-9cbda7d234df" />
<img width="372" alt="Screenshot 2025-01-02 at 12 58 26 PM" src="https://github.com/user-attachments/assets/103911df-950a-4bf6-ba94-d6bc85be51c5" />



</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
