### PR TITLE
fix: send conflict response when user has a pending request

### DIFF
--- a/controllers/onboardingExtension.ts
+++ b/controllers/onboardingExtension.ts
@@ -57,7 +57,7 @@ export const createOnboardingExtensionRequestController = async (req: Onboarding
         });
 
         if(latestExtensionRequest && latestExtensionRequest.state === REQUEST_STATE.PENDING){
-            return res.boom.badRequest(REQUEST_ALREADY_PENDING);
+            return res.boom.conflict(REQUEST_ALREADY_PENDING);
         }
         
         const millisecondsInThirtyOneDays = convertDaysToMilliseconds(31);

--- a/test/integration/onboardingExtension.test.ts
+++ b/test/integration/onboardingExtension.test.ts
@@ -215,7 +215,7 @@ describe("/requests Onboarding Extension", () => {
             })
         })
     
-        it("should return 400 response when a user already has a pending request", (done)=> {
+        it("should return 409 response when a user already has a pending request", (done)=> {
             createUserStatusWithState(testUserId, userStatusModel, userState.ONBOARDING);
             requestsQuery.createRequest({...extensionRequest, state: REQUEST_STATE.PENDING, userId: testUserId});
     
@@ -225,8 +225,8 @@ describe("/requests Onboarding Extension", () => {
             .send(body)
             .end((err, res) => {
                 if (err) return done(err);
-                expect(res.statusCode).to.equal(400);
-                expect(res.body.error).to.equal("Bad Request");
+                expect(res.statusCode).to.equal(409);
+                expect(res.body.error).to.equal("Conflict");
                 expect(res.body.message).to.equal(REQUEST_ALREADY_PENDING);
                 done();
             })


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 8 Jan, 2025
<!--Developer Name Here-->
Developer Name: @pankajjs 

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
- Closes #2187 
## Description

<!--Description of the changes made in this PR-->
This PR fixes the error response when a user has a pending request and try to create another request.
### Documentation Updated?

- [x] Yes
- [ ] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
