### PR TITLE
Fix: Handle `id` query parameter in Get Requests API

### DIFF
--- a/controllers/requests.ts
+++ b/controllers/requests.ts
@@ -60,6 +60,13 @@ export const getRequestsController = async (req: any, res: any) => {
       return res.status(204).send();
     }
 
+       if (query.id) {
+         return res.status(200).json({
+           message: REQUEST_FETCHED_SUCCESSFULLY,
+           data: requests,
+         });
+       }
+
     const { allRequests, next, prev, page } = requests;
     if (allRequests.length === 0) {
       return res.status(204).send();

--- a/test/integration/requests.test.ts
+++ b/test/integration/requests.test.ts
@@ -273,6 +273,17 @@ describe("/requests OOO", function () {
         });
     });
 
+       it("should return the request by Id query", function (done) {
+         chai
+           .request(app)
+           .get(`/requests?id=${oooRequestId}`)
+           .end(function (err, res) {
+             expect(res).to.have.status(200);
+             expect(res.body.data.id === oooRequestId);
+             done();
+           });
+       });
+
     it("should return all requests by specific user", function (done) {
       chai
         .request(app)


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 25 Jan, 2025
<!--Developer Name Here-->
Developer Name: @AnujChhikara

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
- Closes #2366 
## Description
- Fixed an issue where the Get Requests API fails with a 500 Internal Server Error when the `id` query parameter is provided (e.g., `?id=randomId`).
- Added test to validate the behavior of the `id` query parameter.
<!--Description of the changes made in this PR-->

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

https://github.com/user-attachments/assets/0177a627-5efd-49c9-aa4b-57e1edb7cb9e


<!-- Attach your screenshots here👇-->

</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->
![image](https://github.com/user-attachments/assets/d7bfcc7c-7d80-4f74-ae67-31622b13f68f)

![image](https://github.com/user-attachments/assets/f460d912-86be-4065-b1bc-3dd864af66e5)

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
