### PR TITLE
Dev to Main Sync

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,12 +23,13 @@ app.use(function (req, res, next) {
 });
 
 // error handler
-app.use(function (err, req, res, next) {
+app.use(function (err, req, res, _next) {
   if (isMulterError(err)) {
-    multerErrorHandling(err, req, res);
-  } else {
-    res.boom.notFound(err);
+    return multerErrorHandling(err, req, res);
   }
+  return res.boom.boomify(err, {
+    statusCode: err.statusCode,
+  });
 });
 
 module.exports = app;

--- a/controllers/extensionRequests.js
+++ b/controllers/extensionRequests.js
@@ -105,7 +105,7 @@ const createTaskExtensionRequest = async (req, res) => {
  */
 const fetchExtensionRequests = async (req, res) => {
   try {
-    const { cursor, size, order } = req.query;
+    const { cursor, size = 5, order } = req.query;
     const { status, taskId, assignee } = parseQueryParams(req._parsedUrl.search);
     const { transformedSize, transformedStatus } = transformQuery(size, status);
 

--- a/controllers/onboardingExtension.ts
+++ b/controllers/onboardingExtension.ts
@@ -151,10 +151,6 @@ export const updateOnboardingExtensionRequestState = async (
     req: UpdateOnboardingExtensionStateRequest, 
     res: OnboardingExtensionResponse )
     : Promise<OnboardingExtensionResponse> => {
-    
-    const dev = req.query.dev === "true";
-    
-    if(!dev) return res.boom.notImplemented("Feature not implemented");
 
     const body = req.body as UpdateOnboardingExtensionStateRequestBody;
     const lastModifiedBy = req?.userData?.id;
@@ -224,9 +220,6 @@ export const updateOnboardingExtensionRequestController = async (
     const id = req.params.id;
     const lastModifiedBy = req?.userData?.id;
     const isSuperuser = req?.userData?.roles?.super_user === true;
-    const dev = req.query.dev === "true";
-
-    if(!dev) return res.boom.notImplemented("Feature not implemented");
 
     try{
         const extensionRequestDoc = await requestModel.doc(id).get();

--- a/middlewares/skipAuthenticateForOnboardingExtension.ts
+++ b/middlewares/skipAuthenticateForOnboardingExtension.ts
@@ -14,14 +14,8 @@ import { REQUEST_TYPE } from "../constants/requests";
 export const skipAuthenticateForOnboardingExtensionRequest = (authenticate, verifyDiscordBot) => {
     return async (req: Request, res: Response, next: NextFunction) => {
         const type = req.body.type;
-        const dev = req.query.dev;
 
         if(type === REQUEST_TYPE.ONBOARDING){
-            if (dev != "true"){
-                return res.status(501).json({
-                    message: "Feature not implemented"
-                })
-            }
             return await verifyDiscordBot(req, res, next);
         }
 

--- a/models/progresses.js
+++ b/models/progresses.js
@@ -50,15 +50,11 @@ const createProgressDocument = async (progressData) => {
  * @throws {Error} If the userId or taskId is invalid or does not exist.
  **/
 const getProgressDocument = async (queryParams) => {
-  const { dev } = queryParams;
   await assertUserOrTaskExists(queryParams);
   const query = buildQueryToFetchDocs(queryParams);
   const progressDocs = await getProgressDocs(query);
 
-  if (dev === "true") {
-    return await addUserDetailsToProgressDocs(progressDocs);
-  }
-  return progressDocs;
+  return await addUserDetailsToProgressDocs(progressDocs);
 };
 
 /**

--- a/test/integration/extensionRequests.test.js
+++ b/test/integration/extensionRequests.test.js
@@ -281,6 +281,24 @@ describe("Extension Requests", function () {
         });
     });
 
+    it("should return 5 extension requests by default when size query is not provided", function (done) {
+      chai
+        .request(app)
+        .get(`/extension-requests`)
+        .set("cookie", `${cookieName}=${appOwnerjwt}`)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+          expect(res).to.have.status(200);
+          expect(res.body).to.be.a("object");
+          expect(res.body.message).to.be.equal("Extension Requests returned successfully!");
+          expect(res.body.allExtensionRequests).to.be.a("array");
+          expect(res.body.allExtensionRequests).to.have.lengthOf(5);
+          return done();
+        });
+    });
+
     it("should return success response and all extension requests with query params", function (done) {
       chai
         .request(app)

--- a/test/integration/onboardingExtension.test.ts
+++ b/test/integration/onboardingExtension.test.ts
@@ -75,7 +75,7 @@ describe("/requests Onboarding Extension", () => {
 
         it("should not call verifyDiscordBot and return 401 response when extension type is not onboarding", (done)=> {
             chai.request(app)
-            .post(`${postEndpoint}?dev=true`)
+            .post(postEndpoint)
             .send({...body, type: REQUEST_TYPE.OOO})
             .end((err, res)=>{
                 if(err) return done(err);
@@ -86,22 +86,10 @@ describe("/requests Onboarding Extension", () => {
             })
         })
 
-        it("should return Feature not implemented when dev is not true", (done) => {
-            chai.request(app)
-            .post(`${postEndpoint}`)
-            .send(body)
-            .end((err, res)=>{
-                if (err) return done(err);
-                expect(res.statusCode).to.equal(501);
-                expect(res.body.message).to.equal("Feature not implemented");
-                done();
-            })
-        })
-    
         it("should return Invalid Request when authorization header is missing", (done) => {
             chai
             .request(app)
-            .post(`${postEndpoint}?dev=true`)
+            .post(postEndpoint)
             .set("authorization", "")
             .send(body)
             .end((err, res) => {
@@ -114,7 +102,7 @@ describe("/requests Onboarding Extension", () => {
     
         it("should return Unauthorized Bot for invalid token", (done) => {
             chai.request(app)
-            .post(`${postEndpoint}?dev=true`)
+            .post(postEndpoint)
             .set("authorization", `Bearer ${BAD_TOKEN}`)
             .send(body)
             .end((err, res) => {
@@ -127,7 +115,7 @@ describe("/requests Onboarding Extension", () => {
     
         it("should return 400 response for invalid value type of numberOfDays", (done) => {
             chai.request(app)
-            .post(`${postEndpoint}?dev=true`)
+            .post(postEndpoint)
             .set("authorization", `Bearer ${botToken}`)
             .send({...body, numberOfDays:"1"})
             .end((err, res) => {
@@ -141,7 +129,7 @@ describe("/requests Onboarding Extension", () => {
     
         it("should return 400 response for invalid value of numberOfDays", (done) => {
             chai.request(app)
-            .post(`${postEndpoint}?dev=true`)
+            .post(postEndpoint)
             .set("authorization", `Bearer ${botToken}`)
             .send({...body, numberOfDays:1.4})
             .end((err, res) => {
@@ -155,7 +143,7 @@ describe("/requests Onboarding Extension", () => {
     
         it("should return 400 response for invalid userId", (done) => {
             chai.request(app)
-            .post(`${postEndpoint}?dev=true`)
+            .post(postEndpoint)
             .set("authorization", `Bearer ${botToken}`)
             .send({...body, userId: undefined})
             .end((err, res) => {
@@ -172,7 +160,7 @@ describe("/requests Onboarding Extension", () => {
             sinon.stub(requestsQuery, "createRequest")
             .throws("Error while creating extension request");
             chai.request(app)
-            .post(`${postEndpoint}?dev=true`)
+            .post(postEndpoint)
             .set("authorization", `Bearer ${botToken}`)
             .send(body)
             .end((err, res)=>{
@@ -186,7 +174,7 @@ describe("/requests Onboarding Extension", () => {
         it("should return 500 response when discordJoinedAt date string is invalid", (done) => {
             createUserStatusWithState(testUserIdForInvalidDiscordJoinedDate, userStatusModel, userState.ONBOARDING);
             chai.request(app)
-            .post(`${postEndpoint}?dev=true`)
+            .post(postEndpoint)
             .set("authorization", `Bearer ${botToken}`)
             .send({...body, userId: testUserDiscordIdForInvalidDiscordJoinedDate})
             .end((err, res)=>{
@@ -199,7 +187,7 @@ describe("/requests Onboarding Extension", () => {
 
         it("should return 404 response when user does not exist", (done) => {
             chai.request(app)
-            .post(`${postEndpoint}?dev=true`)
+            .post(postEndpoint)
             .set("authorization", `Bearer ${botToken}`)
             .send({...body, userId: "11111"})
             .end((err, res) => {
@@ -214,7 +202,7 @@ describe("/requests Onboarding Extension", () => {
         it("should return 403 response when user's status is not onboarding", (done)=> {
             createUserStatusWithState(testUserId, userStatusModel, userState.ACTIVE);
             chai.request(app)
-            .post(`${postEndpoint}?dev=true`)
+            .post(postEndpoint)
             .set("authorization", `Bearer ${botToken}`)
             .send(body)
             .end((err, res) => {
@@ -231,7 +219,7 @@ describe("/requests Onboarding Extension", () => {
             requestsQuery.createRequest({...extensionRequest, state: REQUEST_STATE.PENDING, userId: testUserId});
     
             chai.request(app)
-            .post(`${postEndpoint}?dev=true`)
+            .post(postEndpoint)
             .set("authorization", `Bearer ${botToken}`)
             .send(body)
             .end((err, res) => {
@@ -246,7 +234,7 @@ describe("/requests Onboarding Extension", () => {
         it("should return 201 for successful response when user has onboarding state", (done)=> {
             createUserStatusWithState(testUserId, userStatusModel, userState.ONBOARDING);
             chai.request(app)
-            .post(`${postEndpoint}?dev=true`)
+            .post(postEndpoint)
             .set("authorization", `Bearer ${botToken}`)
             .send(body)
             .end((err, res) => {
@@ -271,7 +259,7 @@ describe("/requests Onboarding Extension", () => {
             });
 
             const res = await chai.request(app)
-            .post(`${postEndpoint}?dev=true`)
+            .post(postEndpoint)
             .set("authorization", `Bearer ${botToken}`)
             .send(body);
 
@@ -296,7 +284,7 @@ describe("/requests Onboarding Extension", () => {
             });
             
             const res = await chai.request(app)
-            .post(`${postEndpoint}?dev=true`)
+            .post(postEndpoint)
             .set("authorization", `Bearer ${botToken}`)
             .send(body);
 
@@ -418,7 +406,7 @@ describe("/requests Onboarding Extension", () => {
                 type: REQUEST_TYPE.ONBOARDING, 
                 requestNumber: 2
             });
-            putEndpoint = `/requests/${latestExtension.id}?dev=true`;
+            putEndpoint = `/requests/${latestExtension.id}`;
             authToken = generateAuthToken({userId});
         })
 
@@ -443,7 +431,7 @@ describe("/requests Onboarding Extension", () => {
 
         it("should return Invalid request type for incorrect value of type", (done) => {
             chai.request(app)
-            .put("/requests/1111?dev=true")
+            .put("/requests/1111")
             .set("authorization", `Bearer ${authToken}`)
             .send({...body, type: "<InvalidType>"})
             .end((err, res)=>{
@@ -451,19 +439,6 @@ describe("/requests Onboarding Extension", () => {
                 expect(res.statusCode).to.equal(400);
                 expect(res.body.error).to.equal("Bad Request");
                 expect(res.body.message).to.equal('"type" must be one of [OOO, EXTENSION, ONBOARDING]');
-                done();
-            })
-        })
-
-        it("should return Feature not implemented when dev is not true", (done) => {
-            chai.request(app)
-            .put(`/requests/1111?dev=false`)
-            .send(body)
-            .set("authorization", `Bearer ${authToken}`)
-            .end((err, res)=>{
-                if (err) return done(err);
-                expect(res.statusCode).to.equal(501);
-                expect(res.body.message).to.equal("Feature not implemented");
                 done();
             })
         })
@@ -510,7 +485,7 @@ describe("/requests Onboarding Extension", () => {
 
         it("should return 404 response for invalid extension id", (done) => {
             chai.request(app)
-            .put(`/requests/1111?dev=true`)
+            .put(`/requests/1111`)
             .set("authorization", `Bearer ${authToken}`)
             .send(body)
             .end((err, res) => {
@@ -538,7 +513,7 @@ describe("/requests Onboarding Extension", () => {
 
         it("should return 400 response when extension state is approved", (done) => {
             chai.request(app)
-            .put(`/requests/${latestApprovedExtension.id}?dev=true`)
+            .put(`/requests/${latestApprovedExtension.id}`)
             .set("authorization", `Bearer ${authToken}`)
             .send(body)
             .end((err, res) => {
@@ -552,7 +527,7 @@ describe("/requests Onboarding Extension", () => {
 
         it("should return 400 response when extension state is rejected", (done) => {
             chai.request(app)
-            .put(`/requests/${latestRejectedExtension.id}?dev=true`)
+            .put(`/requests/${latestRejectedExtension.id}`)
             .set("authorization", `Bearer ${authToken}`)
             .send(body)
             .end((err, res) => {
@@ -646,7 +621,7 @@ describe("/requests Onboarding Extension", () => {
                 userId: userId
             });
             oooRequest = await requestsQuery.createRequest({type: REQUEST_TYPE.OOO, userId: userId});
-            patchEndpoint = `/requests/${latestValidExtension.id}?dev=true`;
+            patchEndpoint = `/requests/${latestValidExtension.id}`;
             authToken = generateAuthToken({userId});
         })
             
@@ -665,19 +640,6 @@ describe("/requests Onboarding Extension", () => {
                 expect(res.statusCode).to.equal(400);
                 expect(res.body.error).to.equal("Bad Request");
                 expect(res.body.message).to.equal("Invalid type");
-                done();
-            })
-        })
-
-        it("should return Feature not implemented when dev is not true", (done) => {
-            chai.request(app)
-            .patch(`/requests/1111?dev=false`)
-            .send(body)
-            .set("authorization", `Bearer ${authToken}`)
-            .end((err, res)=>{
-                if (err) return done(err);
-                expect(res.statusCode).to.equal(501);
-                expect(res.body.message).to.equal("Feature not implemented");
                 done();
             })
         })
@@ -725,7 +687,7 @@ describe("/requests Onboarding Extension", () => {
 
         it("should return 404 response for invalid extension id", (done) => {
             chai.request(app)
-            .patch(`/requests/1111?dev=true`)
+            .patch(`/requests/1111`)
             .set("authorization", `Bearer ${authToken}`)
             .send(body)
             .end((err, res) => {
@@ -753,7 +715,7 @@ describe("/requests Onboarding Extension", () => {
 
         it("should return 400 response when request type is not onboarding", (done) => {
             chai.request(app)
-            .patch(`/requests/${oooRequest.id}?dev=true`)
+            .patch(`/requests/${oooRequest.id}`)
             .set("authorization", `Bearer ${authToken}`)
             .send(body)
             .end((err, res) => {
@@ -767,7 +729,7 @@ describe("/requests Onboarding Extension", () => {
 
         it("should return 400 response when extension state is not pending", (done) => {
             chai.request(app)
-            .patch(`/requests/${latestApprovedExtension.id}?dev=true`)
+            .patch(`/requests/${latestApprovedExtension.id}`)
             .set("authorization", `Bearer ${authToken}`)
             .send(body)
             .end((err, res) => {
@@ -781,7 +743,7 @@ describe("/requests Onboarding Extension", () => {
 
         it("should return 400 response when old dealdine is greater than new deadline", (done) => {
             chai.request(app)
-            .patch(`/requests/${latestInvalidExtension.id}?dev=true`)
+            .patch(`/requests/${latestInvalidExtension.id}`)
             .set("authorization", `Bearer ${authToken}`)
             .send(body)
             .end((err, res) => {

--- a/test/integration/progressesTasks.test.js
+++ b/test/integration/progressesTasks.test.js
@@ -212,61 +212,7 @@ describe("Test Progress Updates API for Tasks", function () {
               "type",
               "completed",
               "planned",
-              "blockers",
-              "userId",
-              "createdAt",
-              "date",
-            ]);
-          });
-          return done();
-        });
-    });
-
-    it("Returns the progress array for the task with userData object", function (done) {
-      chai
-        .request(app)
-        .get(`/progresses?taskId=${taskId1}&dev=true`)
-        .end((err, res) => {
-          if (err) return done(err);
-          expect(res).to.have.status(200);
-          expect(res.body).to.have.keys(["message", "data", "count", "links"]);
-          expect(res.body.data).to.be.an("array");
-          expect(res.body.message).to.be.equal("Progress document retrieved successfully.");
-          res.body.data.forEach((progress) => {
-            expect(progress).to.have.keys([
-              "id",
-              "taskId",
-              "type",
-              "completed",
-              "planned",
-              "blockers",
               "userData",
-              "userId",
-              "createdAt",
-              "date",
-            ]);
-          });
-          return done();
-        });
-    });
-
-    it("Returns the progress array for the task without userData field if dev is false", function (done) {
-      chai
-        .request(app)
-        .get(`/progresses?taskId=${taskId1}&dev=false`)
-        .end((err, res) => {
-          if (err) return done(err);
-          expect(res).to.have.status(200);
-          expect(res.body).to.have.keys(["message", "data", "count"]);
-          expect(res.body.data).to.be.an("array");
-          expect(res.body.message).to.be.equal("Progress document retrieved successfully.");
-          res.body.data.forEach((progress) => {
-            expect(progress).to.have.keys([
-              "id",
-              "taskId",
-              "type",
-              "completed",
-              "planned",
               "blockers",
               "userId",
               "createdAt",
@@ -371,36 +317,8 @@ describe("Test Progress Updates API for Tasks", function () {
               "type",
               "completed",
               "planned",
-              "blockers",
-              "userId",
-              "createdAt",
-              "date",
-            ]);
-          });
-          return done();
-        });
-    });
-
-    it("Returns the progress array for all the tasks with userData object", function (done) {
-      chai
-        .request(app)
-        .get(`/progresses?type=task&dev=true`)
-        .end((err, res) => {
-          if (err) return done(err);
-          expect(res).to.have.status(200);
-          expect(res.body).to.have.keys(["message", "data", "count", "links"]);
-          expect(res.body.data).to.be.an("array");
-          expect(res.body.message).to.be.equal("Progress document retrieved successfully.");
-          expect(res.body.count).to.be.equal(4);
-          res.body.data.forEach((progress) => {
-            expect(progress).to.have.keys([
-              "id",
-              "taskId",
-              "type",
-              "completed",
-              "planned",
-              "blockers",
               "userData",
+              "blockers",
               "userId",
               "createdAt",
               "date",
@@ -681,6 +599,7 @@ describe("Test Progress Updates API for Tasks", function () {
               "planned",
               "blockers",
               "userId",
+              "userData",
               "taskId",
               "createdAt",
               "date",

--- a/test/integration/progressesUsers.test.js
+++ b/test/integration/progressesUsers.test.js
@@ -192,6 +192,7 @@ describe("Test Progress Updates API for Users", function () {
               "planned",
               "blockers",
               "userId",
+              "userData",
               "createdAt",
               "date",
             ]);
@@ -208,59 +209,6 @@ describe("Test Progress Updates API for Users", function () {
           if (err) return done(err);
           expect(res).to.have.status(200);
           expect(res.body).to.have.keys(["message", "data", "count"]);
-          expect(res.body.data).to.be.an("array");
-          expect(res.body.message).to.be.equal("Progress document retrieved successfully.");
-          res.body.data.forEach((progress) => {
-            expect(progress).to.have.keys([
-              "id",
-              "type",
-              "completed",
-              "planned",
-              "blockers",
-              "userId",
-              "createdAt",
-              "date",
-            ]);
-          });
-          return done();
-        });
-    });
-
-    it("Returns the progress array for a specific user with userData object", function (done) {
-      chai
-        .request(app)
-        .get(`/progresses?userId=${userId1}&dev=true`)
-        .end((err, res) => {
-          if (err) return done(err);
-          expect(res).to.have.status(200);
-          expect(res.body).to.have.keys(["message", "data", "count", "links"]);
-          expect(res.body.data).to.be.an("array");
-          expect(res.body.message).to.be.equal("Progress document retrieved successfully.");
-          res.body.data.forEach((progress) => {
-            expect(progress).to.have.keys([
-              "id",
-              "type",
-              "completed",
-              "planned",
-              "blockers",
-              "userId",
-              "userData",
-              "createdAt",
-              "date",
-            ]);
-          });
-          return done();
-        });
-    });
-
-    it("Returns the progress array for all the user with userData object when dev is true", function (done) {
-      chai
-        .request(app)
-        .get(`/progresses?type=user&dev=true`)
-        .end((err, res) => {
-          if (err) return done(err);
-          expect(res).to.have.status(200);
-          expect(res.body).to.have.keys(["message", "data", "count", "links"]);
           expect(res.body.data).to.be.an("array");
           expect(res.body.message).to.be.equal("Progress document retrieved successfully.");
           res.body.data.forEach((progress) => {
@@ -416,31 +364,6 @@ describe("Test Progress Updates API for Users", function () {
             "completed",
             "planned",
             "blockers",
-            "userId",
-            "createdAt",
-            "date",
-          ]);
-          return done();
-        });
-    });
-
-    it("Returns the progress data for a specific user with userData object", function (done) {
-      chai
-        .request(app)
-        .get(`/progresses/user/${userId}/date/2023-05-02?dev=true`)
-        .end((err, res) => {
-          if (err) return done(err);
-          expect(res).to.have.status(200);
-          expect(res.body).to.have.keys(["message", "data"]);
-          expect(res.body.data).to.be.an("object");
-          expect(res.body.message).to.be.equal("Progress document retrieved successfully.");
-          expect(res.body.data).to.have.keys([
-            "id",
-            "type",
-            "completed",
-            "planned",
-            "blockers",
-            "userData",
             "userId",
             "createdAt",
             "date",

--- a/test/unit/middlewares/skipAuthenticateForOnboardingExtension.test.ts
+++ b/test/unit/middlewares/skipAuthenticateForOnboardingExtension.test.ts
@@ -25,18 +25,7 @@ describe("skipAuthenticateForOnboardingExtensionRequest Middleware", () => {
         assert.isTrue(verifyDiscordBot.notCalled, "verifyDiscordBot should not be called");
     });
 
-    it("should not call verifyDicordBot and authenticate when dev is not true and type is onboarding", async () => {
-        req.query.dev = "false";
-        req.body.type = REQUEST_TYPE.ONBOARDING;
-
-        middleware(req, res, next);
-
-        assert.isTrue(verifyDiscordBot.notCalled, "verifyDiscordBot should not be called");
-        assert.isTrue(authenticate.notCalled, "authenticate should not be called");
-    });
-
-    it("should call verifyDiscordBot when dev is true and type is onboarding", () => {
-        req.query.dev = "true";
+    it("should call verifyDiscordBot when type is onboarding", async () => {
         req.body.type = REQUEST_TYPE.ONBOARDING;
 
         middleware(req, res, next);


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 7 Feb, 2025
<!--Developer Name Here-->
Developer Name: @pankajjs @AnujChhikara @mbramani 

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
- Closes #2371
- Closes #2338 
- Closes #2376 
## Description
@pankajjs's change fixes error handler middleware to send error response.
@mbramani's change removes feature flag from ```POST /requests```,  ```PUT /requests/id```, and ```PATCH /requests/id``` endpoints for onboarding extension feature.
@AnujChhikara's change removes feature flag from progress api and adds a default size(5) for ```GET /extension-requests``` endpoint when user does not pass any size.
## PR going to Sync
- #2372 
- #2378 
- #2382 
- #2380

<!--Description of the changes made in this PR-->

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshots</summary>
Onboarding Extension Feature

![image](https://github.com/user-attachments/assets/3138ff6a-f833-4325-ab3d-062a917fb59c)

![image](https://github.com/user-attachments/assets/4dd67643-3fd9-453b-ae7c-790274a7d55f)
<!-- Attach your screenshots here👇-->

- For PR-2378

![image](https://github.com/user-attachments/assets/ce6c06c2-e7ef-4682-800b-e03d23b9040e)

- In this video you can see that only 5 extension request loads if we don't provide any size query

https://github.com/user-attachments/assets/f481b364-e1d2-432d-8157-d11df1219ee3

- For PR-2380
 You we can see we are returning the userdata in the response without the dev flag
![Screenshot from 2025-03-03 22-20-34](https://github.com/user-attachments/assets/1e578f85-3fc2-48ec-b0a5-5915d6080276)



</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshots</summary>

<!-- Attach your screenshots here👇-->

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
