### PR TITLE
fix: Set default size for GET /extension-requests API

### DIFF
--- a/controllers/extensionRequests.js
+++ b/controllers/extensionRequests.js
@@ -105,7 +105,7 @@ const createTaskExtensionRequest = async (req, res) => {
  */
 const fetchExtensionRequests = async (req, res) => {
   try {
-    const { cursor, size, order } = req.query;
+    const { cursor, size = 5, order } = req.query;
     const { status, taskId, assignee } = parseQueryParams(req._parsedUrl.search);
     const { transformedSize, transformedStatus } = transformQuery(size, status);
 

--- a/test/integration/extensionRequests.test.js
+++ b/test/integration/extensionRequests.test.js
@@ -281,6 +281,24 @@ describe("Extension Requests", function () {
         });
     });
 
+    it("should return 5 extension requests by default when size query is not provided", function (done) {
+      chai
+        .request(app)
+        .get(`/extension-requests`)
+        .set("cookie", `${cookieName}=${appOwnerjwt}`)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+          expect(res).to.have.status(200);
+          expect(res.body).to.be.a("object");
+          expect(res.body.message).to.be.equal("Extension Requests returned successfully!");
+          expect(res.body.allExtensionRequests).to.be.a("array");
+          expect(res.body.allExtensionRequests).to.have.lengthOf(5);
+          return done();
+        });
+    });
+
     it("should return success response and all extension requests with query params", function (done) {
       chai
         .request(app)


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 7 Feb 2025
<!--Developer Name Here-->
Developer Name: @AnujChhikara 

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
- #2338 
## Description

<!--Description of the changes made in this PR-->
- Added a default size=5 for the /extension-requests API when the size query parameter is not provided.
- Wrote a test to verify that the API returns exactly 5 extension requests by default.

### Documentation Updated?

- [x] Yes
- [ ] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>


<!-- Attach your screenshots here👇-->
- In the video, you can see that if the size query parameter is not provided, the response returns only five objects.

![image](https://github.com/user-attachments/assets/e00d5eea-394d-4813-bed4-498b5f851152)

https://github.com/user-attachments/assets/ff075540-2b66-40ea-ae4c-aefb0e23e0d0

https://github.com/user-attachments/assets/24d5d1f6-1bb7-4e26-b41a-c64568a715b5
</details>




<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->
![image](https://github.com/user-attachments/assets/e55f6044-9db6-4ed1-a7ac-4f2e82a8f2d2)


</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
