### PR TITLE
Fix: Allow Only Super Users or Request Owners to Edit Requests

### DIFF
--- a/controllers/extensionRequests.js
+++ b/controllers/extensionRequests.js
@@ -218,6 +218,14 @@ const updateExtensionRequest = async (req, res) => {
       return res.boom.badRequest("Only pending extension request can be updated");
     }
 
+    if (
+      isDev &&
+      !req.userData?.roles.super_user &&
+      extensionRequest.extensionRequestData.assigneeId !== req.userData.id
+    ) {
+      return res.boom.forbidden("You don't have permission to update the extension request");
+    }
+
     if (req.body.assignee) {
       const { taskData: task } = await tasks.fetchTask(extensionRequest.extensionRequestData.taskId);
       if (task.assignee !== (await getUsername(req.body.assignee))) {

--- a/test/integration/extensionRequests.test.js
+++ b/test/integration/extensionRequests.test.js
@@ -19,10 +19,11 @@ const { LOGS_FETCHED_SUCCESSFULLY } = require("../../constants/logs");
 chai.use(chaiHttp);
 
 const user = userData[6];
+const user2 = userData[5];
 const appOwner = userData[3];
 const superUser = userData[4];
 
-let appOwnerjwt, superUserJwt, jwt, superUserId, extensionRequestId5;
+let appOwnerjwt, superUserJwt, jwt, jwt2, superUserId, extensionRequestId5;
 
 describe("Extension Requests", function () {
   let taskId0,
@@ -40,6 +41,7 @@ describe("Extension Requests", function () {
 
   before(async function () {
     const userId = await addUser(user);
+    const userId2 = await addUser(user2);
     user.id = userId;
     const appOwnerUserId = await addUser(appOwner);
     appOwner.id = appOwnerUserId;
@@ -47,6 +49,7 @@ describe("Extension Requests", function () {
     appOwnerjwt = authService.generateAuthToken({ userId: appOwnerUserId });
     superUserJwt = authService.generateAuthToken({ userId: superUserId });
     jwt = authService.generateAuthToken({ userId: userId });
+    jwt2 = authService.generateAuthToken({ userId: userId2 });
 
     const taskData = [
       {
@@ -1090,6 +1093,26 @@ describe("Extension Requests", function () {
             return done(err);
           }
           expect(res).to.have.status(204);
+          return done();
+        });
+    });
+
+    it("Should return a 403 error if a non-superuser and non-owner try to update the request with the dev flag enabled.", function (done) {
+      chai
+        .request(app)
+        .patch(`/extension-requests/${extensionRequestId4}?dev=true`)
+        .set("cookie", `${cookieName}=${jwt2}`)
+        .send({
+          title: "new-title",
+        })
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+          expect(res).to.have.status(403);
+          expect(res.body)
+            .to.have.property("message")
+            .that.equals("You don't have permission to update the extension request");
           return done();
         });
     });


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 29 March 2025
<!--Developer Name Here-->
Developer Name: @AnujChhikara 

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
- #2397 
## Description
- Updated authorization logic to ensure that only superusers or the request assignee can edit extension requests.

<!--Description of the changes made in this PR-->

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [x] Yes
- [ ] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->
![Screenshot from 2025-03-29 23-24-07](https://github.com/user-attachments/assets/b3c499bd-1a2c-4f0a-a0d3-b574ec03ea20)

</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->
![Screenshot from 2025-03-29 23-25-26](https://github.com/user-attachments/assets/ad110843-1b5f-4415-8409-58aa3d10bbbe)
![Screenshot from 2025-03-29 23-28-20](https://github.com/user-attachments/assets/43fb5263-99e6-4822-b7ca-9a1b3efc8024)

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
