### PR TITLE
Fix: Apply Negligent Tag to Users When Task Status Is "Approved

### DIFF
--- a/models/tasks.js
+++ b/models/tasks.js
@@ -19,6 +19,7 @@ const {
   SANITY_CHECK,
   BACKLOG,
   DONE,
+  APPROVED,
 } = TASK_STATUS;
 const { OLD_ACTIVE, OLD_BLOCKED, OLD_PENDING, OLD_COMPLETED } = TASK_STATUS_OLD;
 const { INTERNAL_SERVER_ERROR } = require("../constants/errorMessages");
@@ -605,6 +606,7 @@ const getOverdueTasks = async (days = 0) => {
       SMOKE_TESTING,
       BLOCKED,
       SANITY_CHECK,
+      APPROVED,
     ];
 
     const query = tasksModel.where("endsOn", "<", targetTime).where("status", "in", OVERDUE_TASK_STATUSES);

--- a/test/fixtures/tasks/tasks.js
+++ b/test/fixtures/tasks/tasks.js
@@ -158,5 +158,18 @@ module.exports = () => {
       createdAt: 1644753600,
       updatedAt: 1644753600,
     },
+    {
+      title: "Approved task that can be overdue",
+      purpose: "testing for approved overdue tasks",
+      type: "feature",
+      assignee: "alex",
+      createdBy: "ankush",
+      createdAt: 1644753600,
+      updatedAt: 1644753600,
+      status: "APPROVED",
+      percentCompleted: 90,
+      endsOn: 1647172800, // 13 march
+      startedOn: 1644753600, //  13 feb
+    },
   ];
 };

--- a/test/unit/models/tasks.test.js
+++ b/test/unit/models/tasks.test.js
@@ -307,12 +307,12 @@ describe("tasks", function () {
       overdueTask.endsOn = Date.now() / 1000 + 24 * 60 * 60 * 7;
       await tasks.updateTask(overdueTask);
       const usersWithOverdueTasks = await tasks.getOverdueTasks(days);
-      expect(usersWithOverdueTasks.length).to.be.equal(5);
+      expect(usersWithOverdueTasks.length).to.be.equal(6);
     });
 
     it("should return all users which have overdue tasks if days is not passed", async function () {
       const usersWithOverdueTasks = await tasks.getOverdueTasks();
-      expect(usersWithOverdueTasks.length).to.be.equal(4);
+      expect(usersWithOverdueTasks.length).to.be.equal(5);
     });
   });
 
@@ -336,8 +336,8 @@ describe("tasks", function () {
 
     it("Should update task status COMPLETED to DONE", async function () {
       const res = await tasks.updateTaskStatus();
-      expect(res.totalTasks).to.be.equal(9);
-      expect(res.totalUpdatedStatus).to.be.equal(9);
+      expect(res.totalTasks).to.be.equal(10);
+      expect(res.totalUpdatedStatus).to.be.equal(10);
     });
 
     it("should throw an error if firebase batch operation fails", async function () {

--- a/test/unit/services/tasks.test.js
+++ b/test/unit/services/tasks.test.js
@@ -53,7 +53,7 @@ describe("Tasks services", function () {
       const res = await updateTaskStatusToDone(tasks);
 
       expect(res).to.deep.equal({
-        totalUpdatedStatus: 9,
+        totalUpdatedStatus: 10,
         totalOperationsFailed: 0,
         updatedTaskDetails: taskDetails,
         failedTaskDetails: [],
@@ -73,7 +73,7 @@ describe("Tasks services", function () {
 
       expect(res).to.deep.equal({
         totalUpdatedStatus: 0,
-        totalOperationsFailed: 9,
+        totalOperationsFailed: 10,
         updatedTaskDetails: [],
         failedTaskDetails: taskDetails,
       });


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 07 Apr 2025
<!--Developer Name Here-->
Developer Name: @mridxl

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
Closes #2390 

## Description

<!--Description of the changes made in this PR-->
This pull request addresses the issue where users with the "Approved" task status were not receiving the "Negligent" tag if they missed updates for more than three days. The "Approved" status was not included in the list of statuses that trigger the "Negligent" tag, causing this oversight. 

I have added "Approved" to the list of OVERDUE_TASK_STATUSES in the code.

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>
Integration tests: 
![image](https://github.com/user-attachments/assets/a7e42a88-3da8-4f1a-b75c-d7d3b04dcf29)

Unit tests:
![image](https://github.com/user-attachments/assets/f018a4c5-a5da-4aa5-8614-66610411b499)

![image](https://github.com/user-attachments/assets/ec6e522a-e212-4f7b-b5d2-599b9a8a218b)

![image](https://github.com/user-attachments/assets/7179fdaa-d999-40ca-9436-ae7508162066)

<!-- Attach your screenshots here👇-->

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
