### PR TITLE
Refactor negligent tagging logic to exclude only OOO users

### DIFF
--- a/models/discordactions.js
+++ b/models/discordactions.js
@@ -1019,7 +1019,7 @@ const getMissedProgressUpdatesUsers = async (options = {}) => {
         usersMap.set(taskAssignee, {
           tasksCount: 1,
           latestProgressCount: dateGap + 1,
-          isActive: false,
+          isOOO: false,
         });
       }
       const updateTasksIdMap = async () => {
@@ -1038,7 +1038,7 @@ const getMissedProgressUpdatesUsers = async (options = {}) => {
     const userIdChunks = chunks(Array.from(usersMap.keys()), FIRESTORE_IN_CLAUSE_SIZE);
     const userStatusSnapshotPromise = userIdChunks.map(
       async (userIdList) =>
-        await userStatusModel.where("currentStatus.state", "!=", userState.OOO).where("userId", "in", userIdList).get()
+        await userStatusModel.where("currentStatus.state", "==", userState.OOO).where("userId", "in", userIdList).get()
     );
     const userDetailsPromise = userIdChunks.map(
       async (userIdList) =>
@@ -1052,7 +1052,7 @@ const getMissedProgressUpdatesUsers = async (options = {}) => {
 
     userStatusChunks.forEach((userStatusList) =>
       userStatusList.forEach((doc) => {
-        usersMap.get(doc.data().userId).isActive = true;
+        usersMap.get(doc.data().userId).isOOO = true;
       })
     );
 
@@ -1094,7 +1094,7 @@ const getMissedProgressUpdatesUsers = async (options = {}) => {
       const isDiscordMember = !!discordUserData;
       const shouldAddRole =
         userData.latestProgressCount === 0 &&
-        userData.isActive &&
+        !userData.isOOO &&
         isDiscordMember &&
         discordUserData.isDeveloper &&
         !discordUserData.isMaven &&

--- a/models/discordactions.js
+++ b/models/discordactions.js
@@ -1038,10 +1038,7 @@ const getMissedProgressUpdatesUsers = async (options = {}) => {
     const userIdChunks = chunks(Array.from(usersMap.keys()), FIRESTORE_IN_CLAUSE_SIZE);
     const userStatusSnapshotPromise = userIdChunks.map(
       async (userIdList) =>
-        await userStatusModel
-          .where("currentStatus.state", "==", userState.ACTIVE)
-          .where("userId", "in", userIdList)
-          .get()
+        await userStatusModel.where("currentStatus.state", "!=", userState.OOO).where("userId", "in", userIdList).get()
     );
     const userDetailsPromise = userIdChunks.map(
       async (userIdList) =>

--- a/test/integration/tasks.test.js
+++ b/test/integration/tasks.test.js
@@ -1813,39 +1813,45 @@ describe("Tasks", function () {
   });
 
   describe("GET /tasks/users", function () {
-    let activeUserWithProgressUpdates;
+    let activeUserWithMissedProgressUpdates;
     let idleUser;
     let userNotInDiscord;
     let jwtToken;
     let getDiscordMembersStub;
+    let oooUserWithMissedUpdates;
+    let activeUserWithProgressUpdates;
 
     beforeEach(async function () {
       await cleanDb();
       idleUser = { ...userData[9], discordId: getDiscordMembers[0].user.id };
-      activeUserWithProgressUpdates = { ...userData[10], discordId: getDiscordMembers[1].user.id };
-      const activeUserWithNoUpdates = { ...userData[0], discordId: getDiscordMembers[2].user.id };
+      activeUserWithMissedProgressUpdates = { ...userData[10], discordId: getDiscordMembers[1].user.id };
+      activeUserWithProgressUpdates = { ...userData[0], discordId: getDiscordMembers[2].user.id };
       userNotInDiscord = { ...userData[4], discordId: "Not in discord" };
+      oooUserWithMissedUpdates = { ...userData[1], discordId: getDiscordMembers[3].user.id };
+
       const {
         idleStatus: idleUserStatus,
         activeStatus: activeUserStatus,
         userStatusDataForOooState: oooUserStatus,
       } = userStatusData;
       const userIdList = await Promise.all([
-        await addUser(idleUser), // idle user with no task progress updates
-        await addUser(activeUserWithProgressUpdates), // active user with task progress updates
-        await addUser(activeUserWithNoUpdates), // active user with no task progress updates
-        await addUser(userNotInDiscord), // OOO user with
+        await addUser(idleUser),
+        await addUser(activeUserWithMissedProgressUpdates),
+        await addUser(activeUserWithProgressUpdates),
+        await addUser(userNotInDiscord),
+        await addUser(oooUserWithMissedUpdates),
       ]);
       await Promise.all([
         await userStatusModel.updateUserStatus(userIdList[0], idleUserStatus),
         await userStatusModel.updateUserStatus(userIdList[1], activeUserStatus),
         await userStatusModel.updateUserStatus(userIdList[2], activeUserStatus),
         await userStatusModel.updateUserStatus(userIdList[3], oooUserStatus),
+        await userStatusModel.updateUserStatus(userIdList[4], oooUserStatus),
       ]);
 
       const tasksPromise = [];
 
-      for (let index = 0; index < 4; index++) {
+      for (let index = 0; index < 5; index++) {
         const task = tasksData[index];
         const validTask = {
           ...task,
@@ -1893,11 +1899,11 @@ describe("Tasks", function () {
       expect(response.body.message).to.equal(
         "Discord details of users with status missed updates fetched successfully"
       );
-      expect(response.body.data.tasks).to.equal(4);
-      expect(response.body.data.missedUpdatesTasks).to.equal(3);
-      expect(response.body.data.usersToAddRole.includes(activeUserWithProgressUpdates.discordId)).to.equal(true);
+      expect(response.body.data.tasks).to.equal(5);
+      expect(response.body.data.missedUpdatesTasks).to.equal(4);
+      expect(response.body.data.usersToAddRole.includes(activeUserWithMissedProgressUpdates.discordId)).to.equal(true);
       expect(response.body.data.usersToAddRole.includes(idleUser.discordId)).to.equal(true);
-      expect(response.body.data.usersToAddRole.includes(userNotInDiscord.discordId)).to.equal(false);
+      expect(response.body.data.usersToAddRole.includes(oooUserWithMissedUpdates.discordId)).to.equal(false);
       expect(response.status).to.be.equal(200);
     });
 
@@ -1906,7 +1912,7 @@ describe("Tasks", function () {
         .request(app)
         .get("/tasks/users/discord")
         .query({
-          size: 5,
+          size: 6,
           q: `status:${tasksUsersStatus.MISSED_UPDATES} -weekday:sun -weekday:mon -weekday:tue -weekday:wed -weekday:thu -weekday:fri -date:231423432 -days-count:4`,
         })
         .set("Authorization", `Bearer ${jwtToken}`);
@@ -1914,7 +1920,7 @@ describe("Tasks", function () {
         message: "Discord details of users with status missed updates fetched successfully",
         data: {
           usersToAddRole: [],
-          tasks: 4,
+          tasks: 5,
           missedUpdatesTasks: 0,
         },
       });

--- a/test/integration/tasks.test.js
+++ b/test/integration/tasks.test.js
@@ -1889,14 +1889,15 @@ describe("Tasks", function () {
         .get("/tasks/users/discord")
         .query({ q: `status:${tasksUsersStatus.MISSED_UPDATES}` })
         .set("Authorization", `Bearer ${jwtToken}`);
-      expect(response.body).to.be.deep.equal({
-        message: "Discord details of users with status missed updates fetched successfully",
-        data: {
-          usersToAddRole: [activeUserWithProgressUpdates.discordId],
-          tasks: 4,
-          missedUpdatesTasks: 3,
-        },
-      });
+
+      expect(response.body.message).to.equal(
+        "Discord details of users with status missed updates fetched successfully"
+      );
+      expect(response.body.data.tasks).to.equal(4);
+      expect(response.body.data.missedUpdatesTasks).to.equal(3);
+      expect(response.body.data.usersToAddRole.includes(activeUserWithProgressUpdates.discordId)).to.equal(true);
+      expect(response.body.data.usersToAddRole.includes(idleUser.discordId)).to.equal(true);
+      expect(response.body.data.usersToAddRole.includes(userNotInDiscord.discordId)).to.equal(false);
       expect(response.status).to.be.equal(200);
     });
 

--- a/test/unit/models/discordactions.test.js
+++ b/test/unit/models/discordactions.test.js
@@ -751,17 +751,17 @@ describe("discordactions", function () {
     it("should list of users who missed updating progress", async function () {
       const result = await getMissedProgressUpdatesUsers();
       expect(result).to.be.an("object");
-      expect(result).to.be.deep.equal({
-        tasks: 4,
-        missedUpdatesTasks: 3,
-        usersToAddRole: [activeUserWithProgressUpdates.discordId],
-      });
+      expect(result.tasks).to.not.equal(undefined);
+      expect(result.tasks).to.equal(4);
+      expect(result.missedUpdatesTasks).to.not.equal(undefined);
+      expect(result.missedUpdatesTasks).to.equal(3);
+      expect(result.usersToAddRole.includes(activeUserWithProgressUpdates.discordId)).to.equal(true);
+      expect(result.usersToAddRole.includes(idleUser.discordId)).to.equal(true);
     });
 
     it("should not list of users who are not active and who missed updating progress", async function () {
       const result = await getMissedProgressUpdatesUsers();
       expect(result).to.be.an("object");
-      expect(result.usersToAddRole).to.not.contain(idleUser.discordId);
       expect(result.usersToAddRole).to.not.contain(userNotInDiscord.discordId);
     });
 

--- a/test/unit/models/discordactions.test.js
+++ b/test/unit/models/discordactions.test.js
@@ -685,15 +685,16 @@ describe("discordactions", function () {
   });
 
   describe("getMissedProgressUpdatesUsers", function () {
-    let activeUserWithProgressUpdates;
+    let activeUserWithMissedProgressUpdates;
     let idleUser;
     let userNotInDiscord;
     let activeUserId;
+    let activeUserWithProgressUpdates;
 
     beforeEach(async function () {
       idleUser = { ...userData[9], discordId: getDiscordMembers[0].user.id };
-      activeUserWithProgressUpdates = { ...userData[10], discordId: getDiscordMembers[1].user.id };
-      const activeUserWithNoUpdates = { ...userData[0], discordId: getDiscordMembers[2].user.id };
+      activeUserWithMissedProgressUpdates = { ...userData[10], discordId: getDiscordMembers[1].user.id };
+      activeUserWithProgressUpdates = { ...userData[0], discordId: getDiscordMembers[2].user.id };
       userNotInDiscord = { ...userData[4], discordId: "Not in discord" };
       const {
         idleStatus: idleUserStatus,
@@ -701,10 +702,10 @@ describe("discordactions", function () {
         userStatusDataForOooState: oooUserStatus,
       } = userStatusData;
       const userIdList = await Promise.all([
-        await addUser(idleUser), // idle user with no task progress updates
-        await addUser(activeUserWithProgressUpdates), // active user with task progress updates
-        await addUser(activeUserWithNoUpdates), // active user with no task progress updates
-        await addUser(userNotInDiscord), // OOO user with no task progress updates
+        await addUser(idleUser),
+        await addUser(activeUserWithMissedProgressUpdates),
+        await addUser(activeUserWithProgressUpdates),
+        await addUser(userNotInDiscord),
       ]);
       activeUserId = userIdList[2];
       await Promise.all([
@@ -755,7 +756,7 @@ describe("discordactions", function () {
       expect(result.tasks).to.equal(4);
       expect(result.missedUpdatesTasks).to.not.equal(undefined);
       expect(result.missedUpdatesTasks).to.equal(3);
-      expect(result.usersToAddRole.includes(activeUserWithProgressUpdates.discordId)).to.equal(true);
+      expect(result.usersToAddRole.includes(activeUserWithMissedProgressUpdates.discordId)).to.equal(true);
       expect(result.usersToAddRole.includes(idleUser.discordId)).to.equal(true);
     });
 


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 29 April, 2025
<!--Developer Name Here-->
Developer Name: @pankajjs 

---

## Issue Ticket Number
- Closes #2390 
<!--Issue ticket this PR closes-->

## Description
 - This PR fixes a bug where negligent tag was not being applied on users who had status other than ```ACTIVE``` and their task's status were not ```Completed```, ```VERIFIED``` or ```Done```. Now, the changes will apply negligent tag to all users who have status other than ```OOO``` and their task's status is not ```Completed```, ```VERIFIED``` or ```Done```.
- The changes are not behind feature flag because cron job executes this API and there is no user or any service involvement directly for now.
- The changes also fixes the existing test-cases.
<!--Description of the changes made in this PR-->

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Working Video</summary>

https://github.com/user-attachments/assets/ccb6c9c9-273c-42fc-af8b-7afc899eaf08


https://github.com/user-attachments/assets/e73ad810-f151-4e1b-b7fc-003dd16cfa41


<!-- Attach your screenshots here👇-->

</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot</summary>
<img width="1238" alt="Screenshot 2025-05-01 at 6 53 36 PM" src="https://github.com/user-attachments/assets/1894a285-b4e5-4486-bac4-122127da8bdf" />
<img width="1206" alt="Screenshot 2025-05-01 at 6 54 07 PM" src="https://github.com/user-attachments/assets/c2849acc-60dd-4d9c-aa48-43ce7da13abc" />
<img width="989" alt="Screenshot 2025-05-01 at 6 54 16 PM" src="https://github.com/user-attachments/assets/40aa3021-2a7d-43f5-833a-6fed7294f019" />
<img width="1227" alt="Screenshot 2025-05-01 at 6 58 19 PM" src="https://github.com/user-attachments/assets/53d2251e-fe92-4aed-af0b-a30d051666fa" />
<img width="713" alt="Screenshot 2025-05-01 at 6 58 27 PM" src="https://github.com/user-attachments/assets/ba90d475-7fd1-44d0-960c-379078b92a1a" />
<img width="1024" alt="Screenshot 2025-04-29 at 9 48 42 PM" src="https://github.com/user-attachments/assets/9fd56768-7b95-4e4d-81f5-3e53f0f8443d" />


<!-- Attach your screenshots here👇-->

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes
- The reason for including `VERIFIED` status is because right now there is no way for developers to update their task status once it is marked as `VERIFIED`. In status-site, the dropdown doesn't appears which is a bug and only after it's fixed, logic will be modified to mark `VERIFIED` as negligent too.

<!--Any additional notes, considerations or explanations for reviewers-->
