### PR TITLE
Fix idle 7 days + calculation logic

### DIFF
--- a/models/discordactions.js
+++ b/models/discordactions.js
@@ -8,7 +8,12 @@ const { findSubscribedGroupIds } = require("../utils/helper");
 const { retrieveUsers } = require("../services/dataAccessLayer");
 const { BATCH_SIZE_IN_CLAUSE } = require("../constants/firebase");
 const { getAllUserStatus, getGroupRole, getUserStatus } = require("./userStatus");
-const { normalizeTimestamp, checkIfUserHasLiveTasks, computeIdleDaysExcludingOOO } = require("../utils/userStatus");
+const {
+  getApprovedOooPeriods,
+  normalizeTimestamp,
+  checkIfUserHasLiveTasks,
+  computeIdleDaysExcludingOOO,
+} = require("../utils/userStatus");
 const { userState, POST_OOO_GRACE_PERIOD_IN_DAYS } = require("../constants/userStatus");
 const config = require("config");
 const logger = require("../utils/logger");
@@ -693,13 +698,17 @@ const updateIdle7dUsersOnDiscord = async (dev) => {
               logger.warn("updateIdle7dUsersOnDiscord: skipping user status with missing userId");
               return;
             }
+            const windowStart =
+              normalizeTimestamp(userStatus.idleWindowStartedAt) ??
+              normalizeTimestamp(userStatus.currentStatus?.from) ??
+              nowMs;
+            const clampedWindowStart = Math.min(windowStart, nowMs);
+            const oooPeriods = await getApprovedOooPeriods(userStatus.userId, clampedWindowStart, nowMs);
             const idleDays = computeIdleDaysExcludingOOO(
               userStatus.idleWindowStartedAt,
-              userStatus.lastOooFrom,
-              userStatus.lastOooUntil,
               userStatus.currentStatus?.from,
               nowMs,
-              userStatus.oooPeriods
+              oooPeriods
             );
             if (idleDays < 7) {
               return;

--- a/models/discordactions.js
+++ b/models/discordactions.js
@@ -699,13 +699,11 @@ const updateIdle7dUsersOnDiscord = async (dev) => {
               return;
             }
             const windowStart =
-              normalizeTimestamp(userStatus.idleWindowStartedAt) ??
-              normalizeTimestamp(userStatus.currentStatus?.from) ??
-              nowMs;
+              normalizeTimestamp(userStatus.idleFrom) ?? normalizeTimestamp(userStatus.currentStatus?.from) ?? nowMs;
             const effectiveWindowStart = Math.min(windowStart, nowMs);
             const oooPeriods = await getApprovedOooPeriods(userStatus.userId, effectiveWindowStart, nowMs);
             const idleDays = computeIdleDaysExcludingOOO(
-              userStatus.idleWindowStartedAt,
+              userStatus.idleFrom,
               userStatus.currentStatus?.from,
               nowMs,
               oooPeriods

--- a/models/discordactions.js
+++ b/models/discordactions.js
@@ -689,6 +689,10 @@ const updateIdle7dUsersOnDiscord = async (dev) => {
       await Promise.all(
         allUserStatus.map(async (userStatus) => {
           try {
+            if (!userStatus?.userId) {
+              logger.warn("updateIdle7dUsersOnDiscord: skipping user status with missing userId");
+              return;
+            }
             const idleDays = computeIdleDaysExcludingOOO(
               userStatus.idleWindowStartedAt,
               userStatus.lastOooFrom,
@@ -700,14 +704,15 @@ const updateIdle7dUsersOnDiscord = async (dev) => {
               return;
             }
             const userData = await userModel.doc(userStatus.userId).get();
-            const isUserArchived = userData.data()?.roles?.archived;
-            if (userData.exists) {
+            const userPayload = userData?.data?.();
+            const isUserArchived = userPayload?.roles?.archived;
+            if (userData?.exists) {
               if (isUserArchived) {
                 totalArchivedUsers++;
-              } else if (dev === "true" && !allMavens.includes(userData.data().discordId)) {
+              } else if (dev === "true" && !allMavens.includes(userPayload?.discordId)) {
                 const shouldAdd = await shouldAddIdleUser(userStatus, tasksModel);
                 if (shouldAdd) {
-                  userStatus.userid = userData.data().discordId;
+                  userStatus.userid = userPayload?.discordId;
                   allIdle7dUsers.push(userStatus);
                 }
               }

--- a/models/discordactions.js
+++ b/models/discordactions.js
@@ -658,8 +658,12 @@ const updateIdle7dUsersOnDiscord = async (dev) => {
 
   try {
     groupIdle7dRole = await getGroupRole("group-idle-7d+");
+    if (!groupIdle7dRole?.roleExists || !groupIdle7dRole?.role?.roleid) {
+      throw new Error(
+        "Idle 7d+ role does not exist or has no roleid. Ensure discord-roles has a document with rolename 'group-idle-7d+'."
+      );
+    }
     groupIdle7dRoleId = groupIdle7dRole.role.roleid;
-    if (!groupIdle7dRole.roleExists) throw new Error("Idle Role does not exist");
 
     const { allUserStatus } = await getAllUserStatus({ state: userState.IDLE });
     const discordUsers = await getDiscordMembers();
@@ -679,21 +683,20 @@ const updateIdle7dUsersOnDiscord = async (dev) => {
       }
     });
 
+    const nowMs = Date.now();
+
     if (allUserStatus) {
-      const nowMs = Date.now();
       await Promise.all(
         allUserStatus.map(async (userStatus) => {
           try {
-            const fullStatusDoc = await userStatusModel.doc(userStatus.id).get();
-            const fullData = fullStatusDoc.exists ? fullStatusDoc.data() : {};
             const idleDays = computeIdleDaysExcludingOOO(
-              fullData.idleWindowStartedAt,
-              fullData.lastOooFrom,
-              fullData.lastOooUntil,
+              userStatus.idleWindowStartedAt,
+              userStatus.lastOooFrom,
+              userStatus.lastOooUntil,
               userStatus.currentStatus?.from,
               nowMs
             );
-            if (idleDays <= 7) {
+            if (idleDays < 7) {
               return;
             }
             const userData = await userModel.doc(userStatus.userId).get();

--- a/models/discordactions.js
+++ b/models/discordactions.js
@@ -702,8 +702,8 @@ const updateIdle7dUsersOnDiscord = async (dev) => {
               normalizeTimestamp(userStatus.idleWindowStartedAt) ??
               normalizeTimestamp(userStatus.currentStatus?.from) ??
               nowMs;
-            const clampedWindowStart = Math.min(windowStart, nowMs);
-            const oooPeriods = await getApprovedOooPeriods(userStatus.userId, clampedWindowStart, nowMs);
+            const effectiveWindowStart = Math.min(windowStart, nowMs);
+            const oooPeriods = await getApprovedOooPeriods(userStatus.userId, effectiveWindowStart, nowMs);
             const idleDays = computeIdleDaysExcludingOOO(
               userStatus.idleWindowStartedAt,
               userStatus.currentStatus?.from,

--- a/models/discordactions.js
+++ b/models/discordactions.js
@@ -698,7 +698,8 @@ const updateIdle7dUsersOnDiscord = async (dev) => {
               userStatus.lastOooFrom,
               userStatus.lastOooUntil,
               userStatus.currentStatus?.from,
-              nowMs
+              nowMs,
+              userStatus.oooPeriods
             );
             if (idleDays < 7) {
               return;

--- a/models/discordactions.js
+++ b/models/discordactions.js
@@ -417,7 +417,7 @@ const updateIdleUsersOnDiscord = async (dev) => {
       throw new Error("Idle Role does not exist");
     }
     groupIdleRoleId = groupIdleRole.role.roleid;
-    const { allUserStatus } = await getAllUserStatus({ state: userState.IDLE });
+    const { allIdleUsers } = await getAllUserStatus({ state: userState.IDLE });
     const discordUsers = await getDiscordMembers();
     const usersHavingIdleRole = [];
     const discordMemberIds = new Set();
@@ -441,9 +441,9 @@ const updateIdleUsersOnDiscord = async (dev) => {
       }
     });
 
-    if (allUserStatus) {
+    if (allIdleUsers) {
       await Promise.all(
-        allUserStatus.map(async (userStatus) => {
+        allIdleUsers.map(async (userStatus) => {
           try {
             const userData = await userModel.doc(userStatus.userId).get();
             if (!userData.exists) {
@@ -670,7 +670,7 @@ const updateIdle7dUsersOnDiscord = async (dev) => {
     }
     groupIdle7dRoleId = groupIdle7dRole.role.roleid;
 
-    const { allUserStatus } = await getAllUserStatus({ state: userState.IDLE });
+    const { allIdleUsers } = await getAllUserStatus({ state: userState.IDLE });
     const discordUsers = await getDiscordMembers();
     const usersHavingIdle7dRole = [];
 
@@ -688,24 +688,22 @@ const updateIdle7dUsersOnDiscord = async (dev) => {
       }
     });
 
-    const nowMs = Date.now();
+    const currentTime = Date.now();
 
-    if (allUserStatus) {
+    if (allIdleUsers) {
       await Promise.all(
-        allUserStatus.map(async (userStatus) => {
+        allIdleUsers.map(async (userStatus) => {
           try {
             if (!userStatus?.userId) {
               logger.warn("updateIdle7dUsersOnDiscord: skipping user status with missing userId");
               return;
             }
-            const windowStart =
-              normalizeTimestamp(userStatus.idleFrom) ?? normalizeTimestamp(userStatus.currentStatus?.from) ?? nowMs;
-            const effectiveWindowStart = Math.min(windowStart, nowMs);
-            const oooPeriods = await getApprovedOooPeriods(userStatus.userId, effectiveWindowStart, nowMs);
+            const windowStart = normalizeTimestamp(userStatus.idleFrom) ?? currentTime;
+            const oooPeriods = await getApprovedOooPeriods(userStatus.userId, windowStart, currentTime);
             const idleDays = computeIdleDaysExcludingOOO(
               userStatus.idleFrom,
               userStatus.currentStatus?.from,
-              nowMs,
+              currentTime,
               oooPeriods
             );
             if (idleDays < 7) {

--- a/models/discordactions.js
+++ b/models/discordactions.js
@@ -417,7 +417,7 @@ const updateIdleUsersOnDiscord = async (dev) => {
       throw new Error("Idle Role does not exist");
     }
     groupIdleRoleId = groupIdleRole.role.roleid;
-    const { allIdleUsers } = await getAllUserStatus({ state: userState.IDLE });
+    const { allUserStatus } = await getAllUserStatus({ state: userState.IDLE });
     const discordUsers = await getDiscordMembers();
     const usersHavingIdleRole = [];
     const discordMemberIds = new Set();
@@ -441,9 +441,9 @@ const updateIdleUsersOnDiscord = async (dev) => {
       }
     });
 
-    if (allIdleUsers) {
+    if (allUserStatus) {
       await Promise.all(
-        allIdleUsers.map(async (userStatus) => {
+        allUserStatus.map(async (userStatus) => {
           try {
             const userData = await userModel.doc(userStatus.userId).get();
             if (!userData.exists) {
@@ -670,7 +670,7 @@ const updateIdle7dUsersOnDiscord = async (dev) => {
     }
     groupIdle7dRoleId = groupIdle7dRole.role.roleid;
 
-    const { allIdleUsers } = await getAllUserStatus({ state: userState.IDLE });
+    const { allUserStatus } = await getAllUserStatus({ state: userState.IDLE });
     const discordUsers = await getDiscordMembers();
     const usersHavingIdle7dRole = [];
 
@@ -689,10 +689,9 @@ const updateIdle7dUsersOnDiscord = async (dev) => {
     });
 
     const currentTime = Date.now();
-
-    if (allIdleUsers) {
+    if (allUserStatus) {
       await Promise.all(
-        allIdleUsers.map(async (userStatus) => {
+        allUserStatus.map(async (userStatus) => {
           try {
             if (!userStatus?.userId) {
               logger.warn("updateIdle7dUsersOnDiscord: skipping user status with missing userId");

--- a/models/userStatus.js
+++ b/models/userStatus.js
@@ -184,11 +184,15 @@ const getAllUserStatus = async (query) => {
         .get();
     }
     data.forEach((doc) => {
+      const docData = doc.data();
       const currentUserStatus = {
         id: doc.id,
-        userId: doc.data().userId,
-        currentStatus: doc.data().currentStatus,
-        monthlyHours: doc.data().monthlyHours,
+        userId: docData.userId,
+        currentStatus: docData.currentStatus,
+        monthlyHours: docData.monthlyHours,
+        idleWindowStartedAt: docData.idleWindowStartedAt ?? null,
+        lastOooFrom: docData.lastOooFrom ?? null,
+        lastOooUntil: docData.lastOooUntil ?? null,
       };
       allUserStatus.push(currentUserStatus);
     });
@@ -255,6 +259,8 @@ const updateUserStatus = async (userId, updatedStatusData) => {
       }
       if (requestedNextState === userState.IDLE && previousState === userState.ACTIVE) {
         newStatusData.idleWindowStartedAt = newStatusData.currentStatus?.from ?? newStatusData.currentStatus?.updatedAt;
+      } else if (requestedNextState === userState.ACTIVE) {
+        newStatusData.idleWindowStartedAt = null;
       }
       if (
         userStatusData.currentStatus?.state === userState.IDLE &&
@@ -624,6 +630,8 @@ const batchUpdateUsersStatus = async (users) => {
         }
         if (state === userState.IDLE && currentState === userState.ACTIVE) {
           updatedStatusData.idleWindowStartedAt = statusToUpdate.from ?? currentTimeStamp;
+        } else if (state === userState.ACTIVE) {
+          updatedStatusData.idleWindowStartedAt = null;
         }
         batch.update(docRef, updatedStatusData);
       }

--- a/models/userStatus.js
+++ b/models/userStatus.js
@@ -16,6 +16,7 @@ const {
   getNextDayTimeStamp,
   convertTimestampsToUTC,
   resolveLastOooUntil,
+  appendOooPeriod,
 } = require("../utils/userStatus");
 const { TASK_STATUS } = require("../constants/tasks");
 const userStatusModel = firestore.collection("usersStatus");
@@ -193,6 +194,7 @@ const getAllUserStatus = async (query) => {
         idleWindowStartedAt: docData.idleWindowStartedAt ?? null,
         lastOooFrom: docData.lastOooFrom ?? null,
         lastOooUntil: docData.lastOooUntil ?? null,
+        oooPeriods: Array.isArray(docData.oooPeriods) ? docData.oooPeriods : [],
       };
       allUserStatus.push(currentUserStatus);
     });
@@ -255,6 +257,15 @@ const updateUserStatus = async (userId, updatedStatusData) => {
         newStatusData.lastOooUntil = lastOooUntilUpdate;
         if (previousState === userState.OOO && previousCurrentStatus.from != null) {
           newStatusData.lastOooFrom = previousCurrentStatus.from;
+          newStatusData.oooPeriods = appendOooPeriod(
+            userStatusData.oooPeriods,
+            previousCurrentStatus.from,
+            lastOooUntilUpdate
+          );
+        }
+        if (requestedNextState === userState.OOO) {
+          newStatusData.lastOooFrom = null;
+          newStatusData.lastOooUntil = null;
         }
       }
       if (requestedNextState === userState.IDLE && previousState === userState.ACTIVE) {
@@ -282,7 +293,7 @@ const updateUserStatus = async (userId, updatedStatusData) => {
           }
         }
       }
-      const initialData = { userId, lastOooUntil: null, ...newStatusData };
+      const initialData = { userId, lastOooUntil: null, oooPeriods: [], ...newStatusData };
       if (newStatusData.currentStatus?.state === userState.IDLE) {
         initialData.idleWindowStartedAt = newStatusData.currentStatus.from ?? newStatusData.currentStatus.updatedAt;
       }
@@ -339,6 +350,7 @@ const updateAllUserStatus = async () => {
             newStatusData.lastOooUntil = lastOooUntilUpdate;
             if (currentState === userState.OOO && currentStatus?.from != null) {
               newStatusData.lastOooFrom = currentStatus.from;
+              newStatusData.oooPeriods = appendOooPeriod(doc.oooPeriods, currentStatus.from, lastOooUntilUpdate);
             }
           }
           toUpdate = !toUpdate;
@@ -552,6 +564,7 @@ const batchUpdateUsersStatus = async (users) => {
       const newUserStatusData = {
         userId,
         lastOooUntil: null,
+        oooPeriods: [],
         currentStatus: statusToUpdate,
       };
       state === userState.ACTIVE ? summary.activeUsersAltered++ : summary.idleUsersAltered++;
@@ -600,6 +613,9 @@ const batchUpdateUsersStatus = async (users) => {
             ...(lastOooUntilUpdate !== undefined && {
               lastOooUntil: lastOooUntilUpdate,
               ...(currentStatusData.from != null && { lastOooFrom: currentStatusData.from }),
+              ...(currentStatusData.from != null && {
+                oooPeriods: appendOooPeriod(data?.oooPeriods, currentStatusData.from, lastOooUntilUpdate),
+              }),
             }),
           };
           batch.update(docRef, batchUpdateData);
@@ -745,6 +761,7 @@ const cancelOooStatus = async (userId) => {
       newStatusData.lastOooUntil = lastOooUntilUpdate;
       if (docData.currentStatus?.from != null) {
         newStatusData.lastOooFrom = docData.currentStatus.from;
+        newStatusData.oooPeriods = appendOooPeriod(docData.oooPeriods, docData.currentStatus.from, lastOooUntilUpdate);
       }
     }
     if (futureStatus?.state) {

--- a/models/userStatus.js
+++ b/models/userStatus.js
@@ -347,6 +347,7 @@ const updateAllUserStatus = async () => {
           }
           newStatusData.currentStatus = newCurrentStatus;
           newStatusData.futureStatus = newFutureStatus;
+          newStatusData.lastOooUntil = null;
           toUpdate = !toUpdate;
           summary.nonOooUsersAltered++;
         } else {
@@ -533,6 +534,7 @@ const batchUpdateUsersStatus = async (users) => {
       const newUserStatusRef = userStatusModel.doc();
       const newUserStatusData = {
         userId,
+        lastOooUntil: null,
         currentStatus: statusToUpdate,
       };
       state === userState.ACTIVE ? summary.activeUsersAltered++ : summary.idleUsersAltered++;

--- a/models/userStatus.js
+++ b/models/userStatus.js
@@ -15,6 +15,7 @@ const {
   generateNewStatus,
   getNextDayTimeStamp,
   convertTimestampsToUTC,
+  resolveLastOooUntil,
 } = require("../utils/userStatus");
 const { TASK_STATUS } = require("../constants/tasks");
 const userStatusModel = firestore.collection("usersStatus");
@@ -217,6 +218,7 @@ const updateUserStatus = async (userId, updatedStatusData) => {
       const userStatusData = userStatusDoc.data();
       const previousCurrentStatus = userStatusData.currentStatus || {};
       const previousState = previousCurrentStatus.state;
+      const previousUntil = previousCurrentStatus.until;
       let requestedNextState;
       if (Object.keys(newStatusData).includes("currentStatus")) {
         requestedNextState = newStatusData.currentStatus?.state;
@@ -241,10 +243,14 @@ const updateUserStatus = async (userId, updatedStatusData) => {
           }
         }
       }
-      if (requestedNextState === userState.IDLE && previousState === userState.ACTIVE) {
-        newStatusData.idleWindowStartedAt = newStatusData.currentStatus?.from ?? newStatusData.currentStatus?.updatedAt;
-      } else if (requestedNextState === userState.ACTIVE) {
-        newStatusData.idleWindowStartedAt = null;
+      const lastOooUntilUpdate = resolveLastOooUntil({
+        previousState,
+        previousUntil,
+        nextState: requestedNextState,
+        fallbackTimestamp: newStatusData.currentStatus?.updatedAt,
+      });
+      if (lastOooUntilUpdate !== undefined) {
+        newStatusData.lastOooUntil = lastOooUntilUpdate;
       }
       if (
         userStatusData.currentStatus?.state === userState.IDLE &&
@@ -266,10 +272,7 @@ const updateUserStatus = async (userId, updatedStatusData) => {
           }
         }
       }
-      const initialData = { userId, ...newStatusData };
-      if (newStatusData.currentStatus?.state === userState.IDLE) {
-        initialData.idleWindowStartedAt = newStatusData.currentStatus.from ?? newStatusData.currentStatus.updatedAt;
-      }
+      const initialData = { userId, lastOooUntil: null, ...newStatusData };
       const { id } = await userStatusModel.add(initialData);
       return { id, userStatusExists: false, data: newStatusData };
     }
@@ -307,11 +310,21 @@ const updateAllUserStatus = async () => {
       const { futureStatus, currentStatus } = doc;
       const futureState = futureStatus?.state;
       const currentState = currentStatus?.state;
+      const currentUntil = currentStatus?.until;
       if (futureState === "ACTIVE" || futureState === "IDLE") {
         if (today >= futureStatus.from) {
           // OOO period is over and we need to update their current status
           newStatusData.currentStatus = { ...futureStatus, until: "", updatedAt: today };
           delete newStatusData.futureStatus;
+          const lastOooUntilUpdate = resolveLastOooUntil({
+            previousState: currentState,
+            previousUntil: currentUntil,
+            nextState: futureState,
+            fallbackTimestamp: today,
+          });
+          if (lastOooUntilUpdate !== undefined) {
+            newStatusData.lastOooUntil = lastOooUntilUpdate;
+          }
           toUpdate = !toUpdate;
           summary.oooUsersAltered++;
         } else {
@@ -555,10 +568,16 @@ const batchUpdateUsersStatus = async (users) => {
 
         if (timeDifferenceDays >= 1) {
           if (state === userState.IDLE) await addGroupIdleRoleToDiscordUser(userId);
-          const batchUpdateData = {
+          const lastOooUntilUpdate = resolveLastOooUntil({
+            previousState: currentState,
+            previousUntil: currentUntil,
+            nextState: state,
+            fallbackTimestamp: currentTimeStamp,
+          });
+          batch.update(docRef, {
             currentStatus: statusToUpdate,
-          };
-          batch.update(docRef, batchUpdateData);
+            ...(lastOooUntilUpdate !== undefined && { lastOooUntil: lastOooUntilUpdate }),
+          });
         } else {
           const getNextDayAfterUntil = getNextDayTimeStamp(currentUntil);
           batch.update(docRef, {
@@ -575,10 +594,14 @@ const batchUpdateUsersStatus = async (users) => {
         const updatedStatusData = {
           currentStatus: statusToUpdate,
         };
-        if (state === userState.IDLE && currentState === userState.ACTIVE) {
-          updatedStatusData.idleWindowStartedAt = statusToUpdate.from ?? currentTimeStamp;
-        } else if (state === userState.ACTIVE) {
-          updatedStatusData.idleWindowStartedAt = null;
+        const lastOooUntilUpdate = resolveLastOooUntil({
+          previousState: currentState,
+          previousUntil: currentUntil,
+          nextState: state,
+          fallbackTimestamp: currentTimeStamp,
+        });
+        if (lastOooUntilUpdate !== undefined) {
+          updatedStatusData.lastOooUntil = lastOooUntilUpdate;
         }
         batch.update(docRef, updatedStatusData);
       }
@@ -682,6 +705,15 @@ const cancelOooStatus = async (userId) => {
     }
     const updatedStatus = generateNewStatus(isActive);
     const newStatusData = { ...docData, ...updatedStatus };
+    const lastOooUntilUpdate = resolveLastOooUntil({
+      previousState: docData.currentStatus?.state,
+      previousUntil: docData.currentStatus?.until,
+      nextState: updatedStatus.currentStatus?.state,
+      fallbackTimestamp: Date.now(),
+    });
+    if (lastOooUntilUpdate !== undefined) {
+      newStatusData.lastOooUntil = lastOooUntilUpdate;
+    }
     if (futureStatus?.state) {
       newStatusData.futureStatus = {};
     }

--- a/models/userStatus.js
+++ b/models/userStatus.js
@@ -15,8 +15,6 @@ const {
   generateNewStatus,
   getNextDayTimeStamp,
   convertTimestampsToUTC,
-  resolveLastOooUntil,
-  appendOooPeriod,
 } = require("../utils/userStatus");
 const { TASK_STATUS } = require("../constants/tasks");
 const userStatusModel = firestore.collection("usersStatus");
@@ -192,9 +190,6 @@ const getAllUserStatus = async (query) => {
         currentStatus: docData.currentStatus,
         monthlyHours: docData.monthlyHours,
         idleWindowStartedAt: docData.idleWindowStartedAt ?? null,
-        lastOooFrom: docData.lastOooFrom ?? null,
-        lastOooUntil: docData.lastOooUntil ?? null,
-        oooPeriods: Array.isArray(docData.oooPeriods) ? docData.oooPeriods : [],
       };
       allUserStatus.push(currentUserStatus);
     });
@@ -222,7 +217,6 @@ const updateUserStatus = async (userId, updatedStatusData) => {
       const userStatusData = userStatusDoc.data();
       const previousCurrentStatus = userStatusData.currentStatus || {};
       const previousState = previousCurrentStatus.state;
-      const previousUntil = previousCurrentStatus.until;
       let requestedNextState;
       if (Object.keys(newStatusData).includes("currentStatus")) {
         requestedNextState = newStatusData.currentStatus?.state;
@@ -245,27 +239,6 @@ const updateUserStatus = async (userId, updatedStatusData) => {
           } else {
             newStatusData.futureStatus = {};
           }
-        }
-      }
-      const lastOooUntilUpdate = resolveLastOooUntil({
-        previousState,
-        previousUntil,
-        nextState: requestedNextState,
-        fallbackTimestamp: newStatusData.currentStatus?.updatedAt,
-      });
-      if (lastOooUntilUpdate !== undefined) {
-        newStatusData.lastOooUntil = lastOooUntilUpdate;
-        if (previousState === userState.OOO && previousCurrentStatus.from != null) {
-          newStatusData.lastOooFrom = previousCurrentStatus.from;
-          newStatusData.oooPeriods = appendOooPeriod(
-            userStatusData.oooPeriods,
-            previousCurrentStatus.from,
-            lastOooUntilUpdate
-          );
-        }
-        if (requestedNextState === userState.OOO) {
-          newStatusData.lastOooFrom = null;
-          newStatusData.lastOooUntil = null;
         }
       }
       if (requestedNextState === userState.IDLE && previousState === userState.ACTIVE) {
@@ -293,7 +266,7 @@ const updateUserStatus = async (userId, updatedStatusData) => {
           }
         }
       }
-      const initialData = { userId, lastOooUntil: null, oooPeriods: [], ...newStatusData };
+      const initialData = { userId, ...newStatusData };
       if (newStatusData.currentStatus?.state === userState.IDLE) {
         initialData.idleWindowStartedAt = newStatusData.currentStatus.from ?? newStatusData.currentStatus.updatedAt;
       }
@@ -334,25 +307,11 @@ const updateAllUserStatus = async () => {
       const { futureStatus, currentStatus } = doc;
       const futureState = futureStatus?.state;
       const currentState = currentStatus?.state;
-      const currentUntil = currentStatus?.until;
       if (futureState === "ACTIVE" || futureState === "IDLE") {
         if (today >= futureStatus.from) {
           // OOO period is over and we need to update their current status
           newStatusData.currentStatus = { ...futureStatus, until: "", updatedAt: today };
           delete newStatusData.futureStatus;
-          const lastOooUntilUpdate = resolveLastOooUntil({
-            previousState: currentState,
-            previousUntil: currentUntil,
-            nextState: futureState,
-            fallbackTimestamp: today,
-          });
-          if (lastOooUntilUpdate !== undefined) {
-            newStatusData.lastOooUntil = lastOooUntilUpdate;
-            if (currentState === userState.OOO && currentStatus?.from != null) {
-              newStatusData.lastOooFrom = currentStatus.from;
-              newStatusData.oooPeriods = appendOooPeriod(doc.oooPeriods, currentStatus.from, lastOooUntilUpdate);
-            }
-          }
           toUpdate = !toUpdate;
           summary.oooUsersAltered++;
         } else {
@@ -375,8 +334,6 @@ const updateAllUserStatus = async () => {
           }
           newStatusData.currentStatus = newCurrentStatus;
           newStatusData.futureStatus = newFutureStatus;
-          newStatusData.lastOooUntil = null;
-          newStatusData.lastOooFrom = null;
           toUpdate = !toUpdate;
           summary.nonOooUsersAltered++;
         } else {
@@ -563,8 +520,6 @@ const batchUpdateUsersStatus = async (users) => {
       const newUserStatusRef = userStatusModel.doc();
       const newUserStatusData = {
         userId,
-        lastOooUntil: null,
-        oooPeriods: [],
         currentStatus: statusToUpdate,
       };
       state === userState.ACTIVE ? summary.activeUsersAltered++ : summary.idleUsersAltered++;
@@ -574,7 +529,6 @@ const batchUpdateUsersStatus = async (users) => {
       const currentStatusData = data?.currentStatus || {};
       const currentState = currentStatusData.state;
       const currentUntil = currentStatusData.until;
-      const nextState = state;
       if (currentState === state) {
         currentState === userState.ACTIVE ? summary.activeUsersUnaltered++ : summary.idleUsersUnaltered++;
         continue;
@@ -601,22 +555,8 @@ const batchUpdateUsersStatus = async (users) => {
 
         if (timeDifferenceDays >= 1) {
           if (state === userState.IDLE) await addGroupIdleRoleToDiscordUser(userId);
-          const lastOooUntilUpdate = resolveLastOooUntil({
-            previousState: currentState,
-            previousUntil: currentUntil,
-            nextState,
-            fallbackTimestamp: currentTimeStamp,
-          });
-          const currentStatusData = data?.currentStatus || {};
           const batchUpdateData = {
             currentStatus: statusToUpdate,
-            ...(lastOooUntilUpdate !== undefined && {
-              lastOooUntil: lastOooUntilUpdate,
-              ...(currentStatusData.from != null && { lastOooFrom: currentStatusData.from }),
-              ...(currentStatusData.from != null && {
-                oooPeriods: appendOooPeriod(data?.oooPeriods, currentStatusData.from, lastOooUntilUpdate),
-              }),
-            }),
           };
           batch.update(docRef, batchUpdateData);
         } else {
@@ -635,15 +575,6 @@ const batchUpdateUsersStatus = async (users) => {
         const updatedStatusData = {
           currentStatus: statusToUpdate,
         };
-        const lastOooUntilUpdate = resolveLastOooUntil({
-          previousState: currentState,
-          previousUntil: currentUntil,
-          nextState,
-          fallbackTimestamp: currentTimeStamp,
-        });
-        if (lastOooUntilUpdate !== undefined) {
-          updatedStatusData.lastOooUntil = lastOooUntilUpdate;
-        }
         if (state === userState.IDLE && currentState === userState.ACTIVE) {
           updatedStatusData.idleWindowStartedAt = statusToUpdate.from ?? currentTimeStamp;
         } else if (state === userState.ACTIVE) {
@@ -751,23 +682,32 @@ const cancelOooStatus = async (userId) => {
     }
     const updatedStatus = generateNewStatus(isActive);
     const newStatusData = { ...docData, ...updatedStatus };
-    const lastOooUntilUpdate = resolveLastOooUntil({
-      previousState: docData.currentStatus?.state,
-      previousUntil: docData.currentStatus?.until,
-      nextState: updatedStatus.currentStatus?.state,
-      fallbackTimestamp: Date.now(),
-    });
-    if (lastOooUntilUpdate !== undefined) {
-      newStatusData.lastOooUntil = lastOooUntilUpdate;
-      if (docData.currentStatus?.from != null) {
-        newStatusData.lastOooFrom = docData.currentStatus.from;
-        newStatusData.oooPeriods = appendOooPeriod(docData.oooPeriods, docData.currentStatus.from, lastOooUntilUpdate);
-      }
-    }
     if (futureStatus?.state) {
       newStatusData.futureStatus = {};
     }
     await userStatusModel.doc(docId).update(newStatusData);
+
+    try {
+      const requestsCollection = firestore.collection("requests");
+      const oooRequests = await requestsCollection
+        .where("requestedBy", "==", userId)
+        .where("type", "==", "OOO")
+        .orderBy("createdAt", "desc")
+        .limit(1)
+        .get();
+
+      if (!oooRequests.empty) {
+        const requestDoc = oooRequests.docs[0];
+        const requestData = requestDoc.data();
+        const isApproved = requestData.status === "APPROVED" || requestData.state === "APPROVED";
+        if (isApproved) {
+          await requestsCollection.doc(requestDoc.id).update({ until: Date.now() });
+        }
+      }
+    } catch (error) {
+      logger.error(`Error updating OOO request until on cancel for user ${userId}: ${error.message}`);
+    }
+
     if (!isActive) {
       await addGroupIdleRoleToDiscordUser(userId);
     }

--- a/models/userStatus.js
+++ b/models/userStatus.js
@@ -721,27 +721,6 @@ const cancelOooStatus = async (userId) => {
     }
     await userStatusModel.doc(docId).update(newStatusData);
 
-    try {
-      const requestsCollection = firestore.collection("requests");
-      const oooRequests = await requestsCollection
-        .where("requestedBy", "==", userId)
-        .where("type", "==", "OOO")
-        .orderBy("createdAt", "desc")
-        .limit(1)
-        .get();
-
-      if (!oooRequests.empty) {
-        const requestDoc = oooRequests.docs[0];
-        const requestData = requestDoc.data();
-        const isApproved = requestData.status === "APPROVED" || requestData.state === "APPROVED";
-        if (isApproved) {
-          await requestsCollection.doc(requestDoc.id).update({ until: Date.now() });
-        }
-      }
-    } catch (error) {
-      logger.error(`Error updating OOO request until on cancel for user ${userId}: ${error.message}`);
-    }
-
     if (!isActive) {
       await addGroupIdleRoleToDiscordUser(userId);
     }

--- a/models/userStatus.js
+++ b/models/userStatus.js
@@ -190,7 +190,7 @@ const getAllUserStatus = async (query) => {
         userId: docData.userId,
         currentStatus: docData.currentStatus,
         monthlyHours: docData.monthlyHours,
-        idleWindowStartedAt: docData.idleWindowStartedAt ?? null,
+        idleFrom: docData.idleFrom ?? null,
       };
       allUserStatus.push(currentUserStatus);
     });

--- a/test/integration/taskBasedStatusUpdate.test.js
+++ b/test/integration/taskBasedStatusUpdate.test.js
@@ -648,7 +648,7 @@ describe("Task Based Status Updates", function () {
 
       const doc = await firestore.collection("usersStatus").doc("userStatusIdleWindow").get();
       expect(doc.data().currentStatus.state).to.equal(userState.ACTIVE);
-      expect(doc.data().idleFrom ?? null).to.equal(null);
+      expect(doc.data().idleFrom).to.equal(null);
     });
 
     it("should NOT update idleFrom when user is already IDLE (no duplicate reset)", async function () {

--- a/test/integration/taskBasedStatusUpdate.test.js
+++ b/test/integration/taskBasedStatusUpdate.test.js
@@ -587,7 +587,7 @@ describe("Task Based Status Updates", function () {
     });
   });
 
-  describe("idleWindowStartedAt field lifecycle", function () {
+  describe("idleFrom field lifecycle", function () {
     let userId;
     let superUserId;
     let userJwt;
@@ -608,7 +608,7 @@ describe("Task Based Status Updates", function () {
       await cleanDb();
     });
 
-    it("should set idleWindowStartedAt when user transitions ACTIVE → IDLE (task completed)", async function () {
+    it("should set idleFrom when user transitions ACTIVE → IDLE (task completed)", async function () {
       const activeStatusData = generateStatusDataForState(userId, userState.ACTIVE);
       await firestore.collection("usersStatus").doc("userStatusIdleWindow").set(activeStatusData);
 
@@ -622,15 +622,15 @@ describe("Task Based Status Updates", function () {
       expect(res.body.userStatus.data.currentStatus).to.equal(userState.IDLE);
 
       const doc = await firestore.collection("usersStatus").doc("userStatusIdleWindow").get();
-      const idleWindowStartedAt = doc.data().idleWindowStartedAt;
-      expect(idleWindowStartedAt).to.be.a("number");
-      expect(idleWindowStartedAt).to.be.at.least(beforeMs);
+      const idleFrom = doc.data().idleFrom;
+      expect(idleFrom).to.be.a("number");
+      expect(idleFrom).to.be.at.least(beforeMs);
     });
 
-    it("should clear idleWindowStartedAt when user transitions IDLE → ACTIVE (new task assigned)", async function () {
+    it("should clear idleFrom when user transitions IDLE → ACTIVE (new task assigned)", async function () {
       const idleStatusData = {
         ...generateStatusDataForState(userId, userState.IDLE),
-        idleWindowStartedAt: Date.now() - 5 * 24 * 60 * 60 * 1000, // 5 days ago
+        idleFrom: Date.now() - 5 * 24 * 60 * 60 * 1000, // 5 days ago
       };
       await firestore.collection("usersStatus").doc("userStatusIdleWindow").set(idleStatusData);
 
@@ -648,14 +648,14 @@ describe("Task Based Status Updates", function () {
 
       const doc = await firestore.collection("usersStatus").doc("userStatusIdleWindow").get();
       expect(doc.data().currentStatus.state).to.equal(userState.ACTIVE);
-      expect(doc.data().idleWindowStartedAt ?? null).to.equal(null);
+      expect(doc.data().idleFrom ?? null).to.equal(null);
     });
 
-    it("should NOT update idleWindowStartedAt when user is already IDLE (no duplicate reset)", async function () {
+    it("should NOT update idleFrom when user is already IDLE (no duplicate reset)", async function () {
       const existingIdleWindowTs = Date.now() - 3 * 24 * 60 * 60 * 1000; // 3 days ago
       const alreadyIdleData = {
         ...generateStatusDataForState(userId, userState.IDLE),
-        idleWindowStartedAt: existingIdleWindowTs,
+        idleFrom: existingIdleWindowTs,
       };
       await firestore.collection("usersStatus").doc("userStatusIdleWindow").set(alreadyIdleData);
 
@@ -668,7 +668,7 @@ describe("Task Based Status Updates", function () {
       expect(res.body.userStatus.message).to.equal("The status is already IDLE");
 
       const doc = await firestore.collection("usersStatus").doc("userStatusIdleWindow").get();
-      expect(doc.data().idleWindowStartedAt).to.equal(existingIdleWindowTs);
+      expect(doc.data().idleFrom).to.equal(existingIdleWindowTs);
     });
   });
 });

--- a/test/integration/taskBasedStatusUpdate.test.js
+++ b/test/integration/taskBasedStatusUpdate.test.js
@@ -564,7 +564,7 @@ describe("Task Based Status Updates", function () {
         .send(reqBody);
       expect(res.status).to.equal(204);
       const userStatus002Data = (await userStatusModel.doc("userStatusDoc001").get()).data();
-      expect(userStatus002Data).to.have.keys(["userId", "currentStatus"]);
+      expect(userStatus002Data).to.include.keys("userId", "currentStatus");
       expect(userStatus002Data.currentStatus.state).to.equal(userState.IDLE);
     });
 
@@ -582,7 +582,7 @@ describe("Task Based Status Updates", function () {
         .send(reqBody);
       expect(res.status).to.equal(204);
       const userStatus002Data = (await userStatusModel.doc("userStatusDoc001").get()).data();
-      expect(userStatus002Data).to.have.keys(["userId", "currentStatus"]);
+      expect(userStatus002Data).to.include.keys("userId", "currentStatus");
       expect(userStatus002Data.currentStatus.state).to.equal(userState.ACTIVE);
     });
   });

--- a/test/integration/taskBasedStatusUpdate.test.js
+++ b/test/integration/taskBasedStatusUpdate.test.js
@@ -586,4 +586,89 @@ describe("Task Based Status Updates", function () {
       expect(userStatus002Data.currentStatus.state).to.equal(userState.ACTIVE);
     });
   });
+
+  describe("idleWindowStartedAt field lifecycle", function () {
+    let userId;
+    let superUserId;
+    let userJwt;
+    let taskArr;
+
+    beforeEach(async function () {
+      userId = await addUser(userData[6]);
+      superUserId = await addUser(userData[4]);
+      userJwt = authService.generateAuthToken({ userId });
+      taskArr = allTasks();
+      const sampleTask1 = taskArr[0];
+      sampleTask1.assignee = userId;
+      sampleTask1.createdBy = superUserId;
+      await firestore.collection("tasks").doc("taskid-idle-window-1").set(sampleTask1);
+    });
+
+    afterEach(async function () {
+      await cleanDb();
+    });
+
+    it("should set idleWindowStartedAt when user transitions ACTIVE → IDLE (task completed)", async function () {
+      const activeStatusData = generateStatusDataForState(userId, userState.ACTIVE);
+      await firestore.collection("usersStatus").doc("userStatusIdleWindow").set(activeStatusData);
+
+      const beforeMs = Date.now();
+      const res = await chai
+        .request(app)
+        .patch(`/tasks/self/taskid-idle-window-1`)
+        .set("cookie", `${cookieName}=${userJwt}`)
+        .send({ status: "COMPLETED", percentCompleted: 100 });
+
+      expect(res.body.userStatus.data.currentStatus).to.equal(userState.IDLE);
+
+      const doc = await firestore.collection("usersStatus").doc("userStatusIdleWindow").get();
+      const idleWindowStartedAt = doc.data().idleWindowStartedAt;
+      expect(idleWindowStartedAt).to.be.a("number");
+      expect(idleWindowStartedAt).to.be.at.least(beforeMs);
+    });
+
+    it("should clear idleWindowStartedAt when user transitions IDLE → ACTIVE (new task assigned)", async function () {
+      const idleStatusData = {
+        ...generateStatusDataForState(userId, userState.IDLE),
+        idleWindowStartedAt: Date.now() - 5 * 24 * 60 * 60 * 1000, // 5 days ago
+      };
+      await firestore.collection("usersStatus").doc("userStatusIdleWindow").set(idleStatusData);
+
+      const sampleTask2 = taskArr[1];
+      sampleTask2.assignee = userId;
+      sampleTask2.createdBy = superUserId;
+      await firestore.collection("tasks").doc("taskid-idle-window-2").set(sampleTask2);
+
+      const superUserJwt = authService.generateAuthToken({ userId: superUserId });
+      await chai
+        .request(app)
+        .patch(`/tasks/taskid-idle-window-1`)
+        .set("cookie", `${cookieName}=${superUserJwt}`)
+        .send({ assignee: userData[6].username });
+
+      const doc = await firestore.collection("usersStatus").doc("userStatusIdleWindow").get();
+      expect(doc.data().currentStatus.state).to.equal(userState.ACTIVE);
+      expect(doc.data().idleWindowStartedAt ?? null).to.equal(null);
+    });
+
+    it("should NOT update idleWindowStartedAt when user is already IDLE (no duplicate reset)", async function () {
+      const existingIdleWindowTs = Date.now() - 3 * 24 * 60 * 60 * 1000; // 3 days ago
+      const alreadyIdleData = {
+        ...generateStatusDataForState(userId, userState.IDLE),
+        idleWindowStartedAt: existingIdleWindowTs,
+      };
+      await firestore.collection("usersStatus").doc("userStatusIdleWindow").set(alreadyIdleData);
+
+      const res = await chai
+        .request(app)
+        .patch(`/tasks/self/taskid-idle-window-1`)
+        .set("cookie", `${cookieName}=${userJwt}`)
+        .send({ status: "COMPLETED", percentCompleted: 100 });
+
+      expect(res.body.userStatus.message).to.equal("The status is already IDLE");
+
+      const doc = await firestore.collection("usersStatus").doc("userStatusIdleWindow").get();
+      expect(doc.data().idleWindowStartedAt).to.equal(existingIdleWindowTs);
+    });
+  });
 });

--- a/test/unit/models/userStatus.js
+++ b/test/unit/models/userStatus.js
@@ -34,10 +34,6 @@ describe("tasks", function () {
     expect(response.data.userId).to.equal(userId);
     expect(response.data.currentStatus).to.not.equal(userState.OOO);
     expect(response.data.futureStatus?.state).to.equal(undefined);
-    expect(response.data.lastOooFrom != null).to.equal(true);
-    expect(response.data.lastOooUntil != null).to.equal(true);
-    expect(response.data.oooPeriods).to.be.an("array");
-    expect(response.data.oooPeriods.length).to.be.greaterThan(0);
   });
 
   it("Should clear the future Status if the User cancels OOO", async function () {

--- a/test/unit/models/userStatus.js
+++ b/test/unit/models/userStatus.js
@@ -34,6 +34,10 @@ describe("tasks", function () {
     expect(response.data.userId).to.equal(userId);
     expect(response.data.currentStatus).to.not.equal(userState.OOO);
     expect(response.data.futureStatus?.state).to.equal(undefined);
+    expect(response.data.lastOooFrom != null).to.equal(true);
+    expect(response.data.lastOooUntil != null).to.equal(true);
+    expect(response.data.oooPeriods).to.be.an("array");
+    expect(response.data.oooPeriods.length).to.be.greaterThan(0);
   });
 
   it("Should clear the future Status if the User cancels OOO", async function () {

--- a/test/unit/utils/userStatus.test.js
+++ b/test/unit/utils/userStatus.test.js
@@ -114,59 +114,74 @@ describe("User Status Functions", function () {
     it("should return total idle days when no OOO period", function () {
       const windowStart = Date.now() - 10 * ONE_DAY_MS;
       const now = Date.now();
-      const days = computeIdleDaysExcludingOOO(windowStart, null, null, null, now);
+      const days = computeIdleDaysExcludingOOO(windowStart, null, now);
       expect(days).to.equal(10);
     });
 
-    it("should exclude last OOO period from idle days", function () {
-      const windowStart = Date.now() - 15 * ONE_DAY_MS;
-      const oooFrom = Date.now() - 10 * ONE_DAY_MS;
-      const oooUntil = Date.now() - 5 * ONE_DAY_MS;
+    it("should exclude OOO periods from idle days", function () {
       const now = Date.now();
-      const days = computeIdleDaysExcludingOOO(windowStart, oooFrom, oooUntil, null, now);
+      const windowStart = now - 15 * ONE_DAY_MS;
+      const oooPeriods = [{ from: now - 10 * ONE_DAY_MS, until: now - 5 * ONE_DAY_MS }];
+      const days = computeIdleDaysExcludingOOO(windowStart, null, now, oooPeriods);
       expect(days).to.equal(10);
     });
 
     it("should fall back to currentStatusFrom when idleWindowStartedAt is missing", function () {
       const currentStatusFrom = Date.now() - 8 * ONE_DAY_MS;
       const now = Date.now();
-      const days = computeIdleDaysExcludingOOO(null, null, null, currentStatusFrom, now);
+      const days = computeIdleDaysExcludingOOO(null, currentStatusFrom, now);
       expect(days).to.equal(8);
     });
 
     it("should return 0 when window has no span", function () {
       const now = Date.now();
-      const days = computeIdleDaysExcludingOOO(now, null, null, null, now);
+      const days = computeIdleDaysExcludingOOO(now, null, now);
       expect(days).to.equal(0);
     });
 
     it("should return 0 when window start is in the future (edge case)", function () {
       const now = Date.now();
       const futureStart = now + 5 * ONE_DAY_MS;
-      const days = computeIdleDaysExcludingOOO(futureStart, null, null, null, now);
+      const days = computeIdleDaysExcludingOOO(futureStart, null, now);
       expect(days).to.equal(0);
     });
 
-    it("should subtract multiple OOO periods when oooPeriods is provided", function () {
+    it("should subtract multiple OOO periods", function () {
       const now = Date.now();
       const windowStart = now - 20 * ONE_DAY_MS;
       const oooPeriods = [
         { from: now - 18 * ONE_DAY_MS, until: now - 16 * ONE_DAY_MS }, // 2 days
         { from: now - 10 * ONE_DAY_MS, until: now - 7 * ONE_DAY_MS }, // 3 days
       ];
-      const days = computeIdleDaysExcludingOOO(windowStart, null, null, null, now, oooPeriods);
+      const days = computeIdleDaysExcludingOOO(windowStart, null, now, oooPeriods);
       expect(days).to.equal(15);
     });
 
-    it("should merge overlapping OOO periods and not double subtract", function () {
+    it("should handle overlapping OOO periods without double subtracting", function () {
       const now = Date.now();
       const windowStart = now - 20 * ONE_DAY_MS;
       const oooPeriods = [
-        { from: now - 12 * ONE_DAY_MS, until: now - 8 * ONE_DAY_MS }, // 4 days
-        { from: now - 10 * ONE_DAY_MS, until: now - 6 * ONE_DAY_MS }, // overlaps by 2 days
+        { from: now - 12 * ONE_DAY_MS, until: now - 8 * ONE_DAY_MS },
+        { from: now - 10 * ONE_DAY_MS, until: now - 6 * ONE_DAY_MS },
       ];
-      const days = computeIdleDaysExcludingOOO(windowStart, null, null, null, now, oooPeriods);
-      expect(days).to.equal(14);
+      const days = computeIdleDaysExcludingOOO(windowStart, null, now, oooPeriods);
+      expect(days).to.equal(12);
+    });
+
+    it("should handle OOO period partially outside window", function () {
+      const now = Date.now();
+      const windowStart = now - 10 * ONE_DAY_MS;
+      const oooPeriods = [{ from: now - 15 * ONE_DAY_MS, until: now - 7 * ONE_DAY_MS }];
+      const days = computeIdleDaysExcludingOOO(windowStart, null, now, oooPeriods);
+      expect(days).to.equal(7);
+    });
+
+    it("should return full idle days when OOO period is outside window", function () {
+      const now = Date.now();
+      const windowStart = now - 10 * ONE_DAY_MS;
+      const oooPeriods = [{ from: now - 20 * ONE_DAY_MS, until: now - 15 * ONE_DAY_MS }];
+      const days = computeIdleDaysExcludingOOO(windowStart, null, now, oooPeriods);
+      expect(days).to.equal(10);
     });
   });
 });

--- a/test/unit/utils/userStatus.test.js
+++ b/test/unit/utils/userStatus.test.js
@@ -146,5 +146,27 @@ describe("User Status Functions", function () {
       const days = computeIdleDaysExcludingOOO(futureStart, null, null, null, now);
       expect(days).to.equal(0);
     });
+
+    it("should subtract multiple OOO periods when oooPeriods is provided", function () {
+      const now = Date.now();
+      const windowStart = now - 20 * ONE_DAY_MS;
+      const oooPeriods = [
+        { from: now - 18 * ONE_DAY_MS, until: now - 16 * ONE_DAY_MS }, // 2 days
+        { from: now - 10 * ONE_DAY_MS, until: now - 7 * ONE_DAY_MS }, // 3 days
+      ];
+      const days = computeIdleDaysExcludingOOO(windowStart, null, null, null, now, oooPeriods);
+      expect(days).to.equal(15);
+    });
+
+    it("should merge overlapping OOO periods and not double subtract", function () {
+      const now = Date.now();
+      const windowStart = now - 20 * ONE_DAY_MS;
+      const oooPeriods = [
+        { from: now - 12 * ONE_DAY_MS, until: now - 8 * ONE_DAY_MS }, // 4 days
+        { from: now - 10 * ONE_DAY_MS, until: now - 6 * ONE_DAY_MS }, // overlaps by 2 days
+      ];
+      const days = computeIdleDaysExcludingOOO(windowStart, null, null, null, now, oooPeriods);
+      expect(days).to.equal(14);
+    });
   });
 });

--- a/test/unit/utils/userStatus.test.js
+++ b/test/unit/utils/userStatus.test.js
@@ -126,7 +126,7 @@ describe("User Status Functions", function () {
       expect(days).to.equal(10);
     });
 
-    it("should fall back to currentStatusFrom when idleWindowStartedAt is missing", function () {
+    it("should fall back to currentStatusFrom when idleFrom is missing", function () {
       const currentStatusFrom = Date.now() - 8 * ONE_DAY_MS;
       const now = Date.now();
       const days = computeIdleDaysExcludingOOO(null, currentStatusFrom, now);

--- a/test/unit/utils/userStatus.test.js
+++ b/test/unit/utils/userStatus.test.js
@@ -139,5 +139,12 @@ describe("User Status Functions", function () {
       const days = computeIdleDaysExcludingOOO(now, null, null, null, now);
       expect(days).to.equal(0);
     });
+
+    it("should return 0 when window start is in the future (edge case)", function () {
+      const now = Date.now();
+      const futureStart = now + 5 * ONE_DAY_MS;
+      const days = computeIdleDaysExcludingOOO(futureStart, null, null, null, now);
+      expect(days).to.equal(0);
+    });
   });
 });

--- a/utils/userStatus.js
+++ b/utils/userStatus.js
@@ -37,6 +37,29 @@ const normalizeTimestamp = (value) => {
   return null;
 };
 
+/**
+ * Determines the timestamp to persist in the `lastOooUntil` field based on state transitions.
+ * If the user is moving out of OOO, the previous `until` is used (with fallbacks). If they are
+ * headed into OOO, the stored value is cleared.
+ *
+ * @param {Object} params
+ * @param {string|undefined} params.previousState - The state prior to the transition.
+ * @param {number|string|admin.firestore.Timestamp|null|undefined} params.previousUntil - Previous OOO `until` value.
+ * @param {string|undefined} params.nextState - The state being transitioned to.
+ * @param {number|undefined} params.fallbackTimestamp - Optional fallback timestamp to use when `previousUntil` is invalid.
+ * @returns {number|null|undefined} Millisecond timestamp when leaving OOO, null when entering OOO,
+ * or undefined when no change to `lastOooUntil` is required.
+ */
+const resolveLastOooUntil = ({ previousState, previousUntil, nextState, fallbackTimestamp }) => {
+  if (nextState === userState.OOO) {
+    return null;
+  }
+  const isLeavingOoo = previousState === userState.OOO && nextState !== userState.OOO;
+  if (!isLeavingOoo) return undefined;
+  const normalized = normalizeTimestamp(previousUntil);
+  return normalized ?? fallbackTimestamp ?? null;
+};
+
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
 const normalizeOooPeriod = (period) => {
@@ -502,6 +525,7 @@ module.exports = {
   getFilteredPaginationLink,
   convertTimestampsToUTC,
   normalizeTimestamp,
+  resolveLastOooUntil,
   getApprovedOooPeriods,
   computeIdleDaysExcludingOOO,
 };

--- a/utils/userStatus.js
+++ b/utils/userStatus.js
@@ -62,32 +62,87 @@ const resolveLastOooUntil = ({ previousState, previousUntil, nextState, fallback
 
 const ONE_DAY_MS = 1000 * 60 * 60 * 24;
 
+const normalizeOooPeriod = (period) => {
+  if (!period || typeof period !== "object") return null;
+  const from = normalizeTimestamp(period.from);
+  const until = normalizeTimestamp(period.until);
+  if (from == null || until == null || from >= until) {
+    return null;
+  }
+  return { from, until };
+};
+
+const mergeOooPeriods = (periods) => {
+  if (!periods.length) return [];
+  const sorted = [...periods].sort((a, b) => a.from - b.from);
+  const merged = [];
+  for (const period of sorted) {
+    if (!merged.length || period.from > merged[merged.length - 1].until) {
+      merged.push({ ...period });
+      continue;
+    }
+    merged[merged.length - 1].until = Math.max(merged[merged.length - 1].until, period.until);
+  }
+  return merged;
+};
+
 /**
- * Computes total idle days in the window [windowStart, now], excluding the last OOO period.
- * Used for group-idle-7d+ so that OOO days are not counted toward the 7-day idle threshold.
+ * Appends a valid OOO interval to oooPeriods and merges overlaps.
+ * Keeps the structure stable for downstream idle-day calculation.
  *
- *
- * @param {number|string|admin.firestore.Timestamp|null|undefined} idleWindowStartedAt - When idle window started (e.g. task completed).
- * @param {number|string|admin.firestore.Timestamp|null|undefined} lastOooFrom - Start of last OOO period (we know "from when" OOO via this).
- * @param {number|string|admin.firestore.Timestamp|null|undefined} lastOooUntil - End of last OOO period.
- * @param {number|string|admin.firestore.Timestamp|null|undefined} currentStatusFrom - Fallback window start (e.g. currentStatus.from).
- * @param {number} nowMs - Reference "now" in milliseconds.
- * @returns {number} Total idle days (excluding OOO) in the window.
+ * @param {Array<{from:number|string,until:number|string}>|undefined|null} existingPeriods
+ * @param {number|string|null|undefined} from
+ * @param {number|string|null|undefined} until
+ * @returns {Array<{from:number,until:number}>}
  */
-const computeIdleDaysExcludingOOO = (idleWindowStartedAt, lastOooFrom, lastOooUntil, currentStatusFrom, nowMs) => {
+const appendOooPeriod = (existingPeriods, from, until) => {
+  const nextPeriods = Array.isArray(existingPeriods) ? existingPeriods.map(normalizeOooPeriod).filter(Boolean) : [];
+  const next = normalizeOooPeriod({ from, until });
+  if (!next) {
+    return mergeOooPeriods(nextPeriods);
+  }
+  nextPeriods.push(next);
+  return mergeOooPeriods(nextPeriods);
+};
+
+/**
+ * Computes total idle days in [windowStart, now], excluding OOO durations.
+ * Supports multiple OOO periods via oooPeriods and falls back to lastOooFrom/lastOooUntil.
+ *
+ * @param {number|string|admin.firestore.Timestamp|null|undefined} idleWindowStartedAt
+ * @param {number|string|admin.firestore.Timestamp|null|undefined} lastOooFrom
+ * @param {number|string|admin.firestore.Timestamp|null|undefined} lastOooUntil
+ * @param {number|string|admin.firestore.Timestamp|null|undefined} currentStatusFrom
+ * @param {number} nowMs
+ * @param {Array<{from:number|string,until:number|string}>|undefined|null} oooPeriods
+ * @returns {number}
+ */
+const computeIdleDaysExcludingOOO = (
+  idleWindowStartedAt,
+  lastOooFrom,
+  lastOooUntil,
+  currentStatusFrom,
+  nowMs,
+  oooPeriods
+) => {
   const rawWindowStart = normalizeTimestamp(idleWindowStartedAt) ?? normalizeTimestamp(currentStatusFrom) ?? nowMs;
   const windowStart = Math.min(rawWindowStart, nowMs);
   const windowEnd = nowMs;
   let totalMs = Math.max(0, windowEnd - windowStart);
 
-  const oooFrom = normalizeTimestamp(lastOooFrom);
-  const oooUntil = normalizeTimestamp(lastOooUntil);
-  if (oooFrom != null && oooUntil != null && oooFrom < oooUntil) {
-    const overlapStart = Math.max(windowStart, oooFrom);
-    const overlapEnd = Math.min(windowEnd, oooUntil);
+  let effectivePeriods = Array.isArray(oooPeriods) ? appendOooPeriod(oooPeriods, null, null) : [];
+  if (!effectivePeriods.length) {
+    const fallbackPeriod = normalizeOooPeriod({ from: lastOooFrom, until: lastOooUntil });
+    if (fallbackPeriod) {
+      effectivePeriods = [fallbackPeriod];
+    }
+  }
+
+  for (const period of effectivePeriods) {
+    const overlapStart = Math.max(windowStart, period.from);
+    const overlapEnd = Math.min(windowEnd, period.until);
     if (overlapStart < overlapEnd) {
-      const overlapMs = overlapEnd - overlapStart;
-      totalMs = Math.max(0, totalMs - overlapMs);
+      totalMs = Math.max(0, totalMs - (overlapEnd - overlapStart));
     }
   }
 
@@ -233,6 +288,19 @@ const updateCurrentStatusToState = async (collection, latestStatusData, newState
   });
   if (lastOooUntilUpdate !== undefined) {
     updatedStatusData.lastOooUntil = lastOooUntilUpdate;
+    if (previousState === userState.OOO && currentStatus.from != null) {
+      updatedStatusData.lastOooFrom = currentStatus.from;
+      updatedStatusData.oooPeriods = appendOooPeriod(docData.oooPeriods, currentStatus.from, lastOooUntilUpdate);
+    }
+    if (newState === userState.OOO) {
+      updatedStatusData.lastOooFrom = null;
+      updatedStatusData.lastOooUntil = null;
+    }
+  }
+  if (newState === userState.IDLE && previousState === userState.ACTIVE) {
+    updatedStatusData.idleWindowStartedAt = currentTimeStamp;
+  } else if (newState === userState.ACTIVE) {
+    updatedStatusData.idleWindowStartedAt = null;
   }
   try {
     await collection.doc(id).update(updatedStatusData);
@@ -315,9 +383,10 @@ const updateFutureStatusToState = async (collection, latestStatusData, newState)
 const createUserStatusWithState = async (userId, collection, state) => {
   const currentTimeStamp = new Date().getTime();
   try {
-    await collection.add({
+    const payload = {
       userId,
       lastOooUntil: null,
+      oooPeriods: [],
       currentStatus: {
         state,
         message: "",
@@ -325,7 +394,11 @@ const createUserStatusWithState = async (userId, collection, state) => {
         until: "",
         updatedAt: currentTimeStamp,
       },
-    });
+    };
+    if (state === userState.IDLE) {
+      payload.idleWindowStartedAt = currentTimeStamp;
+    }
+    await collection.add(payload);
   } catch (err) {
     logger.error(`error creating the current status for user id ${userId} - ${err.message}`);
     throw new Error("Status Creation Failed.");
@@ -475,5 +548,6 @@ module.exports = {
   convertTimestampsToUTC,
   normalizeTimestamp,
   resolveLastOooUntil,
+  appendOooPeriod,
   computeIdleDaysExcludingOOO,
 };

--- a/utils/userStatus.js
+++ b/utils/userStatus.js
@@ -124,14 +124,14 @@ const getApprovedOooPeriods = async (userId, windowStart, windowEnd) => {
 /**
  * Computes total idle days in [windowStart, now], excluding OOO durations.
  *
- * @param {number|string|admin.firestore.Timestamp|null|undefined} idleWindowStartedAt
+ * @param {number|string|admin.firestore.Timestamp|null|undefined} idleFrom
  * @param {number|string|admin.firestore.Timestamp|null|undefined} currentStatusFrom
  * @param {number} nowMs
  * @param {Array<{from:number,until:number}>} oooPeriods - Pre-queried and merged OOO periods
  * @returns {number}
  */
-const computeIdleDaysExcludingOOO = (idleWindowStartedAt, currentStatusFrom, nowMs, oooPeriods = []) => {
-  const rawWindowStart = normalizeTimestamp(idleWindowStartedAt) ?? normalizeTimestamp(currentStatusFrom) ?? nowMs;
+const computeIdleDaysExcludingOOO = (idleFrom, currentStatusFrom, nowMs, oooPeriods = []) => {
+  const rawWindowStart = normalizeTimestamp(idleFrom) ?? normalizeTimestamp(currentStatusFrom) ?? nowMs;
   const windowStart = Math.min(rawWindowStart, nowMs);
   const windowEnd = nowMs;
   let totalMs = Math.max(0, windowEnd - windowStart);
@@ -288,9 +288,9 @@ const updateCurrentStatusToState = async (collection, latestStatusData, newState
     updatedStatusData.lastOooUntil = lastOooUntilUpdate;
   }
   if (newState === userState.IDLE && previousState === userState.ACTIVE) {
-    updatedStatusData.idleWindowStartedAt = currentTimeStamp;
+    updatedStatusData.idleFrom = currentTimeStamp;
   } else if (newState === userState.ACTIVE) {
-    updatedStatusData.idleWindowStartedAt = null;
+    updatedStatusData.idleFrom = null;
   }
   try {
     await collection.doc(id).update(updatedStatusData);
@@ -384,7 +384,7 @@ const createUserStatusWithState = async (userId, collection, state) => {
       },
     };
     if (state === userState.IDLE) {
-      payload.idleWindowStartedAt = currentTimeStamp;
+      payload.idleFrom = currentTimeStamp;
     }
     await collection.add(payload);
   } catch (err) {

--- a/utils/userStatus.js
+++ b/utils/userStatus.js
@@ -66,15 +66,17 @@ const ONE_DAY_MS = 1000 * 60 * 60 * 24;
  * Computes total idle days in the window [windowStart, now], excluding the last OOO period.
  * Used for group-idle-7d+ so that OOO days are not counted toward the 7-day idle threshold.
  *
+ *
  * @param {number|string|admin.firestore.Timestamp|null|undefined} idleWindowStartedAt - When idle window started (e.g. task completed).
- * @param {number|string|admin.firestore.Timestamp|null|undefined} lastOooFrom - Start of last OOO period.
+ * @param {number|string|admin.firestore.Timestamp|null|undefined} lastOooFrom - Start of last OOO period (we know "from when" OOO via this).
  * @param {number|string|admin.firestore.Timestamp|null|undefined} lastOooUntil - End of last OOO period.
  * @param {number|string|admin.firestore.Timestamp|null|undefined} currentStatusFrom - Fallback window start (e.g. currentStatus.from).
  * @param {number} nowMs - Reference "now" in milliseconds.
  * @returns {number} Total idle days (excluding OOO) in the window.
  */
 const computeIdleDaysExcludingOOO = (idleWindowStartedAt, lastOooFrom, lastOooUntil, currentStatusFrom, nowMs) => {
-  const windowStart = normalizeTimestamp(idleWindowStartedAt) ?? normalizeTimestamp(currentStatusFrom) ?? nowMs;
+  const rawWindowStart = normalizeTimestamp(idleWindowStartedAt) ?? normalizeTimestamp(currentStatusFrom) ?? nowMs;
+  const windowStart = Math.min(rawWindowStart, nowMs);
   const windowEnd = nowMs;
   let totalMs = Math.max(0, windowEnd - windowStart);
 
@@ -84,7 +86,8 @@ const computeIdleDaysExcludingOOO = (idleWindowStartedAt, lastOooFrom, lastOooUn
     const overlapStart = Math.max(windowStart, oooFrom);
     const overlapEnd = Math.min(windowEnd, oooUntil);
     if (overlapStart < overlapEnd) {
-      totalMs -= overlapEnd - overlapStart;
+      const overlapMs = overlapEnd - overlapStart;
+      totalMs = Math.max(0, totalMs - overlapMs);
     }
   }
 

--- a/utils/userStatus.js
+++ b/utils/userStatus.js
@@ -3,6 +3,7 @@ const { userState } = require("../constants/userStatus");
 const { convertTimestampToUTCStartOrEndOfDay } = require("./time");
 const firestore = require("./firestore");
 const requestsModel = firestore.collection("requests");
+const logger = require("./logger");
 
 /**
  * Normalizes various timestamp representations into a millisecond number.

--- a/utils/userStatus.js
+++ b/utils/userStatus.js
@@ -62,16 +62,6 @@ const resolveLastOooUntil = ({ previousState, previousUntil, nextState, fallback
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
-const normalizeOooPeriod = (period) => {
-  if (!period || typeof period !== "object") return null;
-  const from = normalizeTimestamp(period.from);
-  const until = normalizeTimestamp(period.until);
-  if (from == null || until == null || from >= until) {
-    return null;
-  }
-  return { from, until };
-};
-
 const mergeOooPeriods = (periods) => {
   if (!periods.length) return [];
   const sorted = [...periods].sort((a, b) => a.from - b.from);
@@ -103,15 +93,15 @@ const getApprovedOooPeriods = async (userId, windowStart, windowEnd) => {
     const periods = [];
     snapshot.forEach((doc) => {
       const data = doc.data();
-      const isApproved = data.status === "APPROVED" || data.state === "APPROVED";
+      const isApproved = data.state === "APPROVED";
       if (!isApproved) return;
 
-      const period = normalizeOooPeriod({ from: data.from, until: data.until });
-      if (!period) return;
+      const from = normalizeTimestamp(data.from);
+      const until = normalizeTimestamp(data.until);
 
-      if (period.from >= windowEnd) return;
+      if (from >= until || from >= windowEnd) return;
 
-      periods.push(period);
+      periods.push({ from, until });
     });
 
     return mergeOooPeriods(periods);

--- a/utils/userStatus.js
+++ b/utils/userStatus.js
@@ -1,6 +1,8 @@
 const { NotFound } = require("http-errors");
 const { userState } = require("../constants/userStatus");
 const { convertTimestampToUTCStartOrEndOfDay } = require("./time");
+const firestore = require("./firestore");
+const requestsModel = firestore.collection("requests");
 
 /**
  * Normalizes various timestamp representations into a millisecond number.
@@ -34,32 +36,6 @@ const normalizeTimestamp = (value) => {
   return null;
 };
 
-/**
- * Determines the timestamp to persist in the `lastOooUntil` field based on state transitions.
- * If the user is moving out of OOO, the previous `until` is used (with fallbacks). If they are
- * headed into OOO, the stored value is cleared.
- *
- * @param {Object} params
- * @param {string|undefined} params.previousState - The state prior to the transition.
- * @param {number|string|admin.firestore.Timestamp|null|undefined} params.previousUntil - Previous OOO `until` value.
- * @param {string|undefined} params.nextState - The state being transitioned to.
- * @param {number|undefined} params.fallbackTimestamp - Optional fallback timestamp to use when `previousUntil` is invalid.
- * @returns {number|null|undefined} Millisecond timestamp when leaving OOO, null when entering OOO,
- * or undefined when no change to `lastOooUntil` is required.
- */
-const resolveLastOooUntil = ({ previousState, previousUntil, nextState, fallbackTimestamp }) => {
-  if (nextState === userState.OOO) {
-    return null;
-  }
-
-  const isLeavingOOO = previousState === userState.OOO && nextState !== undefined && nextState !== userState.OOO;
-  if (isLeavingOOO) {
-    return normalizeTimestamp(previousUntil) ?? normalizeTimestamp(fallbackTimestamp) ?? Date.now();
-  }
-
-  return undefined;
-};
-
 const ONE_DAY_MS = 1000 * 60 * 60 * 24;
 
 const normalizeOooPeriod = (period) => {
@@ -87,58 +63,52 @@ const mergeOooPeriods = (periods) => {
 };
 
 /**
- * Appends a valid OOO interval to oooPeriods and merges overlaps.
- * Keeps the structure stable for downstream idle-day calculation.
- *
- * @param {Array<{from:number|string,until:number|string}>|undefined|null} existingPeriods
- * @param {number|string|null|undefined} from
- * @param {number|string|null|undefined} until
- * @returns {Array<{from:number,until:number}>}
+ * @param {string} userId - The user's ID (requestedBy in requests collection)
+ * @param {number} windowStart - Start of the idle window in ms
+ * @param {number} windowEnd - End of the window (typically Date.now()) in ms
+ * @returns {Promise<Array<{from:number,until:number}>>} Merged OOO periods overlapping the window
  */
-const appendOooPeriod = (existingPeriods, from, until) => {
-  const nextPeriods = Array.isArray(existingPeriods) ? existingPeriods.map(normalizeOooPeriod).filter(Boolean) : [];
-  const next = normalizeOooPeriod({ from, until });
-  if (!next) {
-    return mergeOooPeriods(nextPeriods);
+const getApprovedOooPeriods = async (userId, windowStart, windowEnd) => {
+  try {
+    const snapshot = await requestsModel.where("requestedBy", "==", userId).where("type", "==", "OOO").get();
+
+    const periods = [];
+    snapshot.forEach((doc) => {
+      const data = doc.data();
+      const isApproved = data.status === "APPROVED" || data.state === "APPROVED";
+      if (!isApproved) return;
+
+      const period = normalizeOooPeriod({ from: data.from, until: data.until });
+      if (!period) return;
+
+      if (period.until <= windowStart || period.from >= windowEnd) return;
+
+      periods.push(period);
+    });
+
+    return mergeOooPeriods(periods);
+  } catch (error) {
+    logger.error(`Error fetching approved OOO periods for user ${userId}: ${error.message}`);
+    return [];
   }
-  nextPeriods.push(next);
-  return mergeOooPeriods(nextPeriods);
 };
 
 /**
  * Computes total idle days in [windowStart, now], excluding OOO durations.
- * Supports multiple OOO periods via oooPeriods and falls back to lastOooFrom/lastOooUntil.
  *
  * @param {number|string|admin.firestore.Timestamp|null|undefined} idleWindowStartedAt
- * @param {number|string|admin.firestore.Timestamp|null|undefined} lastOooFrom
- * @param {number|string|admin.firestore.Timestamp|null|undefined} lastOooUntil
  * @param {number|string|admin.firestore.Timestamp|null|undefined} currentStatusFrom
  * @param {number} nowMs
- * @param {Array<{from:number|string,until:number|string}>|undefined|null} oooPeriods
+ * @param {Array<{from:number,until:number}>} oooPeriods - Pre-queried and merged OOO periods
  * @returns {number}
  */
-const computeIdleDaysExcludingOOO = (
-  idleWindowStartedAt,
-  lastOooFrom,
-  lastOooUntil,
-  currentStatusFrom,
-  nowMs,
-  oooPeriods
-) => {
+const computeIdleDaysExcludingOOO = (idleWindowStartedAt, currentStatusFrom, nowMs, oooPeriods = []) => {
   const rawWindowStart = normalizeTimestamp(idleWindowStartedAt) ?? normalizeTimestamp(currentStatusFrom) ?? nowMs;
   const windowStart = Math.min(rawWindowStart, nowMs);
   const windowEnd = nowMs;
   let totalMs = Math.max(0, windowEnd - windowStart);
 
-  let effectivePeriods = Array.isArray(oooPeriods) ? appendOooPeriod(oooPeriods, null, null) : [];
-  if (!effectivePeriods.length) {
-    const fallbackPeriod = normalizeOooPeriod({ from: lastOooFrom, until: lastOooUntil });
-    if (fallbackPeriod) {
-      effectivePeriods = [fallbackPeriod];
-    }
-  }
-
-  for (const period of effectivePeriods) {
+  for (const period of oooPeriods) {
     const overlapStart = Math.max(windowStart, period.from);
     const overlapEnd = Math.min(windowEnd, period.until);
     if (overlapStart < overlapEnd) {
@@ -268,7 +238,6 @@ const updateCurrentStatusToState = async (collection, latestStatusData, newState
     data: { currentStatus = {}, ...docData },
   } = latestStatusData;
   const previousState = currentStatus.state;
-  const previousUntil = currentStatus.until;
   const currentTimeStamp = new Date().getTime();
   const updatedStatusData = {
     ...docData,
@@ -280,23 +249,6 @@ const updateCurrentStatusToState = async (collection, latestStatusData, newState
       updatedAt: currentTimeStamp,
     },
   };
-  const lastOooUntilUpdate = resolveLastOooUntil({
-    previousState,
-    previousUntil,
-    nextState: newState,
-    fallbackTimestamp: currentTimeStamp,
-  });
-  if (lastOooUntilUpdate !== undefined) {
-    updatedStatusData.lastOooUntil = lastOooUntilUpdate;
-    if (previousState === userState.OOO && currentStatus.from != null) {
-      updatedStatusData.lastOooFrom = currentStatus.from;
-      updatedStatusData.oooPeriods = appendOooPeriod(docData.oooPeriods, currentStatus.from, lastOooUntilUpdate);
-    }
-    if (newState === userState.OOO) {
-      updatedStatusData.lastOooFrom = null;
-      updatedStatusData.lastOooUntil = null;
-    }
-  }
   if (newState === userState.IDLE && previousState === userState.ACTIVE) {
     updatedStatusData.idleWindowStartedAt = currentTimeStamp;
   } else if (newState === userState.ACTIVE) {
@@ -385,8 +337,6 @@ const createUserStatusWithState = async (userId, collection, state) => {
   try {
     const payload = {
       userId,
-      lastOooUntil: null,
-      oooPeriods: [],
       currentStatus: {
         state,
         message: "",
@@ -547,7 +497,6 @@ module.exports = {
   getFilteredPaginationLink,
   convertTimestampsToUTC,
   normalizeTimestamp,
-  resolveLastOooUntil,
-  appendOooPeriod,
+  getApprovedOooPeriods,
   computeIdleDaysExcludingOOO,
 };

--- a/utils/userStatus.js
+++ b/utils/userStatus.js
@@ -37,7 +37,7 @@ const normalizeTimestamp = (value) => {
   return null;
 };
 
-const ONE_DAY_MS = 1000 * 60 * 60 * 24;
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
 const normalizeOooPeriod = (period) => {
   if (!period || typeof period !== "object") return null;
@@ -71,7 +71,11 @@ const mergeOooPeriods = (periods) => {
  */
 const getApprovedOooPeriods = async (userId, windowStart, windowEnd) => {
   try {
-    const snapshot = await requestsModel.where("requestedBy", "==", userId).where("type", "==", "OOO").get();
+    const snapshot = await requestsModel
+      .where("requestedBy", "==", userId)
+      .where("type", "==", "OOO")
+      .where("until", ">=", windowStart)
+      .get();
 
     const periods = [];
     snapshot.forEach((doc) => {
@@ -82,7 +86,7 @@ const getApprovedOooPeriods = async (userId, windowStart, windowEnd) => {
       const period = normalizeOooPeriod({ from: data.from, until: data.until });
       if (!period) return;
 
-      if (period.until <= windowStart || period.from >= windowEnd) return;
+      if (period.from >= windowEnd) return;
 
       periods.push(period);
     });

--- a/utils/userStatus.js
+++ b/utils/userStatus.js
@@ -266,6 +266,7 @@ const updateCurrentStatusToState = async (collection, latestStatusData, newState
     data: { currentStatus = {}, ...docData },
   } = latestStatusData;
   const previousState = currentStatus.state;
+  const previousUntil = currentStatus.until;
   const currentTimeStamp = new Date().getTime();
   const updatedStatusData = {
     ...docData,
@@ -277,6 +278,15 @@ const updateCurrentStatusToState = async (collection, latestStatusData, newState
       updatedAt: currentTimeStamp,
     },
   };
+  const lastOooUntilUpdate = resolveLastOooUntil({
+    previousState,
+    previousUntil,
+    nextState: newState,
+    fallbackTimestamp: currentTimeStamp,
+  });
+  if (lastOooUntilUpdate !== undefined) {
+    updatedStatusData.lastOooUntil = lastOooUntilUpdate;
+  }
   if (newState === userState.IDLE && previousState === userState.ACTIVE) {
     updatedStatusData.idleWindowStartedAt = currentTimeStamp;
   } else if (newState === userState.ACTIVE) {


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 27-02-2026
<!--Developer Name Here-->
Developer Name: @vinit717 

---

## Issue Ticket Number
 
- closes #2038 

## Description

Fix the 7-day+ idle users calculation logic

```text
CRON JOB START: Fetch all users where currentStatus.state == IDLE
  │
  ▼
FOR EACH USER: Determine Window Start
  ├─ If `idleWindowStartedAt` exists ──► windowStart = idleWindowStartedAt
  └─ If missing (fallback) ────────────► windowStart = currentStatus.from
  │
  ▼
FETCH SOURCE OF TRUTH OOO DATA
  ├─ Query Firestore `requests` collection:
  │    WHERE requestedBy == "user-id" 
  │      AND type == "OOO" 
  │      AND status (or state) == "APPROVED"
  │
  ▼
PROCESS OOO PERIODS
  ├─ 1. Filter out requests that happened before `windowStart`
  ├─ 2. Merge overlapping timestamps (e.g., 2 consecutive requests become 1 block)
  └─ Result = [Clean list of valid OOO date ranges]
  │
  ▼
CALCULATE IDLE DAYS
  ├─ Total calendar days = (Date.now() - windowStart)
  ├─ Approved OOO days = Sum of the merged OOO date ranges
  ├─ Net Idle Days = (Total calendar days) - (Approved OOO days)
  │
  ▼
APPLY OR REMOVE ROLE
  ├─ IF Net Idle Days >= 7:
  │    └─ Add `group-idle-7d+` Discord role
  ├─ ELSE:
  │    └─ Remove `group-idle-7d+` Discord role (if they currently hold it)
```

### Documentation Updated?

- [x] Yes
- [ ] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [x] Yes
- [ ] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [x] Yes
- [ ] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>
<img width="658" height="718" alt="image" src="https://github.com/user-attachments/assets/375fa90b-ce06-4dc2-8997-334c2d32b655" /> </summary>





</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary><img width="791" height="84" alt="Screenshot 2026-03-02 at 6 29 43 PM" src="https://github.com/user-attachments/assets/b65c7941-f882-416f-b76f-93f9d17418a7" /></summary>



</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
