### PR TITLE
docs: simplify README config instructions (Closes #500)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This Project serves the backend APIs required for [Real Dev Squad](https://reald
 ## Prerequisites
 
 - The application uses [node-config](https://github.com/lorenwest/node-config)([documentation](https://github.com/lorenwest/node-config/wiki/Configuration-Files)) for managing config.
-- Create a new file: `config/local.js`. Override the required config values from `config/development.js` and `config/default.js` into `config/local.js`.
+- Create a new file: `config/local.js`. Copy the contents of `config/development.js` into `config/local.js` and update the `clientId` and `clientSecret` values with your own.
 - Register the application for [GitHub OAuth](https://docs.github.com/en/developers/apps/creating-an-oauth-app) to get the `clientId` and `clientSecret`. Add the callback URL as `http://<HOSTNAME>:<PORT>/auth/github/callback`
 - Create an application on [FireStore](https://firebase.google.com/docs/firestore) and [generate a service file](https://cloud.google.com/iam/docs/creating-managing-service-account-keys). Add the service file credentials in the local config (or your env variables) as a string. Make sure you convert all the escape sequence (newline) - `\n` with `\\n` in private_key field.
 - For running the project locally, [Firebase Local Emulator Suite](https://firebase.google.com/docs/emulator-suite) can also be used instead of using the remote DB. Steps for setting it up: [CONTRIBUTING.md - Using Firebase Emulator Locally](https://github.com/Real-Dev-Squad/website-backend/blob/develop/CONTRIBUTING.md#using-firebase-emulator-locally)


### PR DESCRIPTION
Closes #500

Simplified the config setup instructions to be more beginner-friendly by suggesting to copy the entire development config file instead of overriding from two separate files.