### PR TITLE
feat: restrict routes to super user

### DIFF
--- a/routes/userStatus.js
+++ b/routes/userStatus.js
@@ -21,7 +21,9 @@ const { authorizeAndAuthenticate } = require("../middlewares/authorizeUsersAndSe
 const ROLES = require("../constants/roles");
 const { Services } = require("../constants/bot");
 
-router.get("/", validateGetQueryParams, getUserStatusControllers);
+// TODO: Have a discussion, if this '/search' needs to be open or protected.
+// For now making it protected and super_user only to sort the high firestore read issues, for usersStatus collection
+router.get("/", authenticate, authorizeRoles([SUPERUSER]), validateGetQueryParams, getUserStatusControllers);
 router.get("/self", authenticate, getUserStatus);
 router.get("/:userId", getUserStatus);
 router.patch("/self", authenticate, validateUserStatus, updateUserStatusController); // this route is being deprecated, please use /users/status/:userId PATCH endpoint instead.

--- a/routes/userStatus.js
+++ b/routes/userStatus.js
@@ -21,7 +21,7 @@ const { authorizeAndAuthenticate } = require("../middlewares/authorizeUsersAndSe
 const ROLES = require("../constants/roles");
 const { Services } = require("../constants/bot");
 
-// TODO: Have a discussion, if this '/search' needs to be open or protected.
+// TODO: Have a discussion, if this 'users/status' needs to be open or protected.
 // For now making it protected and super_user only to sort the high firestore read issues, for usersStatus collection
 router.get("/", authenticate, authorizeRoles([SUPERUSER]), validateGetQueryParams, getUserStatusControllers);
 router.get("/self", authenticate, getUserStatus);

--- a/routes/users.js
+++ b/routes/users.js
@@ -28,7 +28,15 @@ router.get("/isDeveloper", authenticate, users.isDeveloper);
 router.get("/isUsernameAvailable/:username", authenticate, users.getUsernameAvailabilty);
 router.get("/username", authenticate, userValidator.validateGenerateUsernameQuery, users.generateUsername);
 router.get("/chaincode", authenticate, users.generateChaincode);
-router.get("/search", userValidator.validateUserQueryParams, users.filterUsers);
+// TODO: Have a discussion, if this '/search' needs to be open or protected.
+// For now making it protected and super_user only to sort the high firestore read issues, for usersStatus collection
+router.get(
+  "/search",
+  authenticate,
+  authorizeRoles([SUPERUSER]),
+  userValidator.validateUserQueryParams,
+  users.filterUsers
+);
 router.get("/identity-stats", authenticate, authorizeRoles([SUPERUSER]), users.getIdentityStats);
 router.patch(
   "/:userId/update-nickname",

--- a/test/integration/userStatus.test.js
+++ b/test/integration/userStatus.test.js
@@ -44,6 +44,19 @@ describe("UserStatus", function () {
   });
 
   describe("GET /users/status", function () {
+    it("Should not be accessed by unauthorized user", function (done) {
+      chai
+        .request(app)
+        .get("/users/status")
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+          expect(res).to.have.status(401);
+          return done();
+        });
+    });
+
     it("Should get all the userStatus in system", function (done) {
       chai
         .request(app)

--- a/test/integration/userStatus.test.js
+++ b/test/integration/userStatus.test.js
@@ -48,7 +48,7 @@ describe("UserStatus", function () {
       chai
         .request(app)
         .get("/users/status")
-        .set("cookie", `${cookieName}=${jwt}`)
+        .set("cookie", `${cookieName}=${superUserAuthToken}`)
         .end((err, res) => {
           if (err) {
             return done(err);
@@ -73,7 +73,10 @@ describe("UserStatus", function () {
       await updateUserStatus(nonArchivedIdleUserId, generateUserStatusData("IDLE", new Date(), new Date()));
       const nonArchivedActiveUserId = await addUser(userData[8]);
       await updateUserStatus(nonArchivedActiveUserId, generateUserStatusData("ACTIVE", new Date(), new Date()));
-      const response = await chai.request(app).get("/users/status?state=IDLE");
+      const response = await chai
+        .request(app)
+        .get("/users/status?state=IDLE")
+        .set("cookie", `${cookieName}=${superUserAuthToken}`);
       expect(response).to.have.status(200);
       expect(response.body.message).to.equal("All User Status found successfully.");
       expect(response.body.totalUserStatus).to.be.a("number");

--- a/test/integration/usersFilter.test.js
+++ b/test/integration/usersFilter.test.js
@@ -132,6 +132,20 @@ describe("Filter Users", function () {
 
   // eslint-disable-next-line mocha/no-skipped-tests
   describe("GET /users/search", function () {
+    it("Should not be accessed by unauthorized user", function (done) {
+      chai
+        .request(app)
+        .get("/users/search")
+        .query({ state: "OOO" })
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+          expect(res).to.have.status(401);
+          return done();
+        });
+    });
+
     it("Should search users based on state", function (done) {
       chai
         .request(app)

--- a/test/integration/usersFilter.test.js
+++ b/test/integration/usersFilter.test.js
@@ -38,7 +38,8 @@ describe("Filter Users", function () {
   before(async function () {
     const updatedAtDate = Date.now();
     const untilDate = updatedAtDate + 16 * 24 * 60 * 60 * 1000;
-    userId = await addUser();
+    const superUser = userData[4];
+    userId = await addUser(superUser);
     archivedUser = await addUser(userData[5]);
     jwt = authService.generateAuthToken({ userId });
     oooUser = await addUser(userData[0]);
@@ -180,6 +181,7 @@ describe("Filter Users", function () {
       chai
         .request(app)
         .get("/users/search")
+        .set("cookie", `${cookieName}=${jwt}`)
         .query({ dev: true, page: 1, size: 10 })
         // eslint-disable-next-line consistent-return
         .end((err, res) => {
@@ -211,6 +213,7 @@ describe("Filter Users", function () {
       chai
         .request(app)
         .get("/users/search")
+        .set("cookie", `${cookieName}=${jwt}`)
         .query({ state: ["OOO", "IDLE", "ONBOARDING"] })
         // eslint-disable-next-line consistent-return
         .end((err, res) => {


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 22-Jun-2026
<!--Developer Name Here-->
Developer Name: @prakashchoudhary07 

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->

## Tech Doc Link
<!--Issue ticket this PR closes-->

## Business Doc Link
<!--Issue ticket this PR closes-->

## Description

Restricted `users/search` and `users/status` routes to only super users. This is done because of the ongoing issues of high Firestore reads for usersStaus collction, which is increasing the cost

<!--Description of the changes made in this PR-->

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [x] Yes
- [ ] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
