### PR TITLE
Dev to Main Sync

### DIFF
--- a/controllers/discordactions.js
+++ b/controllers/discordactions.js
@@ -336,7 +336,7 @@ const setRoleIdle7DToIdleUsers = async (req, res) => {
 const updateDiscordNicknames = async (req, res) => {
   try {
     const membersInDiscord = await getDiscordMembers();
-    const usersInDB = await fetchAllUsers();
+    const usersInDB = await fetchAllUsers({ filterActiveUsers: true });
     const usersToBeEffected = [];
     await Promise.all(
       membersInDiscord.map(async (discordUser) => {

--- a/controllers/userStatus.js
+++ b/controllers/userStatus.js
@@ -1,8 +1,9 @@
 const { Forbidden, NotFound } = require("http-errors");
 const { getUserIdBasedOnRoute } = require("../utils/userStatus");
+const { getPaginationLink } = require("../utils/users");
 const { INTERNAL_SERVER_ERROR } = require("../constants/errorMessages");
-const dataAccess = require("../services/dataAccessLayer");
 const userStatusModel = require("../models/userStatus");
+const usersModel = require("../models/users");
 const { userState, CANCEL_OOO } = require("../constants/userStatus");
 const ROLES = require("../constants/roles");
 const firestore = require("../utils/firestore");
@@ -75,25 +76,49 @@ const getUserStatus = async (req, res) => {
  */
 const getAllUserStatus = async (req, res) => {
   try {
-    const { allUserStatus } = await userStatusModel.getAllUserStatus(req.query);
-    const activeUsers = [];
-    if (allUserStatus) {
-      const allUsersStatusFetchPromises = allUserStatus.map(async (status) => {
-        //  fetching users from users collection with the help of userID in userStatus collection
-        const result = await dataAccess.retrieveUsers({ id: status.userId });
-        if (!result.user?.roles?.archived) {
-          status.full_name = `${result.user.first_name} ${result.user.last_name}`;
-          status.picture = result.user.picture;
-          status.username = result.user.username;
-          activeUsers.push(status);
-        }
+    const { state, next, prev, size } = req.query;
+    const pageSize = parseInt(size) || 100;
+
+    const { users, nextId, prevId } = await usersModel.fetchNonArchivedUsers({ next, prev, size: pageSize });
+
+    if (!users.length) {
+      return res.json({
+        message: "No users found.",
+        totalUserStatus: 0,
+        allUserStatus: [],
+        links: { next: "", prev: "" },
       });
-      await Promise.all(allUsersStatusFetchPromises);
     }
+
+    const userIds = users.map((u) => u.id);
+    const statusMap = await userStatusModel.getUserStatusForUserIds(userIds);
+
+    let allUserStatus = users.map((user) => {
+      const status = statusMap[user.id];
+      return {
+        id: status?.id ?? null,
+        userId: user.id,
+        currentStatus: status?.currentStatus ?? null,
+        monthlyHours: status?.monthlyHours ?? null,
+        idleFrom: status?.idleFrom ?? null,
+        full_name: `${user.first_name} ${user.last_name}`,
+        picture: user.picture,
+        username: user.username,
+      };
+    });
+
+    if (state) {
+      allUserStatus = allUserStatus.filter((entry) => entry.currentStatus?.state === state);
+    }
+
     return res.json({
       message: "All User Status found successfully.",
-      totalUserStatus: activeUsers.length,
-      allUserStatus: activeUsers,
+      totalUserStatus: allUserStatus.length,
+      allUserStatus,
+      links: {
+        next: nextId ? getPaginationLink(req.query, "next", nextId, "/users/status") : "",
+        prev: prevId ? getPaginationLink(req.query, "prev", prevId, "/users/status") : "",
+      },
     });
   } catch (err) {
     logger.error(`Error while fetching all the User Status: ${err}`);

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -675,7 +675,10 @@ const updateDiscordUserNickname = async (req, res) => {
 };
 const markUnverified = async (req, res) => {
   try {
-    const [usersInRdsDiscordServer, allRdsLoggedInUsers] = await Promise.all([getDiscordMembers(), fetchAllUsers()]);
+    const [usersInRdsDiscordServer, allRdsLoggedInUsers] = await Promise.all([
+      getDiscordMembers(),
+      fetchAllUsers({ filterActiveUsers: true }),
+    ]);
     const rdsUserMap = {};
     const unverifiedRoleId = config.get("discordUnverifiedRoleId");
     const usersToApplyUnverifiedRole = [];

--- a/middlewares/validators/userStatus.js
+++ b/middlewares/validators/userStatus.js
@@ -85,6 +85,9 @@ const validateGetQueryParams = async (req, res, next) => {
         .trim()
         .valid(userState.IDLE, userState.ACTIVE, userState.OOO, userState.ONBOARDING)
         .error(new Error(`Invalid State. State must be either IDLE, ACTIVE, OOO, or ONBOARDING`)),
+      next: Joi.string().trim().optional(),
+      prev: Joi.string().trim().optional(),
+      size: Joi.number().integer().min(1).max(100).optional(),
     })
     .messages({
       "object.unknown": "Invalid query param provided.",

--- a/models/discordactions.js
+++ b/models/discordactions.js
@@ -7,7 +7,7 @@ const admin = require("firebase-admin");
 const { findSubscribedGroupIds } = require("../utils/helper");
 const { retrieveUsers } = require("../services/dataAccessLayer");
 const { BATCH_SIZE_IN_CLAUSE } = require("../constants/firebase");
-const { getAllUserStatus, getGroupRole, getUserStatus } = require("./userStatus");
+const { getGroupRole, getUserStatus, getUserStatusForUserIds } = require("./userStatus");
 const {
   getApprovedOooPeriods,
   normalizeTimestamp,
@@ -28,7 +28,7 @@ const discordMissedUpdatesRoleId = config.get("discordMissedUpdatesRoleId");
 
 const userStatusModel = firestore.collection("usersStatus");
 const usersUtils = require("../utils/users");
-const { getUsersBasedOnFilter, fetchUser } = require("./users");
+const { getUsersBasedOnFilter, fetchUser, fetchAllUsers } = require("./users");
 const {
   convertDaysToMilliseconds,
   convertMillisToSeconds,
@@ -397,6 +397,21 @@ const shouldAddIdleUser = async (userStatus, tasksModel) => {
   }
 };
 
+const getNonArchivedIdleUsersWithStatus = async () => {
+  const idleUsers = [];
+  const users = await fetchAllUsers({ filterActiveUsers: true });
+  if (!users.length) return idleUsers;
+
+  const statusById = await getUserStatusForUserIds(users.map((user) => user.id));
+  for (const user of users) {
+    const status = statusById[user.id];
+    if (status?.currentStatus?.state === userState.IDLE) {
+      idleUsers.push({ user, status });
+    }
+  }
+  return idleUsers;
+};
+
 const updateIdleUsersOnDiscord = async (dev) => {
   let totalIdleUsers = 0;
   const totalGroupIdleRolesApplied = { count: 0, response: [] };
@@ -404,7 +419,7 @@ const updateIdleUsersOnDiscord = async (dev) => {
   const totalGroupIdleRolesRemoved = { count: 0, response: [] };
   const totalGroupIdleRolesNotRemoved = { count: 0, errors: [] };
   let totalUsersHavingNoDiscordId = 0;
-  let totalArchivedUsers = 0;
+  const totalArchivedUsers = 0;
   const allIdleUsers = [];
   let allUsersHavingGroupIdle = [];
   let groupIdleRole;
@@ -417,7 +432,7 @@ const updateIdleUsersOnDiscord = async (dev) => {
       throw new Error("Idle Role does not exist");
     }
     groupIdleRoleId = groupIdleRole.role.roleid;
-    const { allUserStatus } = await getAllUserStatus({ state: userState.IDLE });
+    const activeIdleUsers = await getNonArchivedIdleUsersWithStatus();
     const discordUsers = await getDiscordMembers();
     const usersHavingIdleRole = [];
     const discordMemberIds = new Set();
@@ -441,43 +456,25 @@ const updateIdleUsersOnDiscord = async (dev) => {
       }
     });
 
-    if (allUserStatus) {
-      await Promise.all(
-        allUserStatus.map(async (userStatus) => {
-          try {
-            const userData = await userModel.doc(userStatus.userId).get();
-            if (!userData.exists) {
-              return;
-            }
-
-            const userDataObj = userData.data();
-            if (!userDataObj) {
-              logger.warn(`User data is null/undefined for userId: ${userStatus.userId}`);
-              return;
-            }
-
-            const discordId = userDataObj?.discordId;
-
-            if (!discordId || !discordMemberIds.has(discordId)) {
-              return;
-            }
-
-            const isUserArchived = userDataObj?.roles?.archived || false;
-            if (isUserArchived) {
-              totalArchivedUsers++;
-            } else if (dev === "true" && !allMavens.includes(discordId)) {
-              const shouldAdd = await shouldAddIdleUser(userStatus, tasksModel);
-              if (shouldAdd) {
-                userStatus.userid = discordId;
-                allIdleUsers.push(userStatus);
-              }
-            }
-          } catch (error) {
-            logger.error(`error updating discordId in userStatus for userId ${userStatus.userId}: ${error.message}`);
+    await Promise.all(
+      activeIdleUsers.map(async ({ user, status }) => {
+        try {
+          const discordId = user?.discordId;
+          if (!discordId || !discordMemberIds.has(discordId)) {
+            return;
           }
-        })
-      );
-    }
+          if (dev === "true" && !allMavens.includes(discordId)) {
+            const shouldAdd = await shouldAddIdleUser(status, tasksModel);
+            if (shouldAdd) {
+              status.userid = discordId;
+              allIdleUsers.push(status);
+            }
+          }
+        } catch (error) {
+          logger.error(`error processing idle user ${status?.userId}: ${error.message}`);
+        }
+      })
+    );
     allUsersHavingGroupIdle = usersHavingIdleRole;
   } catch (error) {
     logger.error(`unable to get idle users ${error.message}`);
@@ -655,7 +652,7 @@ const updateIdle7dUsersOnDiscord = async (dev) => {
   const totalGroupIdle7dRolesRemoved = { count: 0, response: [] };
   const totalGroupIdle7dRolesNotRemoved = { count: 0, errors: [] };
   let totalUsersHavingNoDiscordId = 0;
-  let totalArchivedUsers = 0;
+  const totalArchivedUsers = 0;
   const allIdle7dUsers = [];
   let allUsersHavingGroupIdle7d = [];
   let groupIdle7dRole;
@@ -670,7 +667,7 @@ const updateIdle7dUsersOnDiscord = async (dev) => {
     }
     groupIdle7dRoleId = groupIdle7dRole.role.roleid;
 
-    const { allUserStatus } = await getAllUserStatus({ state: userState.IDLE });
+    const activeIdleUsers = await getNonArchivedIdleUsersWithStatus();
     const discordUsers = await getDiscordMembers();
     const usersHavingIdle7dRole = [];
 
@@ -689,46 +686,38 @@ const updateIdle7dUsersOnDiscord = async (dev) => {
     });
 
     const currentTime = Date.now();
-    if (allUserStatus) {
-      await Promise.all(
-        allUserStatus.map(async (userStatus) => {
-          try {
-            if (!userStatus?.userId) {
-              logger.warn("updateIdle7dUsersOnDiscord: skipping user status with missing userId");
-              return;
-            }
-            const windowStart = normalizeTimestamp(userStatus.idleFrom) ?? currentTime;
-            const oooPeriods = await getApprovedOooPeriods(userStatus.userId, windowStart, currentTime);
-            const idleDays = computeIdleDaysExcludingOOO(
-              userStatus.idleFrom,
-              userStatus.currentStatus?.from,
-              currentTime,
-              oooPeriods
-            );
-            if (idleDays < 7) {
-              return;
-            }
-            const userData = await userModel.doc(userStatus.userId).get();
-            const userPayload = userData?.data?.();
-            const isUserArchived = userPayload?.roles?.archived;
-            if (userData?.exists) {
-              if (isUserArchived) {
-                totalArchivedUsers++;
-              } else if (dev === "true" && !allMavens.includes(userPayload?.discordId)) {
-                const shouldAdd = await shouldAddIdleUser(userStatus, tasksModel);
-                if (shouldAdd) {
-                  userStatus.userid = userPayload?.discordId;
-                  allIdle7dUsers.push(userStatus);
-                }
-              }
-            }
-          } catch (error) {
-            logger.error(`error updating discordId in userStatus ${error.message}`);
-            throw new Error("error updating discordId in userStatus");
+    await Promise.all(
+      activeIdleUsers.map(async ({ user, status }) => {
+        try {
+          if (!status?.userId) {
+            logger.warn("updateIdle7dUsersOnDiscord: skipping user status with missing userId");
+            return;
           }
-        })
-      );
-    }
+          const windowStart =
+            normalizeTimestamp(status.idleFrom) ?? normalizeTimestamp(status.currentStatus?.from) ?? currentTime;
+          const oooPeriods = await getApprovedOooPeriods(status.userId, windowStart, currentTime);
+          const idleDays = computeIdleDaysExcludingOOO(
+            status.idleFrom,
+            status.currentStatus?.from,
+            currentTime,
+            oooPeriods
+          );
+          if (idleDays < 7) {
+            return;
+          }
+          const discordId = user?.discordId;
+          if (dev === "true" && !allMavens.includes(discordId)) {
+            const shouldAdd = await shouldAddIdleUser(status, tasksModel);
+            if (shouldAdd) {
+              status.userid = discordId;
+              allIdle7dUsers.push(status);
+            }
+          }
+        } catch (error) {
+          logger.error(`error processing idle-7d user ${status?.userId}: ${error.message}`);
+        }
+      })
+    );
 
     allUsersHavingGroupIdle7d = usersHavingIdle7dRole;
   } catch (error) {

--- a/models/userStatus.js
+++ b/models/userStatus.js
@@ -27,6 +27,7 @@ const usersCollection = firestore.collection("users");
 const config = require("config");
 const DISCORD_BASE_URL = config.get("services.discordBot.baseUrl");
 const { generateAuthTokenForCloudflare } = require("../utils/discord-actions");
+const { BATCH_SIZE_IN_CLAUSE } = require("../constants/firebase");
 
 // added this function here to avoid circular dependency
 /**
@@ -622,8 +623,6 @@ const getTaskBasedUsersStatus = async () => {
   const users = [];
   let totalIdleUsers = 0;
   let totalActiveUsers = 0;
-  const unprocessedUsers = [];
-  let errorCount = 0;
   let usersSnapshot;
   try {
     usersSnapshot = await usersCollection
@@ -636,37 +635,27 @@ const getTaskBasedUsersStatus = async () => {
   }
   const totalUsers = usersSnapshot.size;
   if (totalUsers) {
-    await Promise.all(
-      usersSnapshot.docs.map(async (userDoc) => {
-        const assigneeId = userDoc.id;
-        try {
-          const tasksQuerySnapshot = await firestore
-            .collection("tasks")
-            .where("assignee", "==", assigneeId)
-            .where("status", "in", [TASK_STATUS.ASSIGNED, TASK_STATUS.IN_PROGRESS])
-            .get();
-          if (tasksQuerySnapshot.empty) {
-            totalIdleUsers++;
-            users.push({ userId: assigneeId, state: userState.IDLE });
-          } else {
-            totalActiveUsers++;
-            users.push({ userId: assigneeId, state: userState.ACTIVE });
-          }
-        } catch (error) {
-          errorCount++;
-          unprocessedUsers.push(assigneeId);
-          logger.error(`Error retrieving tasks for user ${assigneeId}: ${error.message}`);
-        }
-      })
-    );
+    const liveTasks = await tasksModel.where("status", "in", [TASK_STATUS.ASSIGNED, TASK_STATUS.IN_PROGRESS]).get();
+    const liveAssignees = new Set(liveTasks.docs.map((doc) => doc.data().assignee));
+
+    usersSnapshot.docs.forEach((userDoc) => {
+      const userId = userDoc.id;
+      if (liveAssignees.has(userId)) {
+        totalActiveUsers++;
+        users.push({ userId, state: userState.ACTIVE });
+      } else {
+        totalIdleUsers++;
+        users.push({ userId, state: userState.IDLE });
+      }
+    });
   }
 
   return {
     totalUsers,
     totalIdleUsers,
     totalActiveUsers,
-    totalUnprocessedUsers: errorCount,
-    unprocessedUsers,
+    totalUnprocessedUsers: 0,
+    unprocessedUsers: [],
     users,
   };
 };
@@ -761,6 +750,28 @@ const addFutureStatus = async (futureStatusData) => {
   }
 };
 
+const getUserStatusForUserIds = async (userIds) => {
+  if (!userIds.length) return {};
+
+  const statusMap = {};
+  const chunks = [];
+  for (let i = 0; i < userIds.length; i += BATCH_SIZE_IN_CLAUSE) {
+    chunks.push(userIds.slice(i, i + BATCH_SIZE_IN_CLAUSE));
+  }
+
+  await Promise.all(
+    chunks.map(async (chunk) => {
+      const snapshot = await userStatusModel.where("userId", "in", chunk).get();
+      snapshot.forEach((doc) => {
+        const data = doc.data();
+        statusMap[data.userId] = { id: doc.id, ...data };
+      });
+    })
+  );
+
+  return statusMap;
+};
+
 module.exports = {
   deleteUserStatus,
   getUserStatus,
@@ -775,4 +786,5 @@ module.exports = {
   cancelOooStatus,
   getGroupRole,
   addFutureStatus,
+  getUserStatusForUserIds,
 };

--- a/models/users.js
+++ b/models/users.js
@@ -764,9 +764,10 @@ const getDiscordUsers = async () => {
   }
 };
 
-const fetchAllUsers = async () => {
+const fetchAllUsers = async ({ filterActiveUsers = false } = {}) => {
   const users = [];
-  const usersQuerySnapshot = await userModel.get();
+  const query = filterActiveUsers ? userModel.where("roles.archived", "==", false) : userModel;
+  const usersQuerySnapshot = await query.get();
   usersQuerySnapshot.forEach((user) => users.push({ ...user.data(), id: user.id }));
   return users;
 };
@@ -1129,6 +1130,43 @@ const fetchUsersNotInDiscordServer = async () => {
   }
 };
 
+const fetchNonArchivedUsers = async ({ next = null, prev = null, size = 100 } = {}) => {
+  try {
+    let dbQuery = userModel.where("roles.archived", "==", false).orderBy("username");
+
+    if (prev || next) {
+      const cursorDoc = await userModel.doc(prev || next).get();
+      if (!cursorDoc.exists) {
+        return { users: [], nextId: "", prevId: "" };
+      }
+      dbQuery = prev ? dbQuery.endBefore(cursorDoc).limitToLast(size) : dbQuery.startAfter(cursorDoc).limit(size);
+    } else {
+      dbQuery = dbQuery.limit(size);
+    }
+
+    const snapshot = await dbQuery.get();
+    const users = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+    const firstId = snapshot.docs[0]?.id || "";
+    const lastId = snapshot.docs[snapshot.docs.length - 1]?.id || "";
+    const isFullPage = users.length === size;
+
+    let nextId = "";
+    let prevId = "";
+    if (prev) {
+      nextId = lastId;
+      if (isFullPage) prevId = firstId;
+    } else {
+      if (isFullPage) nextId = lastId;
+      if (next) prevId = firstId;
+    }
+
+    return { users, nextId, prevId };
+  } catch (err) {
+    logger.error("Error retrieving non-archived users", err);
+    throw err;
+  }
+};
+
 module.exports = {
   archiveUsers,
   addOrUpdate,
@@ -1160,4 +1198,5 @@ module.exports = {
   getNonNickNameSyncedUsers,
   updateUsersWithNewUsernames,
   fetchUsersNotInDiscordServer,
+  fetchNonArchivedUsers,
 };

--- a/test/integration/userStatus.test.js
+++ b/test/integration/userStatus.test.js
@@ -97,6 +97,50 @@ describe("UserStatus", function () {
       expect(response.body.allUserStatus).to.be.a("array");
       expect(response.body.allUserStatus.length).to.equal(1);
     });
+
+    it("Should return pagination links with empty next/prev on a single page", async function () {
+      const response = await chai
+        .request(app)
+        .get("/users/status")
+        .set("cookie", `${cookieName}=${superUserAuthToken}`);
+      expect(response).to.have.status(200);
+      expect(response.body.links).to.be.a("object");
+      expect(response.body.links.next).to.equal("");
+      expect(response.body.links.prev).to.equal("");
+    });
+
+    it("Should paginate non-archived user statuses across multiple pages via next/prev cursors", async function () {
+      await addUser(userData[6]);
+      await addUser(userData[8]);
+      await addUser(userData[9]);
+
+      const userIdsFromResponse = (response) => response.body.allUserStatus.map((status) => status.userId);
+
+      const firstPage = await chai
+        .request(app)
+        .get("/users/status?size=2")
+        .set("cookie", `${cookieName}=${superUserAuthToken}`);
+      expect(firstPage).to.have.status(200);
+      expect(firstPage.body.allUserStatus.length).to.equal(2);
+      expect(firstPage.body.links.next).to.not.equal("");
+      expect(firstPage.body.links.prev).to.equal("");
+
+      const secondPage = await chai
+        .request(app)
+        .get(firstPage.body.links.next)
+        .set("cookie", `${cookieName}=${superUserAuthToken}`);
+      expect(secondPage).to.have.status(200);
+      expect(secondPage.body.allUserStatus.length).to.equal(2);
+      expect(secondPage.body.links.prev).to.not.equal("");
+      expect(userIdsFromResponse(secondPage).some((id) => userIdsFromResponse(firstPage).includes(id))).to.equal(false);
+
+      const firstPageAgain = await chai
+        .request(app)
+        .get(secondPage.body.links.prev)
+        .set("cookie", `${cookieName}=${superUserAuthToken}`);
+      expect(firstPageAgain).to.have.status(200);
+      expect(userIdsFromResponse(firstPageAgain)).to.have.members(userIdsFromResponse(firstPage));
+    });
   });
 
   describe("GET /users/status/:userid", function () {

--- a/test/unit/models/discordactions.test.js
+++ b/test/unit/models/discordactions.test.js
@@ -1027,13 +1027,13 @@ describe("discordactions", function () {
       await cleanDb();
     });
 
-    it("should return  totalIdleUsers as 3,totalRolesApplied as 3, totalRoleToBeAdded as 3 as no one is maven", async function () {
+    it("should return totalIdle7dUsers as 2, totalRoleToBeAdded as 2, totalRoleToBeRemoved as 1, totalArchivedUsers as 0", async function () {
       const dev = "true";
       const res = await updateIdle7dUsersOnDiscord(dev);
       expect(res.totalIdle7dUsers).to.be.equal(2);
       expect(res.totalUserRoleToBeAdded).to.be.equal(2);
       expect(res.totalUserRoleToBeRemoved).to.be.equal(1);
-      expect(res.totalArchivedUsers).to.be.equal(1);
+      expect(res.totalArchivedUsers).to.be.equal(0);
     });
   });
 

--- a/test/unit/models/userStatus.js
+++ b/test/unit/models/userStatus.js
@@ -6,7 +6,7 @@ const { expect } = chai;
 const firestore = require("../../../utils/firestore");
 const userStatusModel = firestore.collection("usersStatus");
 const tasksModel = firestore.collection("tasks");
-const { cancelOooStatus, addFutureStatus } = require("../../../models/userStatus");
+const { cancelOooStatus, addFutureStatus, getUserStatusForUserIds } = require("../../../models/userStatus");
 const cleanDb = require("../../utils/cleanDb");
 const addUser = require("../../utils/addUser");
 const { userState } = require("../../../constants/userStatus");
@@ -85,5 +85,21 @@ describe("tasks", function () {
     const response = await addFutureStatus(userFutureStatusData);
     expect(response.userStatusExists).to.equal(true);
     expect(response.data.futureStatus.state).to.equal("UPCOMING");
+  });
+
+  describe("getUserStatusForUserIds", function () {
+    it("returns statuses keyed by userId for the given ids", async function () {
+      await userStatusModel.add({ userId: "user-idle-1", currentStatus: { state: userState.IDLE } });
+      await userStatusModel.add({ userId: "user-active-2", currentStatus: { state: userState.ACTIVE } });
+
+      const statusMap = await getUserStatusForUserIds(["user-idle-1", "user-active-2"]);
+      expect(statusMap["user-idle-1"].currentStatus.state).to.equal(userState.IDLE);
+      expect(statusMap["user-active-2"].currentStatus.state).to.equal(userState.ACTIVE);
+    });
+
+    it("returns an empty object when no ids are passed", async function () {
+      const statusMap = await getUserStatusForUserIds([]);
+      expect(statusMap).to.deep.equal({});
+    });
   });
 });

--- a/test/unit/models/users.test.js
+++ b/test/unit/models/users.test.js
@@ -313,6 +313,94 @@ describe("users", function () {
       const result = await users.fetchAllUsers();
       expect(result).to.have.length(userDataArray.length);
     });
+
+    it("gets only non-archived users when filterActiveUsers is true", async function () {
+      const result = await users.fetchAllUsers({ filterActiveUsers: true });
+      expect(result.length).to.be.below(userDataArray.length);
+      result.forEach((user) => {
+        expect(user.roles?.archived).to.not.equal(true);
+      });
+    });
+  });
+
+  describe("fetchNonArchivedUsers", function () {
+    beforeEach(async function () {
+      await userModel.add({
+        username: "active-alpha",
+        first_name: "Active",
+        last_name: "Alpha",
+        roles: { archived: false, in_discord: true },
+      });
+      await userModel.add({
+        username: "active-beta",
+        first_name: "Active",
+        last_name: "Beta",
+        roles: { archived: false, in_discord: true },
+      });
+      await userModel.add({
+        username: "archived-gamma",
+        first_name: "Archived",
+        last_name: "Gamma",
+        roles: { archived: true, in_discord: false },
+      });
+    });
+
+    it("returns only non-archived users and empty cursors on a single page", async function () {
+      const result = await users.fetchNonArchivedUsers({ size: 100 });
+      expect(result.users).to.be.an("array");
+      expect(result.users.length).to.equal(2);
+      result.users.forEach((user) => expect(user.roles.archived).to.equal(false));
+      expect(result.nextId).to.equal("");
+      expect(result.prevId).to.equal("");
+    });
+
+    it("excludes archived users (archived=true, in_discord=false)", async function () {
+      await userModel.add({
+        username: "archived-delta",
+        first_name: "Archived",
+        last_name: "Delta",
+        roles: { archived: true, in_discord: false },
+      });
+
+      const result = await users.fetchNonArchivedUsers({ size: 100 });
+      const returnedUsernames = result.users.map((user) => user.username);
+
+      result.users.forEach((user) => expect(user.roles.archived).to.equal(false));
+      expect(returnedUsernames).to.not.include("archived-gamma");
+      expect(returnedUsernames).to.not.include("archived-delta");
+    });
+
+    it("paginates forward with the nextId cursor", async function () {
+      const page1 = await users.fetchNonArchivedUsers({ size: 1 });
+      expect(page1.users.length).to.equal(1);
+      expect(page1.nextId).to.not.equal("");
+      expect(page1.prevId).to.equal("");
+
+      const page2 = await users.fetchNonArchivedUsers({ next: page1.nextId, size: 1 });
+      expect(page2.users.length).to.equal(1);
+      expect(page2.users[0].id).to.not.equal(page1.users[0].id);
+      expect(page2.prevId).to.not.equal("");
+    });
+
+    it("paginates backward with the prevId cursor", async function () {
+      const page1 = await users.fetchNonArchivedUsers({ size: 1 });
+      const page2 = await users.fetchNonArchivedUsers({ next: page1.nextId, size: 1 });
+      expect(page2.prevId).to.not.equal("");
+
+      const backToPage1 = await users.fetchNonArchivedUsers({ prev: page2.prevId, size: 1 });
+      expect(backToPage1.users.length).to.equal(1);
+      expect(backToPage1.users[0].id).to.equal(page1.users[0].id);
+    });
+
+    it("caps the returned users to the requested size", async function () {
+      const singleUserPage = await users.fetchNonArchivedUsers({ size: 1 });
+      expect(singleUserPage.users.length).to.equal(1);
+      expect(singleUserPage.nextId).to.not.equal("");
+
+      const allUsersPage = await users.fetchNonArchivedUsers({ size: 100 });
+      expect(allUsersPage.users.length).to.equal(2);
+      expect(allUsersPage.nextId).to.equal("");
+    });
   });
 
   describe("add Join Data", function () {

--- a/utils/users.js
+++ b/utils/users.js
@@ -156,8 +156,8 @@ function getLowestLevelSkill(skills) {
  * @param documentId {string} - DB document Id
  */
 
-function getPaginationLink(query, cursor, documentId) {
-  let endpoint = `/users?${cursor}=${documentId}`;
+function getPaginationLink(query, cursor, documentId, basePath = "/users") {
+  let endpoint = `${basePath}?${cursor}=${documentId}`;
   const keysToExclude = ["next", "prev", "page"]; // next, prev needs to be updated with new document Id and page is not required in the links.
   for (const [key, value] of Object.entries(query)) {
     if (keysToExclude.includes(key)) continue;


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 21 July , 2026
<!--Developer Name Here-->
Developer Name: @AnujChhikara  

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->

- #2603

## PRs going for sync
- #2602

## Description
Most reads scanned entire collections when only non-archived (active) users are needed. Switch the hot paths to active-users-first, paginated, batched reads.

GET /users/status:

Paginate non-archived users (fetchNonArchivedUsers, doc-id cursors) then batch-fetch their statuses (getUserStatusForUserIds, chunked in) instead of scanning all statuses with per-user lookups.
links.next/prev only emitted when a page exists in that direction.
Discord idle crons (group-idle, group-idle-7d):

Active-users-first: page non-archived users -> their statuses -> filter IDLE, avoiding stale IDLE statuses of archived users and per-user reads.
Fix 7-day idle calc: align the OOO fetch window with the idle-day window (idleFrom ?? currentStatus.from ?? now) so past OOO is excluded when idleFrom is missing.
Other:

getTaskBasedUsersStatus: per-user tasks query -> chunked in.
fetchAllUsers({ nonArchivedOnly }): active-only option, used by markUnverified and updateDiscordNicknames.
Reuse getPaginationLink util (basePath param) instead of a duplicate helper.

<!--Description of the changes made in this PR-->

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots



https://github.com/user-attachments/assets/43685023-4d46-499b-83f1-137744d09e83






<img width="885" height="759" alt="image" src="https://github.com/user-attachments/assets/b5d56197-a8ba-40bb-81de-1acf88455c9b" />





</details>
