### PR TITLE
fix(progresses): prevent duplicate progress documents via atomic create (#1158)

### DIFF
--- a/models/progresses.js
+++ b/models/progresses.js
@@ -25,7 +25,7 @@ const { PROGRESS_ALREADY_CREATED, PROGRESS_DOCUMENT_NOT_FOUND } = PROGRESSES_RES
  * @throws {Error} If a progress document has already been created for the given user or task on the current day.
  **/
 const createProgressDocument = async (progressData) => {
-  const { type, taskId } = progressData;
+  const { type, taskId, userId } = progressData;
   const createdAtTimestamp = new Date().getTime();
   const progressDateTimestamp = getProgressDateTimestamp();
   let taskTitle;
@@ -38,8 +38,23 @@ const createProgressDocument = async (progressData) => {
     throw new Conflict(`${type.charAt(0).toUpperCase() + type.slice(1)} ${PROGRESS_ALREADY_CREATED}`);
   }
   const progressDocumentData = { ...progressData, createdAt: createdAtTimestamp, date: progressDateTimestamp };
-  const { id } = await progressesCollection.add(progressDocumentData);
-  const data = { id, ...progressDocumentData };
+  // The query check above narrows the window but cannot prevent two requests made within the
+  // same second from both seeing an empty result and each inserting a document (issue #1158).
+  // Derive a deterministic document id from the uniqueness key (type + user/task + day) and use
+  // an atomic create(), which fails with ALREADY_EXISTS if a document for that key already exists,
+  // so concurrent creates for the same day can never both succeed.
+  const progressDocumentId = `${type}:${type === "user" ? userId : taskId}:${progressDateTimestamp}`;
+  const docRef = progressesCollection.doc(progressDocumentId);
+  try {
+    await docRef.create(progressDocumentData);
+  } catch (error) {
+    const isAlreadyExists = error.code === 6 || error.code === "already-exists";
+    if (isAlreadyExists) {
+      throw new Conflict(`${type.charAt(0).toUpperCase() + type.slice(1)} ${PROGRESS_ALREADY_CREATED}`);
+    }
+    throw error;
+  }
+  const data = { id: docRef.id, ...progressDocumentData };
   return { data, taskTitle };
 };
 

--- a/test/unit/models/progresses.test.js
+++ b/test/unit/models/progresses.test.js
@@ -2,7 +2,11 @@ const chai = require("chai");
 const sinon = require("sinon");
 const { expect } = chai;
 const cleanDb = require("../../utils/cleanDb");
-const { addUserDetailsToProgressDocs, getPaginatedProgressDocument } = require("../../../models/progresses");
+const {
+  addUserDetailsToProgressDocs,
+  getPaginatedProgressDocument,
+  createProgressDocument,
+} = require("../../../models/progresses");
 const fireStore = require("../../../utils/firestore");
 const progressesCollection = fireStore.collection("progresses");
 const { stubbedModelTaskProgressData, stubbedModelProgressData } = require("../../fixtures/progress/progresses");
@@ -139,6 +143,54 @@ describe("progressModel", function () {
       const result = await addUserDetailsToProgressDocs(mockProgressDocs);
 
       expect(result).to.deep.equal([{ userId: "userIdNotExists", taskId: 101, userData: null }]);
+    });
+  });
+
+  describe("createProgressDocument", function () {
+    const buildUserProgress = (userId) => ({
+      type: "user",
+      userId,
+      completed: "Implemented the fix",
+      planned: "Write regression tests",
+      blockers: "None",
+    });
+
+    it("stores exactly one progress document when two requests race for the same day", async function () {
+      const userId = "raceConditionUserId";
+
+      const results = await Promise.allSettled([
+        createProgressDocument(buildUserProgress(userId)),
+        createProgressDocument(buildUserProgress(userId)),
+      ]);
+
+      const fulfilled = results.filter((result) => result.status === "fulfilled");
+      const rejected = results.filter((result) => result.status === "rejected");
+
+      expect(fulfilled).to.have.lengthOf(1);
+      expect(rejected).to.have.lengthOf(1);
+      expect(rejected[0].reason.status).to.equal(409);
+      expect(rejected[0].reason.message).to.equal("User Progress for the day has already been created.");
+
+      const snapshot = await progressesCollection.where("type", "==", "user").where("userId", "==", userId).get();
+      expect(snapshot.size).to.equal(1);
+    });
+
+    it("throws a Conflict when a progress document already exists for the user on the same day", async function () {
+      const userId = "sequentialUserId";
+
+      const { data } = await createProgressDocument(buildUserProgress(userId));
+      expect(data.userId).to.equal(userId);
+
+      try {
+        await createProgressDocument(buildUserProgress(userId));
+        throw new Error("Test failed: expected a Conflict error to be thrown.");
+      } catch (err) {
+        expect(err.status).to.equal(409);
+        expect(err.message).to.equal("User Progress for the day has already been created.");
+      }
+
+      const snapshot = await progressesCollection.where("type", "==", "user").where("userId", "==", userId).get();
+      expect(snapshot.size).to.equal(1);
     });
   });
 });


### PR DESCRIPTION
## Issue Ticket Number

Closes #1158

## Description

`createProgressDocument` created duplicate documents in the `progresses` collection under concurrent load. It used a check-then-add sequence: query for an existing progress document for the current day and, if none was found, call `progressesCollection.add()` with an auto-generated id. Two requests made within the same second can both observe an empty result and each insert a document, producing the duplicates reported in #1158.

Fix: derive a deterministic document id from the uniqueness key (`type` + user/task id + day timestamp) and insert with an atomic `create()`. Firestore's `create()` fails with `ALREADY_EXISTS` when a document with that id already exists, so concurrent creates for the same user/task and day can never both succeed. The losing request is surfaced as the existing `409 Conflict` (`... Progress for the day has already been created.`), preserving current API behaviour. The pre-write query check is retained as a fast path.

Regression tests added in `test/unit/models/progresses.test.js`:
- fires two concurrent `createProgressDocument` calls for the same user/day via `Promise.allSettled` and asserts exactly one document persists (one fulfilled, one `409`);
- asserts a sequential duplicate for the same day still throws `409` and leaves a single document.

### Documentation Updated?

- [ ] Yes
- [x] No

### Under Feature Flag

- [ ] Yes
- [x] No

### Database Changes

- [ ] Yes
- [x] No

New progress documents now use a deterministic id (`type:id:date`) instead of an auto-generated id. Existing documents are unaffected; reads are by query, not by id.

### Breaking Changes

- [ ] Yes
- [x] No

### Test Coverage

Focused unit run against the Firestore emulator:

```
progressModel
  createProgressDocument
    ✔ stores exactly one progress document when two requests race for the same day
    ✔ throws a Conflict when a progress document already exists for the user on the same day

2 passing
```
